### PR TITLE
fix(moe): defensive epsilon floors + restore Markov params on LoadModel

### DIFF
--- a/src/boosting/mixture_gbdt.cpp
+++ b/src/boosting/mixture_gbdt.cpp
@@ -1985,9 +1985,15 @@ void MixtureGBDT::ConvertSelectionToResponsibilities() {
         responsibilities_[i * num_experts_ + k] = 1.0 / num_experts_;
       }
     } else {
-      // Normalize (sum = 1)
+      // Normalize (sum = 1). Epsilon floor is defensive: in practice sum > 0
+      // because soft routing guarantees min_r > 0 for non-selected experts and
+      // hard routing's num_selected == 0 path is handled above. Underflow is
+      // only possible if every selected expert has affinity ≪ -700 (exp → 0)
+      // — vanishingly unlikely given gate logits are bounded — but the cost
+      // of floor()ing is zero and it forecloses one NaN-propagation route.
+      const double inv_sum = 1.0 / std::max(sum, kMixtureEpsilon);
       for (int k = 0; k < num_experts_; ++k) {
-        responsibilities_[i * num_experts_ + k] /= sum;
+        responsibilities_[i * num_experts_ + k] *= inv_sum;
       }
     }
   }
@@ -2011,9 +2017,13 @@ void MixtureGBDT::SmoothResponsibilities() {
                                  lambda * responsibilities_[prev_idx];
         sum += responsibilities_[idx];
       }
