### PR TITLE
feat(moe): v0.8 elbo-trigger — sliding-window drop OR plateau detection

### DIFF
--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -1286,6 +1286,53 @@ struct Config {
   // check = >0
   int mixture_refit_every_n = 10;
 
+  // [doc-only] v0.8 elbo-trigger
+  // desc = drop threshold for the ``elbo`` refit trigger. Fires refit when the
+  //        sliding-window relative drop ``(elbo_t - elbo_{t-W}) / max(|elbo_{t-W}|, 1)``
+  //        falls below ``-mixture_elbo_drop_threshold``
+  // desc = lowered from the v0.7 hard-coded 0.05 because the cost asymmetry favors
+  //        sensitivity: false fire = one extra refit, missed fire = permanent basin
+  //        lock-in. Set to 0.05 to recover v0.7 drop sensitivity
+  // desc = ignored when ``mixture_refit_trigger != "elbo"``
+  // check = >=0.0
+  double mixture_elbo_drop_threshold = 0.01;
+
+  // [doc-only] v0.8 elbo-trigger
+  // desc = plateau threshold for the ``elbo`` refit trigger. Fires refit when
+  //        ``(max(window) - min(window)) / max(|max(window)|, 1) < mixture_elbo_plateau_threshold``
+  //        AND ``moe_iter > mixture_warmup_iters + mixture_elbo_min_iter_for_plateau``
+  // desc = healthy Optuna-tuned configs do not drop ELBO; they plateau at sub-optimal
+  //        local fixed points where E-step output stops changing and M-step
+  //        contributions vanish. Plateau detection catches this where drop detection
+  //        cannot — empirically the v0.7 ``elbo`` trigger fired 0/6 datasets in the
+  //        v0.7 acceptance bench precisely because tuned configs do not drop
+  // desc = set to ``0`` to disable plateau detection (drop-only behavior, v0.7-like)
+  // desc = ignored when ``mixture_refit_trigger != "elbo"``
+  // check = >=0.0
+  double mixture_elbo_plateau_threshold = 0.001;
+
+  // [doc-only] v0.8 elbo-trigger
+  // desc = sliding-window size (in iterations) for the ELBO history used by the
+  //        ``elbo`` trigger
+  // desc = larger window → more stable plateau detection, slower to react;
+  //        smaller window → faster, more false fires from natural ELBO noise
+  //        (one tree per iter ⇒ small per-iter ELBO jitter is normal)
+  // desc = ignored when ``mixture_refit_trigger != "elbo"``
+  // check = >=2
+  int mixture_elbo_window = 10;
+
+  // [doc-only] v0.8 elbo-trigger
+  // desc = minimum number of post-warmup iterations before plateau detection can
+  //        fire. Effective floor is ``mixture_warmup_iters + mixture_elbo_min_iter_for_plateau``
+  // desc = warmup-adjacent ELBO is noisy (gate logits are still equilibrating to
+  //        ``log(r_init)``); firing too early would mistake the warmup transient
+  //        for a converged plateau
+  // desc = drop detection is unaffected by this — it can fire as soon as the
+  //        sliding window contains at least 2 ELBO samples
+  // desc = ignored when ``mixture_refit_trigger != "elbo"``
+  // check = >=0
+  int mixture_elbo_min_iter_for_plateau = 20;
+
   // type = enum
   // options = value, value_and_regime, all
   // desc = output mode for mixture prediction

--- a/src/boosting/mixture_gbdt.cpp
+++ b/src/boosting/mixture_gbdt.cpp
@@ -2549,11 +2549,48 @@ bool MixtureGBDT::ShouldRefit() const {
   if (trigger == "always") {
     return true;
   } else if (trigger == "elbo") {
-    // Fires when the most-recent ELBO log block (every 10 iters past warmup,
-    // and the first 5 iters) saw a >5% drop. Stays at 0 when
-    // mixture_estimate_variance=false (the log block computes nothing then),
-    // so users who turn off variance estimation effectively get no-refit.
-    return last_elbo_drop_ratio_ > 0.05;
+    // v0.8: sliding-window drop OR plateau detection. The v0.7 single-scalar
+    // 5%-drop trigger fired 0/6 datasets in the v0.7 acceptance bench because
+    // Optuna-tuned configs do not drop ELBO — they plateau at a sub-optimal
+    // local fixed point (E-step output stops moving → M-step contributions
+    // vanish → ELBO flatlines without dropping). We detect both modes:
+    //   • drop    — fast change against the back of the window
+    //   • plateau — small spread across the entire window (basin lock-in)
+    // Both signals require mixture_estimate_variance=true (otherwise no ELBO
+    // is computed and elbo_history_ stays empty → trigger never fires).
+    if (elbo_history_.size() < 2) return false;
+    const int W = std::max(2, config_->mixture_elbo_window);
+
+    // Drop detection — usable as soon as we have ≥2 samples; references the
+    // window's earliest (t-W) and latest (t) values.
+    const double elbo_t = elbo_history_.back();
+    const double elbo_w = elbo_history_.front();
+    const double rel_drop = std::max(std::fabs(elbo_w), 1.0);
+    if ((elbo_t - elbo_w) / rel_drop < -config_->mixture_elbo_drop_threshold) {
+      return true;
+    }
+
+    // Plateau detection — requires the window to be full (otherwise "haven't
+    // seen W iters yet" looks identical to "no improvement over W iters") and
+    // gated by min_iter_for_plateau to skip the warmup-adjacent transient
+    // where ELBO is still equilibrating.
+    const double plateau_th = config_->mixture_elbo_plateau_threshold;
+    if (plateau_th > 0.0
+        && static_cast<int>(elbo_history_.size()) >= W
+        && moe_iter > config_->mixture_warmup_iters
+                      + config_->mixture_elbo_min_iter_for_plateau) {
+      double emin = elbo_history_.front();
+      double emax = elbo_history_.front();
+      for (double v : elbo_history_) {
+        if (v < emin) emin = v;
+        if (v > emax) emax = v;
+      }
+      const double rel_plat = std::max(std::fabs(emax), 1.0);
+      if ((emax - emin) / rel_plat < plateau_th) {
+        return true;
+      }
+    }
+    return false;
   } else if (trigger == "every_n") {
     const int n = std::max(1, config_->mixture_refit_every_n);
     return (moe_iter % n) == 0;
@@ -3191,49 +3228,64 @@ bool MixtureGBDT::TrainOneIter(const score_t* gradients, const score_t* hessians
   // monotone non-decreasing in this quantity; here the M-step is
   // approximate (each expert / the gate adds one tree per iter), so
   // monotonicity is not guaranteed but should hold "most of the time".
-  // A persistent decrease across many iters indicates the EM machinery is
-  // not actually fitting the mixture — log it loudly so we notice.
-  if (config_->mixture_estimate_variance &&
-      moe_iter >= warmup_iters &&
-      (iter_ % 10 == 0 || iter_ < 5)) {
+  //
+  // v0.8: ELBO is now computed every post-warmup iter (was every 10 in v0.7)
+  // and pushed to elbo_history_, the sliding window read by ShouldRefit() in
+  // "elbo" trigger mode. The 1-iter lag (trigger at iter t+1 reads ELBO from
+  // iter t) is intentional — refit fires at the start of iter t+1, BEFORE
+  // tree t+1 is built, modifying f_k against the freshly-detected drop or
+  // plateau. Cost: one extra O(N·K) logsumexp per iter (~5–10% wall-time).
+  //
+  // Logging cadence is unchanged from v0.7 (every 10 iters past warmup +
+  // first 5 iters) so console output looks the same to existing users. The
+  // 5%-drop warning is a separate diagnostic from the trigger and stays
+  // tied to the log cadence.
+  if (config_->mixture_estimate_variance && moe_iter >= warmup_iters) {
     const double ll = ComputeMarginalLogLikelihood();
-    Log::Info("MixtureGBDT: iter=%d  marginal_log_lik=%.6f  (per_sample=%.6f)",
-              iter_, ll,
-              num_data_ > 0 ? ll / num_data_ : 0.0);
 
-    // Monotonicity check. Approximate M-step → small dips are normal, but a
-    // drop bigger than 5% of |prev| is symptomatic of misalignment between
-    // E-step and M-step — historically this has been a sign of:
-    //   • bias-side regularizer fighting gate (pre PR #25)
-    //   • diversity sign flip (pre PR #26)
-    //   • dimension mismatch in scale estimation (pre this commit's quantile fix)
-    //   • aggressive expert dropout / adaptive_lr decoupling experts from EM
-    // The user can mute by quietening Log::Warning if expected (e.g. when
-    // deliberately running with high dropout for ablation).
-    const bool prev_finite = std::isfinite(prev_marginal_log_lik_) &&
-                             prev_marginal_log_lik_ > -1e299;
-    if (prev_finite && std::isfinite(ll)) {
-      const double drop = prev_marginal_log_lik_ - ll;
-      const double rel_scale = std::max(std::fabs(prev_marginal_log_lik_), 1.0);
-      // Cache the ratio for ShouldRefit's "elbo" trigger. Stays stale between
-      // log blocks (every 10 iters past warmup, plus the first 5) — the
-      // trigger reads the most recent value, so refit fires on the next iter
-      // after a logged drop. Negative values (= improvements) leave the
-      // trigger off.
-      last_elbo_drop_ratio_ = drop / rel_scale;
-      if (drop > 0.05 * rel_scale) {
-        Log::Warning(
-            "MixtureGBDT: marginal_log_lik dropped %.6f → %.6f "
-            "(Δ=%.6f, %.1f%% of |prev|). Approximate M-step allows small "
-            "dips; persistent / large drops mean E-step and M-step are "
-            "optimizing inconsistent objectives. Suspect: high expert "
-            "dropout, mixture_adaptive_lr, aggressive temperature "
-            "annealing, or a recent code change to gradient/Hessian.",
-            prev_marginal_log_lik_, ll, -drop,
-            100.0 * drop / rel_scale);
-      }
+    // Push to sliding window, trim to mixture_elbo_window length.
+    const int W = std::max(2, config_->mixture_elbo_window);
+    elbo_history_.push_back(ll);
+    while (static_cast<int>(elbo_history_.size()) > W) {
+      elbo_history_.pop_front();
     }
-    prev_marginal_log_lik_ = ll;
+
+    if (iter_ % 10 == 0 || iter_ < 5) {
+      Log::Info("MixtureGBDT: iter=%d  marginal_log_lik=%.6f  (per_sample=%.6f)",
+                iter_, ll,
+                num_data_ > 0 ? ll / num_data_ : 0.0);
+
+      // Monotonicity warning. Approximate M-step → small dips are normal,
+      // but a drop bigger than 5% of |prev| is symptomatic of misalignment
+      // between E-step and M-step — historically this has been a sign of:
+      //   • bias-side regularizer fighting gate (pre PR #25)
+      //   • diversity sign flip (pre PR #26)
+      //   • dimension mismatch in scale estimation (pre quantile fix)
+      //   • aggressive expert dropout / adaptive_lr decoupling experts from EM
+      // This warning is independent of the v0.8 elbo trigger: the trigger
+      // catches the *plateau* failure mode that this warning misses, and
+      // this warning catches the *gross drop* that the trigger may also
+      // catch (with a tighter threshold) but which the user should debug
+      // regardless.
+      const bool prev_finite = std::isfinite(prev_marginal_log_lik_) &&
+                               prev_marginal_log_lik_ > -1e299;
+      if (prev_finite && std::isfinite(ll)) {
+        const double drop = prev_marginal_log_lik_ - ll;
+        const double rel_scale = std::max(std::fabs(prev_marginal_log_lik_), 1.0);
+        if (drop > 0.05 * rel_scale) {
+          Log::Warning(
+              "MixtureGBDT: marginal_log_lik dropped %.6f → %.6f "
+              "(Δ=%.6f, %.1f%% of |prev|). Approximate M-step allows small "
+              "dips; persistent / large drops mean E-step and M-step are "
+              "optimizing inconsistent objectives. Suspect: high expert "
+              "dropout, mixture_adaptive_lr, aggressive temperature "
+              "annealing, or a recent code change to gradient/Hessian.",
+              prev_marginal_log_lik_, ll, -drop,
+              100.0 * drop / rel_scale);
+        }
+      }
+      prev_marginal_log_lik_ = ll;
+    }
   }
 
   ++iter_;

--- a/src/boosting/mixture_gbdt.h
+++ b/src/boosting/mixture_gbdt.h
@@ -10,6 +10,7 @@
 #include <LightGBM/boosting.h>
 #include <LightGBM/objective_function.h>
 
+#include <deque>
 #include <memory>
 #include <random>
 #include <string>
@@ -297,15 +298,24 @@ class MixtureGBDT : public GBDTBase {
   void RefitExpertsAndGate();
 
   /*!
-   * \brief v0.7 leaf-refit trigger gate. Decides whether the current EM
-   *        round should run RefitExpertsAndGate. Always returns false
-   *        when `mixture_refit_leaves` is off; otherwise dispatches on
-   *        `mixture_refit_trigger`:
+   * \brief Leaf-refit trigger gate (v0.7) + partition re-grow trigger (v0.8).
+   *        Decides whether the current EM round should run RefitExpertsAndGate.
+   *        Always returns false when `mixture_refit_leaves` is off; otherwise
+   *        dispatches on `mixture_refit_trigger`:
    *
-   *   - "always": fires every post-warmup iter (highest cost, most faithful EM)
-   *   - "elbo":   fires when the most recent ELBO log showed a >5% drop —
-   *               cheap because ELBO is only computed every 10 iters and
-   *               this reads `last_elbo_drop_ratio_` set by that block
+   *   - "always":  fires every post-warmup iter (highest cost, most faithful EM)
+   *   - "elbo":    v0.8 sliding-window detector. Fires when EITHER
+   *                  • drop:    `(elbo_t - elbo_{t-W}) / max(|elbo_{t-W}|, 1) <
+   *                                -mixture_elbo_drop_threshold`
+   *                  • plateau: `(max(window) - min(window)) / max(|max|, 1) <
+   *                                mixture_elbo_plateau_threshold`
+   *                              AND `moe_iter > warmup_iters +
+   *                                              mixture_elbo_min_iter_for_plateau`
+   *                Reads `elbo_history_`, populated every post-warmup iter by
+   *                the per-iter ELBO compute in TrainOneIter (requires
+   *                `mixture_estimate_variance=true`). Replaces the v0.7
+   *                "5%-drop on every-10-iter logs" trigger that fired 0/6
+   *                datasets in the v0.7 acceptance bench (issue #41).
    *   - "every_n": fires every `mixture_refit_every_n` post-warmup iters
    */
   bool ShouldRefit() const;
@@ -400,13 +410,20 @@ class MixtureGBDT : public GBDTBase {
    */
   double prev_marginal_log_lik_ = -1e300;
 
-  /*! \brief Last seen ELBO drop ratio (positive = drop, negative = improvement),
-   *  normalized by `max(|prev_marginal_log_lik_|, 1.0)`. Updated by the
-   *  every-10-iter ELBO log block in TrainOneIter. Read by ShouldRefit() in
-   *  "elbo" trigger mode — refit fires when this exceeds 0.05.
-   *  Stays at 0.0 when `mixture_estimate_variance=false` (no ELBO computed).
+  /*! \brief Sliding window of recent ELBO values for the v0.8 "elbo" refit
+   *  trigger. Pushed every post-warmup iter (when `mixture_estimate_variance=true`),
+   *  trimmed to `mixture_elbo_window` length. Read by ShouldRefit() in "elbo"
+   *  trigger mode to detect either:
+   *    - drop:    `(elbo_t - elbo_{t-W}) / max(|elbo_{t-W}|, 1) < -mixture_elbo_drop_threshold`
+   *    - plateau: `(max(window) - min(window)) / max(|max|, 1) < mixture_elbo_plateau_threshold`
+   *               AND moe_iter > warmup_iters + mixture_elbo_min_iter_for_plateau
+   *  Stays empty when `mixture_estimate_variance=false` (no ELBO computed,
+   *  trigger never fires). Replaces the v0.7 `last_elbo_drop_ratio_` scalar:
+   *  the v0.7 trigger only saw a 5%-drop signal computed at the every-10-iter
+   *  log cadence, which empirically fired 0/6 datasets in v0.7 acceptance
+   *  because Optuna-tuned configs plateau without dropping. See issue #41.
    */
-  double last_elbo_drop_ratio_ = 0.0;
+  std::deque<double> elbo_history_;
 
   /*! \brief Gradients for mixture (N) */
   std::vector<score_t> gradients_;

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -346,6 +346,10 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "mixture_refit_l2_reg",
   "mixture_refit_trigger",
   "mixture_refit_every_n",
+  "mixture_elbo_drop_threshold",
+  "mixture_elbo_plateau_threshold",
+  "mixture_elbo_window",
+  "mixture_elbo_min_iter_for_plateau",
   "mixture_predict_output",
   "mixture_gate_max_depth",
   "mixture_gate_num_leaves",
@@ -774,6 +778,18 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
   GetInt(params, "mixture_refit_every_n", &mixture_refit_every_n);
   CHECK_GT(mixture_refit_every_n, 0);
 
+  GetDouble(params, "mixture_elbo_drop_threshold", &mixture_elbo_drop_threshold);
+  CHECK_GE(mixture_elbo_drop_threshold, 0.0);
+
+  GetDouble(params, "mixture_elbo_plateau_threshold", &mixture_elbo_plateau_threshold);
+  CHECK_GE(mixture_elbo_plateau_threshold, 0.0);
+
+  GetInt(params, "mixture_elbo_window", &mixture_elbo_window);
+  CHECK_GE(mixture_elbo_window, 2);
+
+  GetInt(params, "mixture_elbo_min_iter_for_plateau", &mixture_elbo_min_iter_for_plateau);
+  CHECK_GE(mixture_elbo_min_iter_for_plateau, 0);
+
   GetString(params, "mixture_predict_output", &mixture_predict_output);
 
   GetInt(params, "mixture_gate_max_depth", &mixture_gate_max_depth);
@@ -1012,6 +1028,10 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[mixture_refit_l2_reg: " << mixture_refit_l2_reg << "]\n";
   str_buf << "[mixture_refit_trigger: " << mixture_refit_trigger << "]\n";
   str_buf << "[mixture_refit_every_n: " << mixture_refit_every_n << "]\n";
+  str_buf << "[mixture_elbo_drop_threshold: " << mixture_elbo_drop_threshold << "]\n";
+  str_buf << "[mixture_elbo_plateau_threshold: " << mixture_elbo_plateau_threshold << "]\n";
+  str_buf << "[mixture_elbo_window: " << mixture_elbo_window << "]\n";
+  str_buf << "[mixture_elbo_min_iter_for_plateau: " << mixture_elbo_min_iter_for_plateau << "]\n";
   str_buf << "[mixture_predict_output: " << mixture_predict_output << "]\n";
   str_buf << "[mixture_gate_max_depth: " << mixture_gate_max_depth << "]\n";
   str_buf << "[mixture_gate_num_leaves: " << mixture_gate_num_leaves << "]\n";
@@ -1207,6 +1227,10 @@ const std::unordered_map<std::string, std::vector<std::string>>& Config::paramet
     {"mixture_refit_l2_reg", {}},
     {"mixture_refit_trigger", {}},
     {"mixture_refit_every_n", {}},
+    {"mixture_elbo_drop_threshold", {}},
+    {"mixture_elbo_plateau_threshold", {}},
+    {"mixture_elbo_window", {}},
+    {"mixture_elbo_min_iter_for_plateau", {}},
     {"mixture_predict_output", {}},
     {"mixture_gate_max_depth", {}},
     {"mixture_gate_num_leaves", {}},
@@ -1402,6 +1426,10 @@ const std::unordered_map<std::string, std::string>& Config::ParameterTypes() {
     {"mixture_refit_l2_reg", "double"},
     {"mixture_refit_trigger", "string"},
     {"mixture_refit_every_n", "int"},
+    {"mixture_elbo_drop_threshold", "double"},
+    {"mixture_elbo_plateau_threshold", "double"},
+    {"mixture_elbo_window", "int"},
+    {"mixture_elbo_min_iter_for_plateau", "int"},
     {"mixture_predict_output", "string"},
     {"mixture_gate_max_depth", "int"},
     {"mixture_gate_num_leaves", "int"},


### PR DESCRIPTION
First sub-PR for v0.8.0 (issue #41), work item **B**.

## Why

The v0.7 \`mixture_refit_trigger='elbo'\` mode fired **0/6 datasets** in the v0.7 acceptance bench (\`bench_results/v0_7_acceptance_FINAL.md\`) on Optuna-tuned configs. Diagnosis:

1. ELBO logged every 10 iters → trigger had up to 9-iter staleness
2. 5%-drop threshold misses the actual basin-lock-in failure mode: **healthy Optuna-tuned configs do not drop ELBO; they plateau** at a sub-optimal local fixed point (E-step output stops moving → M-step contributions vanish → ELBO flatlines without dropping).

So the v0.7 \`elbo\` trigger was a designed safety net that turned out to be a no-op exactly where it was meant to engage.

## What

Replaces \`last_elbo_drop_ratio_\` with \`elbo_history_\` — a per-iter sliding window. New trigger fires on EITHER:

- **drop**: \`(elbo_t - elbo_{t-W}) / max(|elbo_{t-W}|, 1) < -mixture_elbo_drop_threshold\`
- **plateau**: \`(max(window) - min(window)) / max(|max|, 1) < mixture_elbo_plateau_threshold\` AND \`moe_iter > warmup + min_iter_for_plateau\`

ELBO computed every post-warmup iter (was every 10). Cost ~5–10% wall-time overhead. Console log cadence unchanged.

### New parameters
| Param | Default | Replaces |
|---|---|---|
| \`mixture_elbo_drop_threshold\` | \`0.01\` | Hard-coded 0.05 (cost asymmetry favors sensitivity) |
| \`mixture_elbo_plateau_threshold\` | \`0.001\` | New (catches lock-in v0.7 missed) |
| \`mixture_elbo_window\` | \`10\` | New (sliding window size) |
| \`mixture_elbo_min_iter_for_plateau\` | \`20\` | New (warmup transient guard) |

### Backward compat
v0.7 drop-only behavior recoverable by \`mixture_elbo_drop_threshold=0.05\`, \`mixture_elbo_plateau_threshold=0\`. Per-iter ELBO compute is the only forced change.

## Verification

Synthetic two-regime, \`init=random\`, 60 rounds, K=2:
| config | valid RMSE |
|---|---|
| off baseline | 1.8996 |
| \`always\` (refit upper bound) | **1.0452** |
| \`elbo\` NEVER (drop=1, plat=0) | 1.8996 ✓ matches off |
| \`elbo\` ALWAYS (drop=1, plat=1e9, W=2) | **1.1095** ✓ approaches always |
| \`elbo\` default (drop=0.01, plat=0.001) | 1.8996 |

Mechanism is wired correctly:
- NEVER threshold combination → no fire (matches off)
- ALWAYS threshold combination → fires (approaches always)
- default does not fire on this trajectory because ELBO is genuinely improving each iter (~3–5% per 10 iters) — correct behavior, this trajectory is escape-in-progress, not basin-locked

Real evaluation of default thresholds on plateau-prone Optuna-tuned configs (vix / sp500 / hmm from the v0.7 acceptance bench) is follow-up work after work item A lands.

## Math summary

ELBO \`L(θ) = Σ_i log Σ_k π_k p(y_i|f_k, σ_k²)\` is monotone non-decreasing under exact-EM. GBDT-EM's M-step is approximate (one tree per round per expert), so small dips are normal — but a sustained plateau means EM has converged to a fixed point. If validation loss at that fixed point is bad, the model is in a bad basin and refit (or v0.8 work item A's partition re-grow) should fire.

The cost asymmetry is highly skewed: false fire = one extra refit pass; missed fire = permanent basin trap. Hence default thresholds are tightened from v0.7.

## Test plan
- [x] Compile + import smoke test
- [x] Backward-compat threshold behaves like v0.7-equivalent (matches off-baseline on em_refit_demo trajectory)
- [x] Mechanism verification: NEVER thresholds → no fire; ALWAYS thresholds → fires
- [ ] (Follow-up after A merges) Full v0.7 acceptance protocol re-run on 6 datasets, compare per-config + search-level
- [ ] (Follow-up) Measure plateau-fire frequency on tuned configs (target: > 0 fires on at least 2/6 datasets)

Refs: #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)