### PR TITLE
feat: Add validation dataset and early stopping support for MixtureGBDT

### DIFF
--- a/src/boosting/mixture_gbdt.h
+++ b/src/boosting/mixture_gbdt.h
@@ -279,6 +279,64 @@ class MixtureGBDT : public GBDTBase {
 
   /*! \brief Update expert bias based on recent load */
   void UpdateExpertBias();
+
+  /*!
+   * \brief Forward pass for validation data: compute expert predictions and gate probabilities
+   * \param valid_idx Index of validation dataset
+   */
+  void ForwardValid(int valid_idx);
+
+  /*!
+   * \brief Output metrics and check early stopping
+   * \param iter Current iteration
+   * \return Non-empty string if early stopping triggered
+   */
+  std::string OutputMetric(int iter);
+
+  /*!
+   * \brief Evaluate metrics and check early stopping condition
+   * \return true if early stopping triggered
+   */
+  bool EvalAndCheckEarlyStopping();
+
+  // ===== Validation data storage =====
+  /*! \brief Validation datasets */
+  std::vector<const Dataset*> valid_datas_;
+
+  /*! \brief Metrics for each validation dataset */
+  std::vector<std::vector<const Metric*>> valid_metrics_;
+
+  // ===== Validation prediction buffers =====
+  /*! \brief Expert predictions for validation (expert-major: [k * num_valid + i]) */
+  std::vector<std::vector<double>> expert_pred_valid_;
+
+  /*! \brief Gate probabilities for validation (sample-major: [i * K + k]) */
+  std::vector<std::vector<double>> gate_proba_valid_;
+
+  /*! \brief Combined predictions for validation */
+  std::vector<std::vector<double>> yhat_valid_;
+
+  /*! \brief Previous gate probabilities for Markov mode validation */
+  std::vector<std::vector<double>> prev_gate_proba_valid_;
+
+  // ===== Early stopping =====
+  /*! \brief Number of rounds for early stopping (0 = disabled) */
+  int early_stopping_round_;
+
+  /*! \brief Minimum improvement for early stopping */
+  double early_stopping_min_delta_;
+
+  /*! \brief Only use first metric for early stopping */
+  bool es_first_metric_only_;
+
+  /*! \brief Best iteration for each validation dataset and metric */
+  std::vector<std::vector<int>> best_iter_;
+
+  /*! \brief Best score for each validation dataset and metric */
+  std::vector<std::vector<double>> best_score_;
+
+  /*! \brief Output message of best iteration */
+  std::vector<std::vector<std::string>> best_msg_;
 };
 
 }  // namespace LightGBM


### PR DESCRIPTION
## Summary

- Implement validation dataset handling for MixtureGBDT (previously threw `Fatal: MixtureGBDT::AddValidDataset is not implemented`)
- Add early stopping support based on validation metrics
- Fix iteration count restoration when loading saved models

## Changes

### New Methods
- `AddValidDataset`: Register validation data with experts and gate, initialize prediction buffers
- `ForwardValid`: Compute mixture predictions (expert × gate) on validation data after each training iteration
- `OutputMetric`: Output training/validation metrics and check early stopping condition
- `EvalAndCheckEarlyStopping`: Trigger early stopping and rollback to best iteration

### Modified Methods
- `GetEvalAt`: Now supports validation data (data_idx > 0)
- `GetNumPredictAt`: Now returns validation data size
- `GetPredictAt`: Now returns validation predictions
- `TrainOneIter`: Calls `ForwardValid` after each iteration
- `Train`: Checks early stopping after each iteration
- `LoadModelFromString`: Restores `iter_` from child models

## Usage

```python
import lightgbm_moe as lgb

train_data = lgb.Dataset(X_train, label=y_train)
valid_data = lgb.Dataset(X_valid, label=y_valid)

params = {
    "boosting": "mixture",
    "objective": "regression",
    "metric": "rmse",
    "mixture_num_experts": 2,
    "early_stopping_round": 10,
}

model = lgb.train(
    params,
    train_data,
    valid_sets=[valid_data],
    num_boost_round=100,
)
```

## Test plan

- [x] All existing tests pass (`pytest tests/python_package_test/test_mixture.py`)
- [x] Training with validation data works without errors
- [x] Early stopping triggers correctly
- [x] Optuna optimization benchmark runs successfully
- [x] `model.current_iteration()` returns correct value after training

🤖 Generated with [Claude Code](https://claude.com/claude-code)