### PR TITLE
feat: Auto-K selection & expert pruning for MoE models

### DIFF
--- a/python-package/lightgbm_moe/__init__.py
+++ b/python-package/lightgbm_moe/__init__.py
@@ -31,6 +31,10 @@ try:
 except ImportError:
     pass
 
+from .auto_k import select_num_experts
+from .diagnostics import diagnose_moe
+from .pruning import PrunedMoEModel, merge_experts, prune_experts
+
 
 _version_path = Path(__file__).resolve().parent / "VERSION.txt"
 if _version_path.is_file():
@@ -61,4 +65,9 @@ __all__ = [
     "plot_metric",
     "plot_tree",
     "create_tree_digraph",
+    "diagnose_moe",
+    "select_num_experts",
+    "PrunedMoEModel",
+    "prune_experts",
+    "merge_experts",
 ]

--- a/python-package/lightgbm_moe/auto_k.py
+++ b/python-package/lightgbm_moe/auto_k.py
@@ -1,0 +1,271 @@
+# coding: utf-8
+"""Auto-K selection for MoE models — choose the optimal number of experts via information criteria or CV."""
+
+import copy
+import warnings
+
+import numpy as np
+
+from . import engine
+
+
+def select_num_experts(
+    params,
+    train_set,
+    k_range=range(2, 8),
+    criterion="bic",
+    num_boost_round=100,
+    valid_sets=None,
+    callbacks=None,
+    nfold=5,
+    seed=0,
+    verbose=True,
+):
+    """Select the optimal number of experts (K) for a MoE model.
+
+    Trains a MoE model for each candidate K and selects the best one according
+    to the specified information criterion or cross-validation metric.
+
+    Parameters
+    ----------
+    params : dict
+        LightGBM parameters. Must include ``boosting="mixture"``.
+    train_set : Dataset
+        Training dataset. For IC-based criteria (bic/aic/icl), the dataset must
+        retain raw data (use ``Dataset(X, y, free_raw_data=False)``).
+    k_range : sequence of int, default range(2, 8)
+        Candidate values of K (number of experts) to evaluate.
+    criterion : str, default "bic"
+        Selection criterion: ``"bic"``, ``"aic"``, ``"icl"``, or ``"cv_rmse"``.
+    num_boost_round : int, default 100
+        Number of boosting iterations per candidate model.
+    valid_sets : list of Dataset or None, default None
+        Validation datasets (used only for IC-based criteria, not cv_rmse).
+    callbacks : list or None, default None
+        Callbacks passed to ``train()`` or ``cv()``.
+    nfold : int, default 5
+        Number of CV folds (only used when ``criterion="cv_rmse"``).
+    seed : int, default 0
+        Random seed for CV fold splitting.
+    verbose : bool, default True
+        If True, print a results table after evaluation.
+
+    Returns
+    -------
+    best_k : int
+        The K value that minimises the criterion.
+    results : dict
+        Dictionary with keys ``"k_values"``, ``"criterion_values"``,
+        ``"models"`` (list of trained Boosters, None for cv_rmse),
+        and ``"details"`` (list of per-K detail dicts).
+    """
+    criterion = criterion.lower()
+    if criterion not in ("bic", "aic", "icl", "cv_rmse"):
+        raise ValueError(f"criterion must be 'bic', 'aic', 'icl', or 'cv_rmse', got '{criterion}'")
+
+    p = copy.deepcopy(params)
+    if p.get("boosting") != "mixture":
+        raise ValueError("select_num_experts requires boosting='mixture' in params")
+
+    k_values = list(k_range)
+    criterion_values = []
+    models = []
+    details = []
+
+    for k in k_values:
+        p_k = copy.deepcopy(p)
+        p_k["mixture_num_experts"] = k
+
+        try:
+            if criterion == "cv_rmse":
+                crit, detail = _eval_cv_rmse(p_k, train_set, num_boost_round, nfold, seed, callbacks)
+                models.append(None)
+            else:
+                crit, detail, model = _eval_ic(
+                    p_k, train_set, num_boost_round, valid_sets, callbacks, criterion
+                )
+                models.append(model)
+        except Exception as e:
+            warnings.warn(f"K={k} failed: {e}")
+            criterion_values.append(float("inf"))
+            details.append({"error": str(e)})
+            models.append(None)
+            continue
+
+        criterion_values.append(crit)
+        details.append(detail)
+
+    if all(v == float("inf") for v in criterion_values):
+        raise ValueError("All K candidates failed during evaluation")
+
+    best_idx = int(np.argmin(criterion_values))
+    best_k = k_values[best_idx]
+
+    results = {
+        "k_values": k_values,
+        "criterion_values": criterion_values,
+        "models": models,
+        "details": details,
+    }
+
+    if verbose:
+        _print_table(k_values, criterion_values, details, best_idx, criterion)
+
+    return best_k, results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _eval_cv_rmse(params, train_set, num_boost_round, nfold, seed, callbacks):
+    """Evaluate a single K via cross-validation RMSE."""
+    p = copy.deepcopy(params)
+    p.setdefault("objective", "regression")
+    p["metric"] = "rmse"
+
+    cv_result = engine.cv(
+        p,
+        train_set,
+        num_boost_round=num_boost_round,
+        nfold=nfold,
+        seed=seed,
+        callbacks=callbacks,
+        stratified=False,
+    )
+
+    # Find the RMSE key — pattern: "valid rmse-mean"
+    rmse_key = None
+    for key in cv_result:
+        if "rmse" in key and "mean" in key:
+            rmse_key = key
+            break
+    if rmse_key is None:
+        raise RuntimeError(f"Could not find RMSE metric in cv results. Keys: {list(cv_result.keys())}")
+
+    best_rmse = min(cv_result[rmse_key])
+    best_iter = int(np.argmin(cv_result[rmse_key]))
+
+    detail = {
+        "cv_rmse": best_rmse,
+        "best_iteration": best_iter,
+    }
+    return best_rmse, detail
+
+
+def _eval_ic(params, train_set, num_boost_round, valid_sets, callbacks, criterion):
+    """Evaluate a single K via information criterion (BIC/AIC/ICL)."""
+    model = engine.train(
+        params,
+        train_set,
+        num_boost_round=num_boost_round,
+        valid_sets=valid_sets,
+        callbacks=callbacks,
+    )
+
+    # Get X and y from train_set for prediction-based IC computation
+    train_set.construct()
+    X = train_set.get_data()
+    if X is None:
+        raise RuntimeError(
+            "Cannot retrieve training data from Dataset (raw data was freed). "
+            "Use Dataset(X, y, free_raw_data=False) for IC-based criteria."
+        )
+    y = train_set.get_label()
+    N = len(y)
+
+    # MSE on training set
+    preds = model.predict(X)
+    mse = float(np.mean((preds - y) ** 2))
+
+    # Effective number of parameters: total leaf count across all trees
+    model_dump = model.dump_model()
+    n_params = _count_leaves(model_dump)
+
+    # Log-likelihood under Gaussian assumption
+    log_lik = -N / 2.0 * np.log(2 * np.pi * max(mse, 1e-15)) - N / 2.0
+
+    # Compute criterion
+    if criterion == "bic":
+        crit_val = -2 * log_lik + n_params * np.log(N)
+    elif criterion == "aic":
+        crit_val = -2 * log_lik + 2 * n_params
+    elif criterion == "icl":
+        bic_val = -2 * log_lik + n_params * np.log(N)
+        # Entropy penalty from gate probabilities
+        regime_proba = model.predict_regime_proba(X)
+        eps = 1e-12
+        ent = -np.sum(regime_proba * np.log(regime_proba + eps))
+        crit_val = bic_val + 2 * ent
+    else:
+        raise ValueError(f"Unknown criterion: {criterion}")
+
+    detail = {
+        "mse": mse,
+        "n_params": n_params,
+        "log_lik": log_lik,
+        criterion: float(crit_val),
+    }
+    if criterion == "icl":
+        detail["bic"] = float(bic_val)
+        detail["gate_entropy_sum"] = float(ent)
+
+    return float(crit_val), detail, model
+
+
+def _count_leaves(model_dump):
+    """Count total number of leaves across all trees in a dumped model."""
+    total = 0
+    for tree_info in model_dump.get("tree_info", []):
+        total += _count_leaves_in_tree(tree_info.get("tree_structure", {}))
+    return total
+
+
+def _count_leaves_in_tree(node):
+    """Recursively count leaves in a single tree node."""
+    if "leaf_value" in node:
+        return 1
+    count = 0
+    if "left_child" in node:
+        count += _count_leaves_in_tree(node["left_child"])
+    if "right_child" in node:
+        count += _count_leaves_in_tree(node["right_child"])
+    return count
+
+
+def _print_table(k_values, criterion_values, details, best_idx, criterion):
+    """Print a formatted results table."""
+    crit_name = criterion.upper()
+    is_ic = criterion in ("bic", "aic", "icl")
+
+    print()
+    print(f"Auto-K Selection (criterion={criterion})")
+    print("=" * 50)
+
+    if is_ic:
+        print(f"  {'K':>3}  |  {'MSE':>10}  | {'#Params':>7} | {'Log-Lik':>10} | {crit_name:>12}")
+        print("-" * 5 + "+" + "-" * 13 + "+" + "-" * 9 + "+" + "-" * 12 + "+" + "-" * 14)
+        for i, k in enumerate(k_values):
+            marker = "  <-- best" if i == best_idx else ""
+            d = details[i]
+            if "error" in d:
+                print(f"  {k:>3}  |  {'FAILED':>10}  | {'':>7} | {'':>10} | {'inf':>12}{marker}")
+            else:
+                print(
+                    f"  {k:>3}  |  {d['mse']:>10.6f}  | {d['n_params']:>7d} | {d['log_lik']:>10.1f} | "
+                    f"{criterion_values[i]:>12.1f}{marker}"
+                )
+    else:
+        # cv_rmse
+        print(f"  {'K':>3}  |  {'CV-RMSE':>10}  | {'Best Iter':>9}")
+        print("-" * 5 + "+" + "-" * 13 + "+" + "-" * 11)
+        for i, k in enumerate(k_values):
+            marker = "  <-- best" if i == best_idx else ""
+            d = details[i]
+            if "error" in d:
+                print(f"  {k:>3}  |  {'FAILED':>10}  | {'':>9}{marker}")
+            else:
+                print(f"  {k:>3}  |  {d['cv_rmse']:>10.6f}  | {d['best_iteration']:>9d}{marker}")
+
+    print()

