### PR TITLE
bench: default --n-jobs to 1 for reproducible best-RMSE across builds

### DIFF
--- a/examples/comparative_study.py
+++ b/examples/comparative_study.py
@@ -16,12 +16,30 @@ Standard GBDT と MoE (token + expert choice 横断) で Optuna を回し、
 
 mixture_init は {random, gmm, tree_hierarchical} に限定 (uniform/quantile/balanced_kmeans 除外)。
 
+Determinism note (--n-jobs default=1):
+    Earlier versions defaulted to n_jobs=6 to "speed up" Optuna. In practice,
+    n_jobs>1 makes best RMSE non-reproducible across runs / builds even with
+    seed fixed: the TPE sampler's recommendations depend on the order parallel
+    workers report observations back, and that order is non-deterministic. On
+    a regression-checking run (synthetic, 500 trials, 3 seeds × 2 builds, see
+    `bench_logs/regression_check_*`) the n_jobs=6 best-RMSE std was ±0.31 —
+    enough to make a single-seed n_jobs=6 result swing by ±0.6, large enough
+    to falsely flag any code change as a regression. Worse, n_jobs=6 was *not*
+    actually faster: with each LightGBM trial saturating all cores via OMP,
+    6 concurrent trials oversubscribe the CPU and run ~18% slower per dataset
+    than a single sequential pipeline (234s vs 287s on synthetic in that run).
+
+    The default is now n_jobs=1: deterministic best RMSE across runs and
+    builds, AND faster wall time. Override with --n-jobs >1 only if you
+    explicitly need the (noisy) speed/coverage tradeoff and don't care about
+    cross-run comparison.
+
 Usage:
     # 小規模 sanity check
     python examples/comparative_study.py --trials 50 --out bench_results/study_smoke.json
 
-    # 本番 1000 trials × 2 variants × 3 datasets
-    python examples/comparative_study.py --trials 1000 --out bench_results/study_1k.json
+    # 本番 500 trials × 2 variants × 6 datasets (deterministic)
+    python examples/comparative_study.py --trials 500 --out bench_results/study_500.json
 """
 from __future__ import annotations
 
@@ -528,7 +546,12 @@ DATASET_GENERATORS = {
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--trials", type=int, default=500)
-    p.add_argument("--n-jobs", type=int, default=6)
+    # n_jobs=1 is deliberately the default — see the module docstring for the
+    # determinism / speed rationale. tl;dr Optuna n_jobs>1 makes best-RMSE
+    # non-reproducible across runs even with seed fixed (TPE observation
+    # ordering depends on worker scheduling), AND oversubscribes the CPU
+    # against per-trial OMP threading so it's not actually faster.
+    p.add_argument("--n-jobs", type=int, default=1)
     p.add_argument("--rounds", type=int, default=100)
     p.add_argument("--splits", type=int, default=5)
     p.add_argument("--seed", type=int, default=42)


### PR DESCRIPTION
## Summary

`comparative_study.py` defaulted to `--n-jobs 6` to "speed up" Optuna. In practice this made best-RMSE non-reproducible across runs and builds even with `--seed` fixed: TPE's recommendations depend on the order parallel workers report observations back, and that order is non-deterministic.

## Evidence

A regression-check run (`bench_logs/regression_check_20260502_184040`) compared release/v0.6.0 current (PR #27 + #28) vs pre-#27 (PR #26) on synthetic, 500 trials, 3 seeds × 2 builds:

| Build | n_jobs=1 (seed=42) MoE best | n_jobs=6 mean ± std (seeds 42/43/44) MoE best |
|---|---|---|
| current (PR #27 + #28) | **3.6534** | 4.45 ± 0.31 — seeds [4.55, 4.69, 4.10] |
| pre-#27 (PR #26) | **3.7702** | 4.51 ± 0.24 — seeds [4.64, 4.65, 4.23] |
| **Δ (current − pre27)** | **−0.117** (current better) | −0.058 (within noise) |

n_jobs=1 is **deterministic** (Naive RMSE byte-identical between builds, sanity check) and shows PR #27 + #28 is a small improvement over PR #26 — the apparent "3.70 → 4.31 regression" reported earlier was a single-seed n_jobs=6 noise sample.

## And n_jobs=6 isn't even faster

Per-dataset wall time on synthetic, same hardware:

- n_jobs=1: 234s
- n_jobs=6: 287s (3-seed mean)

Each LightGBM trial saturates all cores via OMP. 6 concurrent trials oversubscribe the CPU and run ~18% slower than a single sequential pipeline.

## Change

- Default `--n-jobs` 6 → 1
- Module docstring updated with the determinism rationale
- Inline comment on the argparse default

## What is unchanged

- `--n-jobs <N>` still works for users who want the noisy speed/coverage tradeoff.
- All other defaults (trials=500, splits=5, seed=42, rounds=100).
- Result JSON / report formats.

## Files

- `examples/comparative_study.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)