-      // Renormalize
+      // Renormalize. Mathematically sum ≡ 1 here (convex combination of two
+      // already-normalized rows), so the epsilon floor is purely defensive
+      // against floating-point pathologies — but it matches the momentum
+      // branch below, which has carried the same guard for a while.
+      const double inv_sum = 1.0 / std::max(sum, kMixtureEpsilon);
       for (int k = 0; k < num_experts_; ++k) {
-        responsibilities_[i * num_experts_ + k] /= sum;
+        responsibilities_[i * num_experts_ + k] *= inv_sum;
       }
     }
   } else if (config_->mixture_r_smoothing == "momentum") {

--- a/src/boosting/mixture_gbdt.cpp
+++ b/src/boosting/mixture_gbdt.cpp
@@ -3785,6 +3785,43 @@ bool MixtureGBDT::LoadModelFromString(const char* buffer, size_t len) {
   config_ = std::unique_ptr<Config>(new Config());
   config_->mixture_num_experts = num_experts_;
 
+  // Restore training-time mixture parameters into the freshly-default config.
+  // Without this block, every save/load round-trip silently snapped these
+  // back to defaults — and `lgb.train` performs that round-trip *internally*
+  // at the end of training (engine.py: `booster.model_from_string(model_to_string())`),
+  // so even users who never explicitly save/load were affected.
+  //
+  // The most user-visible symptom was Markov inference: training with
+  // `mixture_r_smoothing=markov` set `use_markov_=true` during fitting, but
+  // after the post-train round-trip the loaded booster had `use_markov_=false`
+  // and `mixture_smoothing_lambda=0`. `predict_markov()` then silently no-ops
+  // (line 3341 / 3376 guards on `use_markov_`), and Python's
+  // `predict_regime_proba_markov` no-ops too because it reads `lambda=0` /
+  // `smoothing="none"` out of the loaded params dict. Test-set predictions
+  // diverged from validation behaviour without any error or warning.
+  if (params.count("mixture_r_smoothing")) {
+    config_->mixture_r_smoothing = params["mixture_r_smoothing"];
+  }
+  if (params.count("mixture_smoothing_lambda")) {
+    try {
+      config_->mixture_smoothing_lambda =
+          std::stod(params["mixture_smoothing_lambda"]);
+    } catch (...) { /* keep default */ }
+  }
+  if (params.count("mixture_e_step_alpha")) {
+    try {
+      config_->mixture_e_step_alpha =
+          std::stod(params["mixture_e_step_alpha"]);
+    } catch (...) { /* keep default */ }
+  }
+  if (params.count("mixture_e_step_mode")) {
+    config_->mixture_e_step_mode = params["mixture_e_step_mode"];
+  }
+  // Re-derive smoothing-mode flags from the restored config (mirrors Init()
+  // line ~266). These flags are not serialized themselves; they are computed.
+  use_markov_ = (config_->mixture_r_smoothing == "markov");
+  use_momentum_ = (config_->mixture_r_smoothing == "momentum");
+
   // Initialize experts
   experts_.clear();
   experts_.reserve(num_experts_);


### PR DESCRIPTION
## Summary

Two related fixes to `src/boosting/mixture_gbdt.cpp` that came out of the post-#28 full-codebase audit. The first is defensive parity; the second is a **HIGH-severity, user-facing bug** that silently broke Markov-mode inference for every model trained with `mixture_r_smoothing="markov"`.

## 1) Defensive epsilon floors on responsibility renormalization

Two normalization sites divided by `sum` without an epsilon guard, while parallel paths in the same file already used `std::max(sum, kMixtureEpsilon)`. Both are mathematically safe under their stated invariants (no NaN observed), but the cost of matching the existing pattern is zero and it forecloses a NaN-propagation route.

- **`ConvertSelectionToResponsibilities`** (Expert-Choice routing): in soft mode `sum ≥ (K − num_selected) · min_r > 0` unless `num_selected == K` and every selected affinity ≪ −700 (`exp` underflow). Now floored.
- **`SmoothResponsibilities` EMA branch**: convex combination of two normalized rows is mathematically `sum == 1`. The momentum branch already had this guard; ema was the asymmetric outlier. Now consistent.

No behavior change at the intended operating point.

## 2) Markov / smoothing params silently dropped on save/load

**This was real and user-visible.** The chain of events:

1. `lgb.train` ends with `engine.py:352` doing `booster.model_from_string(booster.model_to_string())` — an internal save/load round-trip done unconditionally unless `keep_training_booster=True`.
2. `MixtureGBDT::LoadModelFromString` constructed a fresh `Config` and only restored `num_experts`, `e_step_loss_type`, `gate_temperature`, `expert_bias`, `expert_variance`. `mixture_r_smoothing` and `mixture_smoothing_lambda` were *saved* but never read back.
3. Result: `config_->mixture_r_smoothing = "none"`, `mixture_smoothing_lambda = 0`, `use_markov_ = false` on the booster the user receives.
4. Both `predict_markov` (C++ line 3341/3376 guards on `use_markov_`) and Python's `predict_regime_proba_markov` (basic.py:5052 reads params dict) silently no-op — returning un-smoothed predictions with no warning.
5. Subsequent `save_model()` also wrote `"none"/0` to disk, propagating the corruption.

This commit restores `mixture_r_smoothing`, `mixture_smoothing_lambda`, `mixture_e_step_alpha`, `mixture_e_step_mode` in `LoadModelFromString`, and re-derives `use_markov_` / `use_momentum_` from the restored `r_smoothing` (mirroring `Init` line ~266).

### Verification (non-collapsing config)

| | before | after |
|---|---|---|
| `loaded.params['mixture_r_smoothing']` | `"none"` | `"markov"` |
| `loaded.params['mixture_smoothing_lambda']` | `0` | `0.5` |
| `max\|markov − base\|` | `0.0` (no-op) | `0.49` |
| `max\|original_markov − reloaded_markov\|` | n/a | `0.0` (bit-exact) |

## Test plan

- [x] `pytest tests/python_package_test/test_mixture.py` — 15/15 pass
- [x] Manual save/load round-trip with `mixture_r_smoothing=markov, mixture_smoothing_lambda=0.5` — params and Markov inference both recovered correctly
- [x] `mixture_r_smoothing="markov"` vs `"none"` produce different `predict_regime_proba_markov` outputs (was 0.0 diff before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)