--- a/python-package/lightgbm_moe/diagnostics.py
+++ b/python-package/lightgbm_moe/diagnostics.py
@@ -1,0 +1,177 @@
+# coding: utf-8
+"""MoE Regime Diagnostics — label-free diagnostics for mixture-of-experts models."""
+
+import numpy as np
+
+
+def diagnose_moe(model, X, y, print_report=True):
+    """Diagnose whether a trained MoE model is functioning as an effective switching model.
+
+    All metrics are computed without regime ground-truth labels.
+
+    Parameters
+    ----------
+    model : lightgbm_moe.Booster
+        A trained MoE (boosting="mixture") model.
+    X : array-like
+        Feature matrix used for diagnosis.
+    y : array-like
+        Target values used for computing prediction errors.
+    print_report : bool, default True
+        If True, print a human-readable diagnostic report.
+
+    Returns
+    -------
+    dict
+        Diagnostic metrics including gate entropy, expert specialization,
+        routing gain, expert correlation, utilization, and an overall verdict.
+    """
+    y = np.asarray(y, dtype=np.float64)
+
+    regime_proba = model.predict_regime_proba(X)
+    expert_preds = model.predict_expert_pred(X)
+    moe_preds = model.predict(X)
+    regime_pred = model.predict_regime(X)
+    K = regime_proba.shape[1]
+
+    # =========================================================================
+    # [1] Gate Entropy
+    # =========================================================================
+    eps = 1e-12
+    entropy_per_sample = -np.sum(regime_proba * np.log(regime_proba + eps), axis=1)
+    max_entropy = np.log(K)
+    mean_entropy = float(np.mean(entropy_per_sample))
+    median_entropy = float(np.median(entropy_per_sample))
+    confidence_ratio = float(np.mean(entropy_per_sample < 0.3 * max_entropy))
+
+    # =========================================================================
+    # [2] Expert Specialization
+    # =========================================================================
+    se_all = (expert_preds - y[:, None]) ** 2  # (N, K)
+    assigned_se = se_all[np.arange(len(y)), regime_pred]
+
+    # Mean SE of non-assigned experts
+    mask = np.ones((len(y), K), dtype=bool)
+    mask[np.arange(len(y)), regime_pred] = False
+    other_se_mean = np.where(mask, se_all, 0.0).sum(axis=1) / np.maximum(mask.sum(axis=1), 1)
+
+    wins = assigned_se < other_se_mean
+    specialization_rate = float(np.mean(wins))
+
+    improvement_where_wins = np.where(
+        wins & (other_se_mean > 0),
+        (other_se_mean - assigned_se) / (other_se_mean + eps),
+        0.0,
+    )
+    mean_loss_improvement = float(np.sum(improvement_where_wins) / max(np.sum(wins), 1))
+
+    # =========================================================================
+    # [3] Routing Gain
+    # =========================================================================
+    moe_rmse = float(np.sqrt(np.mean((moe_preds - y) ** 2)))
+    expert_rmses = [float(np.sqrt(np.mean((expert_preds[:, k] - y) ** 2))) for k in range(K)]
+    best_single_rmse = min(expert_rmses)
+    routing_gain = (best_single_rmse - moe_rmse) / (best_single_rmse + eps) * 100
+
+    # =========================================================================
+    # [4] Expert Correlation
+    # =========================================================================
+    corrs = []
+    for i in range(K):
+        for j in range(i + 1, K):
+            corrs.append(float(np.corrcoef(expert_preds[:, i], expert_preds[:, j])[0, 1]))
+    if corrs:
+        expert_corr_max = max(corrs)
+        expert_corr_min = min(corrs)
+    else:
+        expert_corr_max = expert_corr_min = 0.0
+    expert_collapsed = expert_corr_max > 0.99
+
+    # =========================================================================
+    # [5] Expert Utilization
+    # =========================================================================
+    utilization = [float(np.mean(regime_pred == k)) for k in range(K)]
+    utilization_min = min(utilization)
+    any_underutilized = utilization_min < 0.05
+
+    # =========================================================================
+    # [6] Verdict
+    # =========================================================================
+    if expert_collapsed or utilization_min < 0.01 or specialization_rate < 0.3:
+        verdict = "Not Switching (Collapsed)"
+    elif specialization_rate > 0.6 and confidence_ratio > 0.5 and routing_gain > 1.0 and not expert_collapsed:
+        verdict = "Effective Switching"
+    else:
+        verdict = "Weak Switching"
+
+    result = {
+        "K": K,
+        "mean_entropy": mean_entropy,
+        "median_entropy": median_entropy,
+        "max_entropy": float(max_entropy),
+        "confidence_ratio": confidence_ratio,
+        "entropy_per_sample": entropy_per_sample,
+        "specialization_rate": specialization_rate,
+        "mean_loss_improvement": mean_loss_improvement,
+        "moe_rmse": moe_rmse,
+        "expert_rmses": expert_rmses,
+        "best_single_rmse": best_single_rmse,
+        "routing_gain": routing_gain,
+        "expert_corr_max": expert_corr_max,
+        "expert_corr_min": expert_corr_min,
+        "expert_collapsed": expert_collapsed,
+        "utilization": utilization,
+        "utilization_min": utilization_min,
+        "any_underutilized": any_underutilized,
+        "verdict": verdict,
+    }
+
+    if print_report:
+        _print_report(result)
+
+    return result
+
+
+def _print_report(r):
+    """Print a human-readable diagnostic report."""
+    K = r["K"]
+    print()
+    print("MoE Regime Diagnostics")
+    print("======================")
+    print(f"Model: K={K} experts")
+
+    print()
+    print("[1] Gate Entropy")
+    print(f"    Mean entropy       : {r['mean_entropy']:.3f} / {r['max_entropy']:.3f} (max)")
+    print(f"    Confidence ratio   : {r['confidence_ratio']:.1%}")
+
+    print()
+    print("[2] Expert Specialization")
+    print(f"    Specialization rate: {r['specialization_rate']:.1%}")
+    print(f"    Mean loss improvement: {r['mean_loss_improvement']:.1%}")
+
+    print()
+    print("[3] Routing Gain")
+    print(f"    MoE RMSE           : {r['moe_rmse']:.4f}")
+    expert_strs = "  ".join(f"E{k}={r['expert_rmses'][k]:.4f}" for k in range(K))
+    print(f"    Expert RMSEs       : {expert_strs}")
+    print(f"    Routing gain       : {r['routing_gain']:+.1f}%")
+
+    print()
+    print("[4] Expert Correlation")
+    print(f"    Pairwise corr      : {r['expert_corr_max']:.2f} (max)  {r['expert_corr_min']:.2f} (min)")
+    print(f"    Collapsed          : {'Yes' if r['expert_collapsed'] else 'No'}")
+
+    print()
+    print("[5] Expert Utilization")
+    util_strs = "   ".join(f"E{k}: {r['utilization'][k]:.1%}" for k in range(K))
+    print(f"    {util_strs}")
+
+    print()
+    if r["verdict"] == "Effective Switching":
+        print(f"Verdict: {r['verdict']} ✓")
+    elif r["verdict"] == "Not Switching (Collapsed)":
+        print(f"Verdict: {r['verdict']} ✗")
+    else:
+        print(f"Verdict: {r['verdict']} ~")
+    print()

--- a/python-package/lightgbm_moe/pruning.py
+++ b/python-package/lightgbm_moe/pruning.py
@@ -1,0 +1,341 @@
+# coding: utf-8
+"""Expert pruning and merging for trained MoE models."""
+
+import numpy as np
+
+
+class PrunedMoEModel:
+    """A wrapper around a trained MoE Booster that masks pruned/merged experts.
+
+    Provides the same prediction interface as ``Booster`` so it can be used
+    directly with ``diagnose_moe()``.
+
+    Attributes
+    ----------
+    original_model : Booster
+        The original trained MoE model.
+    active_mask : np.ndarray
+        Boolean mask of shape ``(K_orig,)`` indicating which experts are active.
+    merge_weights : dict
+        Mapping ``{survivor_idx: {orig_idx: weight, ...}}`` for merged experts.
+    pruning_report : dict
+        Summary of the pruning/merging operations performed.
+    """
+
+    def __init__(self, original_model, active_mask, merge_weights=None, pruning_report=None):
+        self.original_model = original_model
+        self.active_mask = np.asarray(active_mask, dtype=bool)
+        self.merge_weights = merge_weights or {}
+        self.pruning_report = pruning_report or {}
+
+    def num_experts(self):
+        """Return the number of active experts."""
+        return int(self.active_mask.sum())
+
+    def is_mixture(self):
+        """Return True (this is always a mixture model wrapper)."""
+        return True
+
+    def predict_regime_proba(self, X):
+        """Return gate probabilities for active experts only, renormalised.
+
+        Returns
+        -------
+        np.ndarray of shape ``(N, K_active)``
+        """
+        full_proba = self.original_model.predict_regime_proba(X)  # (N, K_orig)
+        active_proba = full_proba[:, self.active_mask]  # (N, K_active)
+        row_sums = active_proba.sum(axis=1, keepdims=True)
+        row_sums = np.maximum(row_sums, 1e-15)
+        return active_proba / row_sums
+
+    def predict_expert_pred(self, X):
+        """Return per-expert predictions for active experts (with merge weighting).
+
+        Returns
+        -------
+        np.ndarray of shape ``(N, K_active)``
+        """
+        full_preds = self.original_model.predict_expert_pred(X)  # (N, K_orig)
+        K_orig = full_preds.shape[1]
+        active_indices = np.where(self.active_mask)[0]
+
+        result = np.empty((full_preds.shape[0], len(active_indices)), dtype=np.float64)
+        for col, orig_idx in enumerate(active_indices):
+            if orig_idx in self.merge_weights:
+                # Weighted average of merged experts
+                merged = np.zeros(full_preds.shape[0], dtype=np.float64)
+                for src_idx, w in self.merge_weights[orig_idx].items():
+                    merged += w * full_preds[:, src_idx]
+                result[:, col] = merged
+            else:
+                result[:, col] = full_preds[:, orig_idx]
+
+        return result
+
+    def predict(self, X):
+        """Return weighted MoE prediction using active experts only.
+
+        Returns
+        -------
+        np.ndarray of shape ``(N,)``
+        """
+        proba = self.predict_regime_proba(X)  # (N, K_active)
+        preds = self.predict_expert_pred(X)   # (N, K_active)
+        return (proba * preds).sum(axis=1)
+
+    def predict_regime(self, X):
+        """Return argmax regime index among active experts.
+
+        Returns
+        -------
+        np.ndarray of shape ``(N,)``
+        """
+        proba = self.predict_regime_proba(X)
+        return np.argmax(proba, axis=1).astype(np.int32)
+
+
+def prune_experts(
+    model,
+    X,
+    y=None,
+    correlation_threshold=0.95,
+    min_utilization=0.02,
+    print_report=True,
+):
+    """Prune underutilised and redundant experts from a trained MoE model.
+
+    Parameters
+    ----------
+    model : Booster
+        A trained MoE model (``boosting="mixture"``).
+    X : array-like
+        Feature matrix used to evaluate expert utilisation and correlation.
+    y : array-like or None, default None
+        Target values (not used in the current implementation, reserved for
+        future loss-based pruning).
+    correlation_threshold : float, default 0.95
+        Expert pairs with prediction correlation above this threshold are
+        merged (the less-utilised expert is folded into the more-utilised one).
+    min_utilization : float, default 0.02
+        Experts with utilisation below this fraction of samples are pruned.
+    print_report : bool, default True
+        If True, print a summary of pruning actions.
+
+    Returns
+    -------
+    PrunedMoEModel
+        A wrapped model with pruned/merged experts masked out.
+    """
+    K = model.num_experts()
+    regime_pred = model.predict_regime(X)
+    expert_preds = model.predict_expert_pred(X)
+
+    # Compute utilization per expert
+    utilization = np.array([float(np.mean(regime_pred == k)) for k in range(K)])
+
+    active = np.ones(K, dtype=bool)
+    actions = []
+    merge_weights = {}
+
+    # Step 1: Prune underutilised experts
+    for k in range(K):
+        if utilization[k] < min_utilization:
+            active[k] = False
+            actions.append(f"  E{k}: underutilized ({utilization[k]:.1%} < {min_utilization:.0%})")
+
+    # Step 2: Merge highly correlated expert pairs (among remaining active)
+    active_indices = list(np.where(active)[0])
+    merged_into = {}  # maps pruned index -> survivor index
+
+    # Compute pairwise correlations among active experts
+    pairs_to_merge = []
+    for i_pos, i in enumerate(active_indices):
+        for j in active_indices[i_pos + 1:]:
+            corr = float(np.corrcoef(expert_preds[:, i], expert_preds[:, j])[0, 1])
+            if corr > correlation_threshold:
+                pairs_to_merge.append((i, j, corr))
+
+    # Sort by correlation descending — merge most similar first
+    pairs_to_merge.sort(key=lambda x: -x[2])
+
+    for i, j, corr in pairs_to_merge:
+        if not active[i] or not active[j]:
+            continue  # One already pruned/merged
+        # Keep the one with higher utilization
+        if utilization[i] >= utilization[j]:
+            survivor, victim = i, j
+        else:
+            survivor, victim = j, i
+
+        active[victim] = False
+        merged_into[victim] = survivor
+
+        # Build merge weight map for the survivor
+        # Collect all experts that are now merged into this survivor
+        group = [survivor]
+        for prev_victim, prev_surv in merged_into.items():
+            if prev_surv == survivor and prev_victim != victim:
+                group.append(prev_victim)
+        group.append(victim)
+
+        total_util = sum(utilization[g] for g in group)
+        if total_util > 0:
+            weights = {g: float(utilization[g] / total_util) for g in group}
+        else:
+            weights = {g: 1.0 / len(group) for g in group}
+        merge_weights[survivor] = weights
+
+        actions.append(f"  E{victim}: merged into E{survivor} (corr={corr:.2f})")
+
+    # Safety: ensure at least one expert remains
+    if not active.any():
+        best = int(np.argmax(utilization))
+        active[best] = True
+        actions.append(f"  E{best}: kept as fallback (all experts would be pruned)")
+
+    # Build active expert info
+    active_indices_final = list(np.where(active)[0])
+    active_utilizations = {}
+    for idx in active_indices_final:
+        if idx in merge_weights:
+            merged_sources = list(merge_weights[idx].keys())
+            total_u = sum(utilization[s] for s in merged_sources)
+            includes = [s for s in merged_sources if s != idx]
+            active_utilizations[idx] = (total_u, includes)
+        else:
+            active_utilizations[idx] = (utilization[idx], [])
+
+    report = {
+        "K_original": K,
+        "K_active": int(active.sum()),
+        "active_indices": active_indices_final,
+        "utilization": utilization.tolist(),
+        "actions": actions,
+        "active_utilizations": active_utilizations,
+    }
+
+    if print_report:
+        _print_prune_report(report)
+
+    return PrunedMoEModel(
+        original_model=model,
+        active_mask=active,
+        merge_weights=merge_weights,
+        pruning_report=report,
+    )
+
+
+def merge_experts(
+    model,
+    X,
+    expert_groups,
+    print_report=True,
+):
+    """Manually merge specified groups of experts.
+
+    Parameters
+    ----------
+    model : Booster
+        A trained MoE model.
+    X : array-like
+        Feature matrix used to compute utilisation-based merge weights.
+    expert_groups : list of list of int
+        Each inner list specifies expert indices to merge. The first index
+        in each group is the survivor.
+    print_report : bool, default True
+        If True, print a summary of merging actions.
+
+    Returns
+    -------
+    PrunedMoEModel
+        A wrapped model with merged experts.
+    """
+    K = model.num_experts()
+    regime_pred = model.predict_regime(X)
+    utilization = np.array([float(np.mean(regime_pred == k)) for k in range(K)])
+
+    active = np.ones(K, dtype=bool)
+    merge_weights = {}
+    actions = []
+
+    for group in expert_groups:
+        if len(group) < 2:
+            continue
+        survivor = group[0]
+        victims = group[1:]
+
+        total_util = sum(utilization[g] for g in group)
+        if total_util > 0:
+            weights = {g: float(utilization[g] / total_util) for g in group}
+        else:
+            weights = {g: 1.0 / len(group) for g in group}
+        merge_weights[survivor] = weights
+
+        for v in victims:
+            active[v] = False
+            actions.append(f"  E{v}: merged into E{survivor}")
+
+    active_indices_final = list(np.where(active)[0])
+
+    report = {
+        "K_original": K,
+        "K_active": int(active.sum()),
+        "active_indices": active_indices_final,
+        "utilization": utilization.tolist(),
+        "actions": actions,
+    }
+
+    if print_report:
+        _print_merge_report(report)
+
+    return PrunedMoEModel(
+        original_model=model,
+        active_mask=active,
+        merge_weights=merge_weights,
+        pruning_report=report,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _print_prune_report(report):
+    """Print a human-readable pruning report."""
+    print()
+    print("Expert Pruning Report")
+    print("=" * 40)
+    print(f"Original: K={report['K_original']} experts -> Active: K={report['K_active']} experts")
+
+    if report["actions"]:
+        print()
+        print("Actions:")
+        for a in report["actions"]:
+            print(a)
+
+    print()
+    print("Active experts:", [f"E{i}" for i in report["active_indices"]])
+    for idx, (util, includes) in report["active_utilizations"].items():
+        inc_str = f" (includes merged E{',E'.join(str(i) for i in includes)})" if includes else ""
+        print(f"  E{idx}: utilization {util:.1%}{inc_str}")
+    print()
+
+
+def _print_merge_report(report):
+    """Print a human-readable merge report."""
+    print()
+    print("Expert Merge Report")
+    print("=" * 40)
+    print(f"Original: K={report['K_original']} experts -> Active: K={report['K_active']} experts")
+
+    if report["actions"]:
+        print()
+        print("Actions:")
+        for a in report["actions"]:
+            print(a)
+
+    print()
+    print("Active experts:", [f"E{i}" for i in report["active_indices"]])
+    print()


### PR DESCRIPTION
## Summary

- **`select_num_experts()`**: 情報量規準(BIC/AIC/ICL)またはCV-RMSEベースでMoEモデルの最適エキスパート数Kを自動選択
- **`prune_experts()` / `merge_experts()`**: 学習済みMoEモデルから低利用率・高相関の冗長エキスパートを刈り込み/統合。`PrunedMoEModel`ラッパーにより`diagnose_moe()`とそのまま互換
- **`diagnose_moe()`**: レジーム診断機能のexport追加

Pure Python実装のみ (C++変更なし)。

## Test plan

- [ ] `select_num_experts()` を各criterion (bic, aic, icl, cv_rmse) で実行し、best_kが妥当な値を返すことを確認
- [ ] IC規準で `free_raw_data=True` の Dataset を渡した場合に適切なエラーメッセージが出ることを確認
- [ ] `prune_experts()` で低利用率エキスパートが除去されることを確認
- [ ] 高相関エキスパートペアが正しくマージされることを確認
- [ ] `PrunedMoEModel` を `diagnose_moe()` に渡して正常動作することを確認
- [ ] `merge_experts()` で手動グループ指定が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)