### PR TITLE
release: v0.8.1 — full-codebase audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,41 +172,88 @@ Bottom line: v0.7 and v0.8 features are **opt-in safety nets for bad-init recove
 
 ## When to use MoE
 
-MoE's gating mechanism wins on regime-structured data — but the **honest baseline is not single-model naive LightGBM, it's a K-way ensemble of LightGBMs** with the same total tree budget. Simply averaging K independent models with different seeds gives variance reduction "for free"; the question is whether MoE's learned routing beats that. The 6-row study below answers it: **MoE clearly wins on `synthetic` (−24.8 %), `vix` (−6.9 %), `hmm` (−1.6 %) — datasets where the regime is observable from `X` —, ties on the `sp500` rows, and *loses to the K-way ensemble on `fred_gdp`* (+3.2 %)**. On `fred_gdp` (~310 quarterly samples) the K-way capacity helps but gating does not — the regime is too noisy or the dataset too small for the gate to learn it, and uniform averaging extracts the available capacity better than learned routing. Compute trade-off: MoE costs **1.3–8.4 ×** naive single-model time, and **0.5–2.8 ×** naive-ensemble time. Net rule: try MoE when (a) you believe the regime is observable from your features and (b) your wall time has 5–10 × headroom over single-model LightGBM.
+MoE's gating mechanism wins on regime-structured data — but the **honest baseline is not single-model naive LightGBM, it's a K-way ensemble of LightGBMs** with the same total tree budget. Simply averaging K independent models with different seeds gives variance reduction "for free"; the question is whether MoE's learned routing beats that. The holdout-first study below answers it: **MoE clearly wins on `synthetic` (−18.4 % vs the ensemble) — the case where the regime is a deterministic function of `X` — and on `fred_gdp` (−3.5 %), where the holdout window contains a genuine regime shock (COVID quarters). It ties on `hmm` and the `sp500` rows, and loses on `vix` (+5.8 %).** Compute trade-off: MoE costs **3–10 ×** naive single-model time and **0.8–4 ×** naive-ensemble time per trial. Net rule: try MoE when (a) you believe the regime is observable from your features or your evaluation window contains regime shifts, and (b) your wall time has 5–10 × headroom over single-model LightGBM.
 
-## Benchmark — 500-trial study (naive vs naive-ensemble vs MoE, 5 datasets)
+## Benchmark — holdout-first study (naive vs naive-ensemble vs MoE)
 
-5-fold time-series CV, 500 Optuna trials per (variant × dataset), 5 datasets spanning synthetic-ideal → real macro/financial → controlled-latent (sp500 is included in two parallel feature configurations, so 6 rows). Numbers are **deterministic** — `--n-jobs 1` (the default since [PR #30](https://github.com/kyo219/LightGBM-MoE/pull/30)) makes Optuna's TPE sampler reproducible across runs and builds with the same seed, so build-to-build comparisons are not contaminated by parallel-worker scheduling noise (which historically had ±0.3 RMSE-std on synthetic). Full report: [`bench_results/study_500_report.md`](bench_results/study_500_report.md). Methodology and dataset-specific recommendations: [docs/moe/benchmark.md](docs/moe/benchmark.md).
+> **Methodology note (v0.8.1).** This table supersedes the pre-v0.8.1 benchmark, which had
+> four defects found in a methodology audit: (1) the headline was the *minimum CV score over
+> 500 Optuna trials* — the selection metric itself, a winner's-curse-biased estimate that
+> rewards larger search spaces; (2) early stopping validated on the scoring fold; (3) the
+> `vix` features leaked the full-sample mean (lookahead for a mean-reverting series — and a
+> regime proxy, precisely the signal a gate exploits); (4) `sp500`/`vix` targets were
+> misaligned by one step. All four are fixed; the old report remains at
+> [`bench_results/study_500_report.md`](bench_results/study_500_report.md) for archaeology.
+> Two headline results changed: **the old `vix` win (−6.9 %) is retracted** (it was an
+> artifact of the leak + selection bias), and **`fred_gdp` flipped from a loss to a win**
+> (the old protocol never evaluated the COVID-containing tail).
 
-The third variant — **`naive-ensemble`** — is a K-way (K ∈ {2, 3, 4}) seed-ensemble of standard LightGBMs that share hyperparameters but diverge per-member via the `seed` master-seed override. Same total tree budget as MoE (K × `num_boost_round`), same Optuna search space as `naive-lightgbm` plus K. It is the fair ablation for "is gating doing real work, or would any K-way ensemble suffice?" — see [PR #33](https://github.com/kyo219/LightGBM-MoE/pull/33).
+Protocol: the final 20 % of every series is a **chronological holdout never seen by Optuna**.
+Hyperparameters are selected by expanding-window time-series CV (5 folds, 1-step embargo,
+early stopping on the chronological tail of each training window — never on the scoring
+fold) over the first 80 %; the CV winner is retrained once and scored once on the holdout.
+300 Optuna trials per (variant × dataset × seed), 3 seeds (synthetic/hmm redraw data,
+TPE + models reseed), reported as holdout RMSE mean ± std. Deterministic per seed
+(`--n-jobs 1`); build provenance (git commit, lib sha256, dataset sha256s) is recorded in
+the output JSON. Full report: [`bench_results/meth2_v081/`](bench_results/meth2_v081/).
 
-| Dataset | Shape | naive best | ensemble best | MoE best | MoE vs naive | **MoE vs ensemble** *(the fair test)* |
+The third variant — **`naive-ensemble`** — is a K-way (K ∈ {2, 3, 4}) seed-ensemble of
+standard LightGBMs that share hyperparameters but diverge per-member via the `seed`
+master-seed override. Same total tree budget as MoE (K × `num_boost_round`), same Optuna
+search space as `naive-lightgbm` plus K. It is the fair ablation for "is gating doing real
+work, or would any K-way ensemble suffice?" — see [PR #33](https://github.com/kyo219/LightGBM-MoE/pull/33).
+
+### Regime datasets (holdout RMSE, mean ± std over 3 seeds)
+
+| Dataset | Shape | naive | ensemble | MoE | MoE vs naive | **MoE vs ensemble** *(the fair test)* |
 |---|---|---|---|---|---|---|
-| `synthetic` | 2000 × 5 | 5.0233 | 4.8899 | **3.6779** | −26.8 % | **−24.8 %** 🎯 |
-| `fred_gdp` | 311 × 12 | 0.9311 | **0.9094** | 0.9381 | +0.75 % | +3.2 % *(ensemble wins)* |
-| `sp500_basic` (13 feat) | 3761 × 13 | 0.01003 | 0.01002 | **0.01001** | −0.24 % | −0.12 % |
-| `sp500` (28 feat, enriched) | 3711 × 28 | 0.01002 | 0.01003 | 0.01002 | ±0.00 % | −0.06 % |
-| `vix` | 3762 × 13 | 2.8869 | 2.8724 | **2.6745** | −7.4 % | **−6.9 %** 🎯 |
-| `hmm` | 2000 × 5 | 2.1913 | 2.1818 | **2.1465** | −2.1 % | **−1.6 %** |
+| `synthetic` | 2000 × 5 | 4.812 ± 0.340 | 4.706 ± 0.372 | **3.842 ± 0.290** | −20.2 % | **−18.4 %** 🎯 |
+| `fred_gdp` | 311 × 12 | 1.528 ± 0.020 | 1.543 ± 0.007 | **1.489 ± 0.014** | −2.6 % | **−3.5 %** 🎯 |
+| `hmm` | 2000 × 5 | 2.218 ± 0.244 | 2.206 ± 0.242 | 2.210 ± 0.243 | −0.3 % | +0.2 % *(tie)* |
+| `vix` | 3762 × 13 | 1.794 ± 0.063 | **1.752 ± 0.044** | 1.854 ± 0.173 | +3.3 % | +5.8 % *(ensemble wins)* |
+| `sp500_basic` (13 feat) | 3761 × 13 | 0.01104 | 0.01104 | 0.01102 | −0.2 % | −0.1 % *(noise floor)* |
+| `sp500` (28 feat) | 3711 × 28 | 0.01105 | 0.01105 | 0.01108 | +0.3 % | +0.3 % *(noise floor)* |
 
-**Read the "MoE vs ensemble" column** — that's where the gating hypothesis is actually tested. MoE clearly beats the K-way average on the three datasets where the regime is structurally observable from features (synthetic, vix, hmm), is a wash on the irreducibly hard sp500 rows, and *loses* on the smallest-data fred_gdp where the gate cannot learn the regime reliably enough to beat uniform averaging.
+The pattern is sharper than the old report's: MoE wins where regime structure is
+**strong and observable** (`synthetic` — regime is a deterministic function of X) or where
+the **evaluation window itself contains a regime break** (`fred_gdp` holdout spans COVID).
+It ties where the regime is weakly observable (`hmm` — two noisy proxy columns) or the
+target is at the noise floor (`sp500`), and it loses on `vix` now that the
+regime-proxy leak is gone — the gate has nothing real to route on there.
 
-| Dataset | naive (s/fold) | ensemble (s/fold) | MoE (s/fold) | ensemble / naive | MoE / naive | MoE / ensemble |
-|---|---|---|---|---|---|---|
-| `synthetic` | 0.033 | 0.083 | 0.044 | 2.5 × | 1.3 × | **0.53 ×** |
-| `fred_gdp` | 0.003 | 0.017 | 0.020 | 5.5 × | 6.5 × | 1.2 × |
-| `sp500_basic` | 0.012 | 0.029 | 0.081 | 2.4 × | 6.7 × | 2.8 × |
-| `sp500` | 0.009 | 0.037 | 0.055 | 4.2 × | 6.2 × | 1.5 × |
-| `vix` | 0.010 | 0.035 | 0.062 | 3.4 × | 6.0 × | 1.8 × |
-| `hmm` | 0.005 | 0.023 | 0.045 | 4.3 × | 8.4 × | 2.0 × |
+### Non-regime control datasets (Grinsztajn et al. 2022 regression track)
 
-On `synthetic` MoE is actually **faster** than the naive-ensemble (0.53 ×) — when the regime is clearly identifiable, sparse routing means each expert sees only its share of samples and converges quickly; the ensemble has to fit all K members on full data. On harder datasets the ratio flips back.
+Four standard i.i.d. tabular regression datasets (OpenML: `houses` 537, `cpu_act` 197,
+`elevators` 216, `wine_quality` 287; numeric features, seeded shuffle, 10k-row cap). These
+have **no regime structure** — the control group: MoE should at best tie naive here, and a
+win would mean the "regime" story is confounded with generic extra capacity.
 
-> **The sp500 pair is a controlled feature-engineering ablation on the same raw series**: only the feature set changes between rows, identical CV / Optuna budget / seed. All three variants are essentially tied at ~0.01001 across both feature sets — the next-day-log-return objective appears to hit the irreducible noise floor under any architecture and any feature set we've tried.
+*(Control-group numbers are being generated by the in-flight study and land here in a
+follow-up commit; the regime-dataset conclusions above are final.)*
+
+### Compute cost (median train s/fold across trials, v0.8.1)
+
+| Dataset | naive | ensemble | MoE | MoE / naive | MoE / ensemble |
+|---|---|---|---|---|---|
+| `synthetic` | 0.110 | 0.321 | 0.327 | 3.0 × | 1.0 × |
+| `fred_gdp` | 0.014 | 0.031 | 0.133 | 9.5 × | 4.3 × |
+| `hmm` | 0.031 | 0.093 | 0.177 | 5.7 × | 1.9 × |
+| `vix` | 0.049 | 0.149 | 0.285 | 5.8 × | 1.9 × |
+| `sp500_basic` | 0.022 | 0.057 | 0.143 | 6.5 × | 2.5 × |
+| `sp500` | 0.023 | 0.133 | 0.103 | 4.5 × | 0.8 × |
+
+> **The sp500 pair is a controlled feature-engineering ablation on the same raw series**:
+> only the feature set changes between rows, identical CV / Optuna budget / seed. All three
+> variants are essentially tied at the noise floor under both feature sets — the
+> next-day-log-return objective appears irreducible under any architecture we've tried.
 
 ### Datasets
 
-Five datasets spanning the regime-switching applicability spectrum: one MoE-ideal synthetic, three real-world series (the canonical references in the regime-switching literature), and one HMM with known ground-truth labels for measuring regime recovery.
+Regime datasets span the regime-switching applicability spectrum: one MoE-ideal synthetic,
+three real-world series (canonical references in the regime-switching literature), and one
+HMM with known ground-truth labels. All time-series generators follow the audited
+alignment convention: **row t's features use information available at time t only; the
+target is the value at t + 1** (verified by `tests/python_package_test/test_benchmark_methodology.py`).
 
 #### `synthetic` — feature-driven regime, MoE-ideal case (2000 × 5)
 
@@ -225,14 +272,14 @@ Five datasets spanning the regime-switching applicability spectrum: one MoE-idea
 
 - **Source**: FRED series [`GDPC1`](https://fred.stlouisfed.org/series/GDPC1) — Real Gross Domestic Product, Chained 2017 Dollars, Quarterly, Seasonally Adjusted Annual Rate (BEA via FRED, no auth, CSV endpoint).
 - **Methodology cite**: Hamilton, J. D. (1989). *A New Approach to the Economic Analysis of Nonstationary Time Series and the Business Cycle.* **Econometrica** 57(2), 357-384. <https://www.jstor.org/stable/1912559>.
-- **Construction**: target is the quarterly growth rate `100·Δlog(GDP)`; features are 4 lags of growth (Hamilton's MS-AR(4)) plus engineered MA / volatility / regime-proxy features. The regime (expansion / recession) is genuinely latent — there is no oracle column. Generator: `generate_fred_gdp_data`.
+- **Construction**: target is the quarterly growth rate `100·Δlog(GDP)`; features are 4 lags of growth (Hamilton's MS-AR(4)) plus engineered MA / volatility / regime-proxy features. The regime (expansion / recession) is genuinely latent — there is no oracle column. The chronological holdout contains the COVID quarters, which is exactly where MoE's win comes from. Generator: `generate_fred_gdp_data`.
 
 #### `sp500_basic` & `sp500` — S&P 500 daily log returns, two feature sets
 
-The S&P 500 series is included in **two parallel configurations** to demonstrate how MoE's lift scales with how observable the regime is from features:
+The S&P 500 series is included in **two parallel configurations** to test how MoE's lift scales with feature richness:
 
-- **`sp500_basic`** (~3760 × 13): the minimal feature set — lagged returns at {1, 2, 3, 5, 10} plus the standard MA / rolling-vol / regime-proxy block (`generate_sp500_basic_data`).
-- **`sp500`** (~3710 × 28): a practitioner-grade feature set — multi-horizon lags {1, 2, 3, 5, 10, 20, 60}, cumulative momentum at {5, 20, 60}, realized volatility at {5, 20, 60} plus the short/long ratio, multi-window MAs and MA crossovers, RSI(14)/RSI(30), rolling skewness and kurtosis (20-day), Bollinger band z-score, drawdown from the 20- and 60-day rolling high, and fraction of positive returns over {5, 20} days (`generate_sp500_data`).
+- **`sp500_basic`** (~3760 × 13): minimal — lagged returns at {1, 2, 3, 5, 10} (lag-1 = today's return) plus the standard MA / rolling-vol / regime-proxy block (`generate_sp500_basic_data`).
+- **`sp500`** (~3710 × 28): practitioner-grade — multi-horizon lags, momentum, realized volatility + ratio, MA crossovers, RSI(14)/RSI(30), rolling skew/kurtosis, Bollinger z-score, drawdowns, positive-day fractions (`generate_sp500_data`).
 
 Common to both:
 
@@ -241,49 +288,57 @@ Common to both:
 - **Target**: next-day log return (deliberately hard predictive setup).
 - **Regime structure**: latent (low-vol vs high-vol periods).
 
-The empirical takeaway from the side-by-side: with the basic feature set the result is a true tie; with the enriched set MoE picks up a sub-percent edge *and* trains faster than naive. **As features make the regime more predictable, MoE's advantage grows** — consistent with the broader thesis that MoE wins scale with regime observability.
-
 #### `vix` — CBOE Volatility Index, daily level (~3760 × 13)
 
 - **Source**: Yahoo Finance, symbol [`^VIX`](https://finance.yahoo.com/quote/%5EVIX/history) (same date range as `sp500`).
 - **Index methodology**: [CBOE VIX](https://www.cboe.com/tradable_products/vix/).
-- **Construction**: target is next-day VIX level. Features: lagged VIX at lags {1, 2, 3, 5, 10} plus MA / rolling-volatility features. Same latent low-vol / high-vol regime structure as `sp500`, viewed through the implied-vol lens. Generator: `generate_vix_data`.
+- **Construction**: target is next-day VIX level. Features: lagged VIX at lags {1, 2, 3, 5, 10} plus MA / rolling-volatility features computed on a **causally demeaned** series (expanding past-only mean — the pre-v0.8.1 version demeaned with the full-sample mean, which leaked "above/below the all-time mean" into the features and inflated MoE's score; that win is retracted). Generator: `generate_vix_data`.
 
 #### `hmm` — 3-state Gaussian HMM with known regime labels (2000 × 5)
 
 - **Source**: internal generator in this repo (`generate_hmm_data`).
 - **Methodology cite**: Rabiner, L. R. (1989). *A Tutorial on Hidden Markov Models and Selected Applications in Speech Recognition.* **Proceedings of the IEEE** 77(2), 257-286. <https://www.cs.ubc.ca/~murphyk/Bayes/rabiner.pdf>.
-- **Construction**: hidden state evolves as a 3-state Markov chain with persistent (95 % diagonal) transitions; emissions are Gaussian with well-separated means `{−3, 0, +3}` and varying scales `{0.4, 0.7, 1.0}`. Two of the five feature columns carry a weak linear signal of the hidden state (so the gate has *some* observable hint, not a free lunch); the remaining three columns are pure noise. **Returns the ground-truth regime labels** — usable for measuring regime recovery, not just RMSE.
+- **Construction**: hidden state evolves as a 3-state Markov chain with persistent (95 % diagonal) transitions; emissions are Gaussian with well-separated means `{−3, 0, +3}` and varying scales `{0.4, 0.7, 1.0}`. Two of the five feature columns carry a weak linear signal of the hidden state; the rest are pure noise. **Returns ground-truth regime labels** — usable for measuring regime recovery, not just RMSE.
+
+#### Control datasets — `houses`, `cpu_act`, `elevators`, `wine_quality`
+
+- **Source**: OpenML v1 originals (data_ids 537 / 197 / 216 / 287), from the regression-on-numerical-features track of Grinsztajn, L., Oyallon, E., & Varoquaux, G. (2022). *Why do tree-based models still outperform deep learning on typical tabular data?* **NeurIPS Datasets & Benchmarks**.
+- **Preprocessing** (ours, documented): numeric columns only, NaN rows dropped, seeded shuffle, 10k-row cap (tabular-benchmark "medium-sized" convention). Rows carry no temporal meaning, so the chronological splits behave like random splits here.
 
 ### Caching
 
-Real-world fetches (FRED, yfinance) are cached under `examples/data_cache/` (gitignored). First run pulls from the network; subsequent runs are offline.
+Real-world fetches (FRED, yfinance, OpenML) are cached under `examples/data_cache/`
+(gitignored); sha256 checksums of every cache file are recorded in each study's output
+JSON, so any run can be tied to the exact bytes it saw. First run pulls from the network;
+subsequent runs are offline.
 
 ### Settings that won — search every knob
 
-In the deterministic 500-trial study, **no MoE knob was a universal winner**: the best `mixture_gate_type` is `gbdt` on 4 of 6 rows but `leaf_reuse` on `fred_gdp` and `vix`; the best `mixture_routing_mode` is split 3 / 3 between `token_choice` and `expert_choice`; the best `mixture_num_experts` is spread across {2, 3, 4}. The only knob that's **non-zero on every dataset** is `mixture_diversity_lambda` (range [0.07, 0.36] across the 6 winners), which validates that the diversity regularizer is doing real work — search it explicitly. Full per-dataset table in [docs/moe/benchmark.md](docs/moe/benchmark.md).
-
-| Parameter | Universal? | Notes |
-|---|---|---|
-| `mixture_gate_type` | **No** | `gbdt` wins on synthetic, sp500_basic, sp500, hmm; `leaf_reuse` wins on fred_gdp, vix. Search both. |
-| `mixture_routing_mode` | **No** | `token_choice` wins on synthetic, sp500, hmm; `expert_choice` wins on fred_gdp, sp500_basic, vix. Search both. |
-| `mixture_num_experts` | **No** | K=4 most common (3 / 6), but K=2 wins on synthetic and vix, K=3 on hmm. Search {2, 3, 4, 6}. |
-| `mixture_diversity_lambda` | search 0.05–0.4 | Always non-zero in the per-dataset best params after the [PR #26](https://github.com/kyo219/LightGBM-MoE/pull/26) sign / Hessian fix. Top-5 in fANOVA importance. |
-| `mixture_estimate_variance` | **leave at default `true`** | Default since [PR #24](https://github.com/kyo219/LightGBM-MoE/pull/24). Setting `false` re-enables the legacy fixed-`alpha` E-step temperature, which is y-scale dependent and emits a warning at Init. |
-
-Dataset-dependent knobs (`mixture_e_step_mode`, `mixture_init`, `mixture_r_smoothing`, `mixture_hard_m_step`, `extra_trees`, `learning_rate`) need per-problem search — see [docs/moe/benchmark.md](docs/moe/benchmark.md) for the full breakdown table.
+*(Being re-measured under the fixed protocol with the widened search space
+(`--moe-space wide`: `gmm_features`/`kmeans_features` inits, K ≤ 6, gate temperature
+annealing, entropy λ, expert dropout, load-balance α). The pre-v0.8.1 per-knob table was
+derived from the retracted methodology and is intentionally removed rather than repeated;
+results land here in a follow-up commit.)*
 
 ```bash
-# Reproduce the full headline study (~20 min on 12-core / 24-thread, 6 dataset rows;
-# default --n-jobs 1 makes the result deterministic across runs and builds — see PR #30)
-python examples/comparative_study.py --trials 500 --out bench_results/study_500.json
+# Full headline study (holdout protocol, 3 seeds; deterministic per seed)
+python examples/comparative_study.py --trials 300 --seeds 42,43,44 \
+    --out bench_results/study_holdout.json
 
-# Smoke test (~1 min, all 6 dataset rows; --n-jobs 2 trades reproducibility for speed)
-python examples/comparative_study.py --trials 10 --n-jobs 2 --out bench_results/smoke.json
+# Wide MoE search space (adds gmm_features/kmeans_features inits, K up to 6,
+# gate temperature annealing, entropy lambda, dropout, load-balance alpha)
+python examples/comparative_study.py --trials 500 --seeds 42,43,44 \
+    --variants naive-lightgbm,moe --moe-space wide \
+    --out bench_results/study_wide.json
 
-# Subset of datasets
-python examples/comparative_study.py --trials 500 \
-    --datasets sp500_basic,sp500 --out bench_results/sp500_ablation.json
+# Smoke test (~2 min)
+python examples/comparative_study.py --trials 10 --seeds 42 \
+    --datasets synthetic,fred_gdp --out bench_results/smoke.json
+
+# A/B two builds of the C++ core with the same protocol
+LGBM_MOE_PACKAGE_DIR=/path/to/other/python-package \
+    python examples/comparative_study.py --trials 300 --seeds 42,43,44 \
+    --out bench_results/study_other_build.json
 ```
 
 ## Documentation

--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -1508,16 +1508,6 @@ Mixture-of-Experts Parameters
 
    -  0 means no warmup (may cause expert collapse)
 
--  ``mixture_predict_output`` :raw-html:`<a id="mixture_predict_output" title="Permalink to this parameter" href="#mixture_predict_output">&#x1F517;&#xFE0E;</a>`, default = ``value``, type = enum, options: ``value``, ``value_and_regime``, ``all``
-
-   -  output mode for mixture prediction
-
-   -  ``value``: only output predicted value (yhat)
-
-   -  ``value_and_regime``: output value and argmax regime
-
-   -  ``all``: output value, regime probabilities, and expert predictions
-
 -  ``mixture_gate_max_depth`` :raw-html:`<a id="mixture_gate_max_depth" title="Permalink to this parameter" href="#mixture_gate_max_depth">&#x1F517;&#xFE0E;</a>`, default = ``3``, type = int, constraints: ``mixture_gate_max_depth > 0``
 
    -  max depth for gate GBDT (shallower than experts for regularization)

--- a/docs/moe/parameters.md
+++ b/docs/moe/parameters.md
@@ -71,14 +71,6 @@ The gate is a **multiclass classifier** (K classes = K experts). It uses shallow
 | `is_mixture()` | `bool` | Check if model is MoE |
 | `num_experts()` | `int` | K |
 
-**Prediction output mode** (`mixture_predict_output` parameter):
-
-| Mode | Output | Description |
-|------|--------|-------------|
-| `"value"` (default) | `ŷ` only | Standard prediction |
-| `"value_and_regime"` | `ŷ` + regime index | Prediction with argmax regime |
-| `"all"` | `ŷ` + regime probabilities + expert predictions | Full diagnostic output |
-
 ## Auto-applied Settings
 
 The library forces some settings to avoid known footguns:

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -670,6 +670,57 @@ def generate_vix_data(seed: int = 42, start: str = "2010-01-01", end: str = "202
     return X, y, None
 
 
+def generate_openml_control_data(name: str, data_id: int, seed: int = 42,
+                                 max_rows: int = 10000):
+    """Non-regime CONTROL dataset from the Grinsztajn et al. (2022) regression
+    track ("Why do tree-based models still outperform deep learning on typical
+    tabular data?", NeurIPS D&B). These are standard i.i.d. tabular regression
+    problems with NO regime structure — the control group for the MoE study:
+    on these, MoE should at best tie naive LightGBM ("does no harm").
+
+    - Source: OpenML, fetched by immutable `data_id` (v1 originals; the
+      Grinsztajn suite's cleaned re-uploads derive from these). Cached to
+      data_cache/openml_{name}.csv so provenance hashing covers them.
+    - Preprocessing (ours, documented rather than inherited): numeric columns
+      only, rows with NaN dropped, target = OpenML default target.
+    - Rows are SHUFFLED with `seed` and capped at `max_rows` (matching the
+      tabular-benchmark "medium-sized" 10k convention). These rows carry no
+      temporal meaning, so the study's chronological holdout / expanding CV
+      behave like random splits here — valid, just not time-ordered. The
+      per-seed shuffle also gives multi-seed runs genuine data variation.
+    """
+    import pandas as pd
+    cache = _CACHE_DIR / f"openml_{name}.csv"
+    if cache.exists():
+        df = pd.read_csv(cache)
+    else:
+        from sklearn.datasets import fetch_openml
+        bunch = fetch_openml(data_id=data_id, as_frame=True, parser="auto")
+        df = bunch.data.copy()
+        df["__target__"] = bunch.target
+        df.to_csv(cache, index=False)
+
+    target_col = "__target__"
+    y_raw = pd.to_numeric(df[target_col], errors="coerce")
+    X_df = df.drop(columns=[target_col]).select_dtypes(include=[np.number])
+    keep = (~y_raw.isna()) & (~X_df.isna().any(axis=1))
+    X_all = X_df[keep].to_numpy(dtype=np.float64)
+    y_all = y_raw[keep].to_numpy(dtype=np.float64)
+
+    rng = np.random.default_rng(seed)
+    order = rng.permutation(len(X_all))[:max_rows]
+    return X_all[order], y_all[order], None
+
+
+# Grinsztajn regression-track controls: (name, OpenML data_id).
+OPENML_CONTROL_DATASETS = {
+    "houses": 537,        # California housing, 20640 x 8
+    "cpu_act": 197,       # computer activity, 8192 x 21
+    "elevators": 216,     # aircraft control, 16599 x 18
+    "wine_quality": 287,  # red+white wine, 6497 x 11
+}
+
+
 def generate_hmm_data(n_samples: int = 2000, n_states: int = 3, n_features: int = 5, seed: int = 42):
     """K-state Gaussian-emission HMM with partially observable regime.
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -263,9 +263,11 @@ def generate_synthetic_data(n_samples: int = 2000, noise_level: float = 0.5, see
     Synthetic regime-switching data (regime determinable from X).
     MoEが得意とするケース：特徴量からregimeが決まる。
     """
-    np.random.seed(seed)
+    # Local generator: np.random.seed() mutated GLOBAL numpy state, silently
+    # coupling any downstream code that relies on the global RNG to this call.
+    rng = np.random.default_rng(seed)
     n_features = 5
-    X = np.random.randn(n_samples, n_features)
+    X = rng.standard_normal((n_samples, n_features))
 
     regime_score = 0.5 * X[:, 1] + 0.3 * X[:, 2] - 0.2 * X[:, 3]
     regime_true = (regime_score > 0).astype(int)
@@ -278,7 +280,7 @@ def generate_synthetic_data(n_samples: int = 2000, noise_level: float = 0.5, see
     mask1 = regime_true == 1
     y[mask1] = -5.0 * X[mask1, 0] - 2.0 * X[mask1, 1] ** 2 + 3.0 * np.cos(2 * X[mask1, 4]) - 10.0
 
-    y += np.random.randn(n_samples) * noise_level
+    y += rng.standard_normal(n_samples) * noise_level
 
     return X, y, regime_true
 
@@ -290,13 +292,13 @@ def generate_hamilton_gnp_data(n_samples: int = 500, seed: int = 42):
     Time-series features (lag, moving average, volatility) are added
     to make the latent regime partially observable from past y values.
     """
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     n_base_features = 4
-    X_base = np.random.randn(n_samples, n_base_features)
+    X_base = rng.standard_normal((n_samples, n_base_features))
 
     t = np.arange(n_samples)
     regime_prob = 0.5 + 0.3 * np.sin(2 * np.pi * t / 100)
-    regime_true = (np.random.rand(n_samples) < regime_prob).astype(int)
+    regime_true = (rng.random(n_samples) < regime_prob).astype(int)
 
     y = np.zeros(n_samples)
 
@@ -306,7 +308,7 @@ def generate_hamilton_gnp_data(n_samples: int = 500, seed: int = 42):
     mask1 = regime_true == 1
     y[mask1] = -0.5 + 0.1 * X_base[mask1, 0] - 0.3 * X_base[mask1, 2]
 
-    y += np.random.randn(n_samples) * 0.3
+    y += rng.standard_normal(n_samples) * 0.3
 
     # Add time-series features derived from y
     # Focus on regime-indicative statistics (level, volatility),
@@ -377,7 +379,9 @@ _CACHE_DIR.mkdir(exist_ok=True)
 def _add_ts_features(y_arr: np.ndarray, windows_ma=(5, 10, 20), windows_vol=(5, 10)) -> np.ndarray:
     """Build standard time-series features from a 1D series y_arr.
 
-    Returns an (N, F) feature matrix. All features are causal (use only past values).
+    Returns an (N, F) feature matrix. Row i uses ONLY y_arr[:i] — strictly
+    past values, exclusive of the current index. Callers that want "features
+    known at time t" must therefore read row t+1 (which sees y_arr[..t]).
     """
     n = len(y_arr)
     feats = []
@@ -477,15 +481,24 @@ def generate_sp500_basic_data(seed: int = 42, start: str = "2010-01-01", end: st
     px = close.to_numpy(dtype=np.float64)
     log_ret = np.diff(np.log(px))
 
+    # Alignment convention (audit fix): row t's features may use log_ret[..t]
+    # (everything known at the close of day t); the target is log_ret[t+1].
+    # The previous construction had an off-by-one — the most recent return a
+    # feature row saw was log_ret[t-1] while the target was log_ret[t+1], so
+    # the model was effectively predicting two steps ahead with the single
+    # most informative lag silently discarded (and the README claimed
+    # "next-day"). lag-1 now means "today's return", as documented.
     lag_set = (1, 2, 3, 5, 10)
     lag_max = max(lag_set)
-    n = len(log_ret) - lag_max - 1
-    if n <= 0:
+    t_idx = np.arange(lag_max - 1, len(log_ret) - 1)  # feature time t
+    if len(t_idx) <= 0:
         raise RuntimeError("S&P series too short after lag construction")
-    lags = np.column_stack([log_ret[lag_max - k: lag_max - k + n] for k in lag_set])
-    ts_feats = _add_ts_features(log_ret)[lag_max: lag_max + n]
+    lags = np.column_stack([log_ret[t_idx - (k - 1)] for k in lag_set])
+    # _add_ts_features row j sees log_ret[:j] (strictly past), so row t+1
+    # sees log_ret[..t] — exactly the info set of feature time t.
+    ts_feats = _add_ts_features(log_ret)[t_idx + 1]
     X = np.column_stack([lags, ts_feats])
-    y = log_ret[lag_max + 1: lag_max + 1 + n]
+    y = log_ret[t_idx + 1]
     return X, y, None
 
 
@@ -510,17 +523,25 @@ def generate_sp500_data(seed: int = 42, start: str = "2010-01-01", end: str = "2
 
     feats: list[np.ndarray] = []
 
-    # 1) Lagged returns
+    # Alignment convention (audit fix): feature row t may use log_ret[..t]
+    # (and prices through the close of day t); the target is log_ret[t+1].
+    # Return windows/lags previously EXCLUDED log_ret[t] (arr[i-w:i],
+    # log_ret[:-lag]) while the price-level features below already used the
+    # day-t close — one day staler than the information set allows, and
+    # inconsistent within the same feature row. All return-based features
+    # now include the current index: lag-1 = today's return.
+
+    # 1) Lagged returns (lag k = k-1 steps back from today, so lag-1 = today)
     for lag in (1, 2, 3, 5, 10, 20, 60):
         f = np.zeros(n_ret)
-        f[lag:] = log_ret[:-lag]
+        f[lag - 1:] = log_ret[:n_ret - lag + 1]
         feats.append(f)
 
-    # 2) Cumulative log return over window (momentum)
+    # 2) Cumulative log return over window (momentum), inclusive of today
     def _rolling_sum(arr, w):
         out = np.zeros_like(arr)
-        for i in range(w, len(arr)):
-            out[i] = arr[i - w:i].sum()
+        for i in range(w - 1, len(arr)):
+            out[i] = arr[i - w + 1:i + 1].sum()
         return out
 
     cum5 = _rolling_sum(log_ret, 5)
@@ -545,8 +566,8 @@ def generate_sp500_data(seed: int = 42, start: str = "2010-01-01", end: str = "2
     # 5) RSI(14) and RSI(30) — Wilder's, computed on returns
     def _rsi(arr, w):
         out = np.full(len(arr), 50.0)
-        for i in range(w, len(arr)):
-            window = arr[i - w:i]
+        for i in range(w - 1, len(arr)):
+            window = arr[i - w + 1:i + 1]
             gains = np.maximum(window, 0).sum()
             losses = -np.minimum(window, 0).sum()
             if losses == 0:
@@ -562,8 +583,8 @@ def generate_sp500_data(seed: int = 42, start: str = "2010-01-01", end: str = "2
     # 6) Rolling skewness / kurtosis (excess) over 20 days
     skew = np.zeros(n_ret)
     kurt = np.zeros(n_ret)
-    for i in range(20, n_ret):
-        w = log_ret[i - 20:i]
+    for i in range(19, n_ret):
+        w = log_ret[i - 19:i + 1]
         m = w.mean()
         s = w.std()
         if s > 0:
@@ -573,8 +594,8 @@ def generate_sp500_data(seed: int = 42, start: str = "2010-01-01", end: str = "2
 
     # 7) Bollinger band position (z-score of log price vs MA(20))
     bb = np.zeros(n_ret)
-    for i in range(20, n_ret):
-        w = log_px_ret[i - 20:i]
+    for i in range(19, n_ret):
+        w = log_px_ret[i - 19:i + 1]
         sd = w.std()
         if sd > 0:
             bb[i] = (log_px_ret[i] - w.mean()) / (2.0 * sd)
@@ -583,8 +604,8 @@ def generate_sp500_data(seed: int = 42, start: str = "2010-01-01", end: str = "2
     # 8) Drawdown from rolling high (log price)
     def _drawdown(arr, w):
         out = np.zeros_like(arr)
-        for i in range(w, len(arr)):
-            peak = arr[i - w:i].max()
+        for i in range(w - 1, len(arr)):
+            peak = arr[i - w + 1:i + 1].max()
             out[i] = arr[i] - peak  # <= 0
         return out
 
@@ -594,8 +615,8 @@ def generate_sp500_data(seed: int = 42, start: str = "2010-01-01", end: str = "2
     # 9) Fraction of positive returns over last w days
     def _frac_pos(arr, w):
         out = np.zeros_like(arr)
-        for i in range(w, len(arr)):
-            out[i] = float((arr[i - w:i] > 0).mean())
+        for i in range(w - 1, len(arr)):
+            out[i] = float((arr[i - w + 1:i + 1] > 0).mean())
         return out
 
     feats.append(_frac_pos(log_ret, 5))
@@ -624,15 +645,28 @@ def generate_vix_data(seed: int = 42, start: str = "2010-01-01", end: str = "202
     close = _yf_download_close("^VIX", start=start, end=end, cache_name="vix_VIX")
     vix = close.to_numpy(dtype=np.float64)
 
+    # Leakage fix (audit): this used to demean with `vix - vix.mean()` — the
+    # FULL-SAMPLE mean, which includes future data. The sign(MA) and
+    # frac-positive features then encoded "is the current level above the
+    # all-time mean", i.e. genuine lookahead for a mean-reverting series.
+    # Demean causally instead: centered[i] = vix[i] - mean(vix[:i])
+    # (expanding mean of strictly past values; centered[0] uses vix[0]).
+    expanding_mean = np.cumsum(vix) / np.arange(1, len(vix) + 1)
+    centered = vix.copy()
+    centered[1:] -= expanding_mean[:-1]
+    centered[0] = 0.0
+
+    # Same alignment convention as generate_sp500_basic_data (audit fix):
+    # row t's features use vix[..t]; target is vix[t+1]. lag-1 = today.
     lag_set = (1, 2, 3, 5, 10)
     lag_max = max(lag_set)
-    n = len(vix) - lag_max - 1
-    if n <= 0:
+    t_idx = np.arange(lag_max - 1, len(vix) - 1)
+    if len(t_idx) <= 0:
         raise RuntimeError("VIX series too short after lag construction")
-    lags = np.column_stack([vix[lag_max - k: lag_max - k + n] for k in lag_set])
-    ts_feats = _add_ts_features(vix - vix.mean())[lag_max: lag_max + n]
+    lags = np.column_stack([vix[t_idx - (k - 1)] for k in lag_set])
+    ts_feats = _add_ts_features(centered)[t_idx + 1]
     X = np.column_stack([lags, ts_feats])
-    y = vix[lag_max + 1: lag_max + 1 + n]
+    y = vix[t_idx + 1]
     return X, y, None
 
 

--- a/examples/comparative_study.py
+++ b/examples/comparative_study.py
@@ -114,6 +114,21 @@ ROUTING_CHOICES = ["token_choice", "expert_choice"]
 E_STEP_MODES = ["em", "loss_only", "gate_only"]
 SMOOTHING_CHOICES = ["none", "ema", "markov"]
 
+# "wide" search space (--moe-space wide). Differences vs standard:
+#   - mixture_init gains gmm_features / kmeans_features — the values the
+#     README Limitations section RECOMMENDS but the study never searched
+#     (found in the methodology audit).
+#   - K widened to 2–6 (README: "search 2-6 for your data").
+#   - Previously-frozen knobs enter the space: gate temperature annealing
+#     (T_init + final/init ratio — parameterized as a ratio so the Optuna
+#     value space stays static), Dirichlet shrinkage
+#     (mixture_gate_entropy_lambda), expert dropout (constant schedule), and
+#     the auxiliary load-balance penalty (mixture_load_balance_alpha).
+# Wide mode adds ~6 dimensions, so give it proportionally more trials —
+# search-space dilution is real (measured in the v0.8 500-trial study).
+WIDE_INIT_CHOICES = ["random", "gmm", "gmm_features", "kmeans_features",
+                     "tree_hierarchical", "uniform"]
+
 
 # =============================================================================
 # CV with per-trial timing
@@ -295,7 +310,8 @@ def make_naive_ensemble_objective(X, y, cfg: BenchmarkConfig, trial_log: list):
 
 
 def make_moe_objective(X, y, cfg: BenchmarkConfig, trial_log: list,
-                       refit_mode: str = "search", refit_decay: float = 0.0):
+                       refit_mode: str = "search", refit_decay: float = 0.0,
+                       space: str = "standard"):
     """Build an Optuna objective that trains MoE.
 
     `refit_mode` controls how the v0.7 / v0.8 refit + regrow machinery is
@@ -320,11 +336,15 @@ def make_moe_objective(X, y, cfg: BenchmarkConfig, trial_log: list,
     forced-on triggers; in "search" mode the decay is itself a search
     variable.
     """
+    wide = (space == "wide")
+    init_choices = WIDE_INIT_CHOICES if wide else INIT_CHOICES
+    k_max = 6 if wide else 4
+
     def objective(trial):
         smoothing = trial.suggest_categorical("mixture_r_smoothing", SMOOTHING_CHOICES)
         routing_mode = trial.suggest_categorical("mixture_routing_mode", ROUTING_CHOICES)
         gate_type = trial.suggest_categorical("mixture_gate_type", GATE_CHOICES)
-        num_experts = trial.suggest_int("mixture_num_experts", 2, 4)
+        num_experts = trial.suggest_int("mixture_num_experts", 2, k_max)
 
         params = {
             "objective": "regression",
@@ -342,7 +362,7 @@ def make_moe_objective(X, y, cfg: BenchmarkConfig, trial_log: list,
             "bagging_fraction": trial.suggest_float("bagging_fraction", 0.5, 1.0),
             "bagging_freq": trial.suggest_int("bagging_freq", 0, 7),
             "extra_trees": trial.suggest_categorical("extra_trees", [True, False]),
-            "mixture_init": trial.suggest_categorical("mixture_init", INIT_CHOICES),
+            "mixture_init": trial.suggest_categorical("mixture_init", init_choices),
             "mixture_num_experts": num_experts,
             # NOTE (audit fix): mixture_e_step_alpha used to be searched here
             # (0.1–3.0), but it is IGNORED whenever mixture_estimate_variance
@@ -363,12 +383,30 @@ def make_moe_objective(X, y, cfg: BenchmarkConfig, trial_log: list,
             "mixture_gate_type": gate_type,
         }
 
+        if wide:
+            # Previously frozen knobs (methodology audit follow-up).
+            params["mixture_expert_dropout_rate"] = trial.suggest_float(
+                "mixture_expert_dropout_rate", 0.0, 0.3)
+            params["mixture_load_balance_alpha"] = trial.suggest_float(
+                "mixture_load_balance_alpha", 0.0, 0.5)
+
         if gate_type in ("gbdt", "leaf_reuse"):
             params["mixture_gate_max_depth"] = trial.suggest_int("mixture_gate_max_depth", 2, 10)
             params["mixture_gate_num_leaves"] = trial.suggest_int("mixture_gate_num_leaves", 4, 64)
             params["mixture_gate_learning_rate"] = trial.suggest_float("mixture_gate_learning_rate", 0.01, 0.5, log=True)
             params["mixture_gate_lambda_l2"] = trial.suggest_float("mixture_gate_lambda_l2", 1e-3, 10.0, log=True)
             params["mixture_gate_iters_per_round"] = trial.suggest_int("mixture_gate_iters_per_round", 1, 3)
+            if wide:
+                # Dirichlet shrinkage toward uniform routing (anti-collapse).
+                params["mixture_gate_entropy_lambda"] = trial.suggest_float(
+                    "mixture_gate_entropy_lambda", 0.0, 0.3)
+                # Temperature annealing, parameterized as (T_init, final/init
+                # ratio) so the value space is static for TPE. ratio=1.0 means
+                # no annealing; T defaults to 1.0/1.0 in standard mode.
+                t_init = trial.suggest_float("mixture_gate_temperature_init", 0.5, 3.0)
+                t_ratio = trial.suggest_float("gate_temp_final_ratio", 0.2, 1.0)
+                params["mixture_gate_temperature_init"] = t_init
+                params["mixture_gate_temperature_final"] = t_init * t_ratio
         if gate_type == "leaf_reuse":
             params["mixture_gate_retrain_interval"] = trial.suggest_int("mixture_gate_retrain_interval", 5, 30)
 
@@ -894,7 +932,8 @@ def run_study(dataset_name: str, X_search, y_search, X_hold, y_hold,
         ("naive-ensemble", lambda log: make_naive_ensemble_objective(X, y, cfg, log)),
         (moe_variant_name, lambda log: make_moe_objective(X, y, cfg, log,
                                                           refit_mode=refit_mode,
-                                                          refit_decay=refit_decay)),
+                                                          refit_decay=refit_decay,
+                                                          space=getattr(cfg, "moe_space", "standard"))),
     ]
     selected_variants = getattr(cfg, "variants", None)
     if selected_variants:
@@ -1027,6 +1066,11 @@ def main():
                         "default 'search' = let Optuna pick (v0.8 study mode)")
     p.add_argument("--moe-refit-decay", type=float, default=0.0,
                    help="leaf blend factor (0=replace, 1=no-op); used when mode != off")
+    p.add_argument("--moe-space", choices=["standard", "wide"], default="standard",
+                   help="MoE search space. 'wide' adds gmm_features/kmeans_features "
+                        "inits, K up to 6, gate temperature annealing, entropy "
+                        "lambda, expert dropout, load-balance alpha (~6 extra "
+                        "dims — budget more trials)")
     p.add_argument("--variants", type=str, default=None,
                    help="comma-separated subset of {naive-lightgbm,naive-ensemble,moe}; "
                         "useful with --moe-refit-mode to skip naive baselines on ablation runs")
@@ -1046,7 +1090,7 @@ def main():
         "config": {"trials": args.trials, "n_jobs": args.n_jobs, "rounds": args.rounds,
                    "splits": args.splits, "seeds": seeds, "holdout_frac": args.holdout_frac,
                    "datasets": selected, "es_fraction": ES_FRACTION, "cv_gap": CV_GAP,
-                   "moe_refit_mode": args.moe_refit_mode},
+                   "moe_refit_mode": args.moe_refit_mode, "moe_space": args.moe_space},
         "provenance": collect_provenance(),
         "runs": {},
     }
@@ -1057,6 +1101,7 @@ def main():
                               num_boost_round=args.rounds)
         cfg.moe_refit_mode = args.moe_refit_mode
         cfg.moe_refit_decay = args.moe_refit_decay
+        cfg.moe_space = args.moe_space
         cfg.variants = [v.strip() for v in args.variants.split(",")] if args.variants else None
         for ds_name in selected:
             X, y, _ = DATASET_GENERATORS[ds_name](seed)

--- a/examples/comparative_study.py
+++ b/examples/comparative_study.py
@@ -50,8 +50,11 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import platform
+import subprocess
 import sys
 import time
 from collections import Counter
@@ -63,8 +66,23 @@ from scipy import stats
 from sklearn.metrics import mean_squared_error
 from sklearn.model_selection import TimeSeriesSplit
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python-package"))
+# Build override for A/B comparisons: LGBM_MOE_PACKAGE_DIR points at an
+# alternate python-package directory (e.g. a worktree build of an older
+# release). An editable install registers a meta-path finder that wins over
+# sys.path, so it must be disarmed for the override to take effect. The
+# resolved package path + lib sha256 are recorded in the output provenance.
+_PKG_DIR = os.environ.get("LGBM_MOE_PACKAGE_DIR")
+if _PKG_DIR:
+    sys.meta_path = [f for f in sys.meta_path
+                     if "editable" not in type(f).__module__.lower()]
+    sys.path.insert(0, _PKG_DIR)
+else:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python-package"))
 import lightgbm_moe as lgb
+
+if _PKG_DIR and not os.path.abspath(lgb.__file__).startswith(os.path.abspath(_PKG_DIR)):
+    raise SystemExit(f"LGBM_MOE_PACKAGE_DIR={_PKG_DIR} requested but lightgbm_moe "
+                     f"resolved to {lgb.__file__}")
 
 sys.path.insert(0, os.path.dirname(__file__))
 from benchmark import (  # noqa: E402
@@ -98,57 +116,91 @@ SMOOTHING_CHOICES = ["none", "ema", "markov"]
 # =============================================================================
 # CV with per-trial timing
 # =============================================================================
+# Audit fixes baked into the evaluation protocol:
+#
+#   1. Early stopping no longer validates on the scoring fold. The old code
+#      passed the fold's validation set to `early_stopping(50)` and then
+#      scored predictions on that same set — best_iteration was tuned
+#      per-fold on the evaluation data, optimistically biasing every fold
+#      score (and differentially favoring high-capacity variants). Each
+#      fold's training window now donates its chronological tail
+#      (ES_FRACTION) as the early-stopping set; the fold's validation
+#      window is only ever predicted once.
+#   2. TimeSeriesSplit(gap=1): with next-step targets, the last training
+#      row's label is the first thing the adjacent validation rows' lag
+#      features encode. A 1-step embargo removes that boundary reuse.
+#   3. Per-fold RMSEs and fold failure counts are returned so the study can
+#      report crash rates and run paired per-fold comparisons, instead of
+#      silently folding failures into an `inf` mean.
+ES_FRACTION = 0.15
+CV_GAP = 1
+
+
+def _es_tail_split(n_rows: int):
+    """Chronological (fit, early-stop) split of a training window."""
+    n_es = max(20, int(n_rows * ES_FRACTION))
+    n_es = min(n_es, n_rows // 2)  # degenerate-window guard
+    return n_rows - n_es
+
+
+def _train_with_es(params, Xt, yt, num_boost_round):
+    """Train with the ES set carved from the tail of the training window."""
+    cut = _es_tail_split(len(Xt))
+    train = lgb.Dataset(Xt[:cut], label=yt[:cut])
+    es_set = lgb.Dataset(Xt[cut:], label=yt[cut:], reference=train)
+    return lgb.train(
+        params,
+        train,
+        num_boost_round=num_boost_round,
+        valid_sets=[es_set],
+        callbacks=[lgb.early_stopping(stopping_rounds=50, verbose=False)],
+    )
+
+
 def evaluate_cv_timed(X, y, params, n_splits: int, num_boost_round: int):
-    """5-fold time-series CV. Returns (rmse_mean, mean_train_seconds_per_fold)."""
-    tscv = TimeSeriesSplit(n_splits=n_splits)
+    """Time-series CV (gap=1, ES on train tail).
+
+    Returns (rmse_mean, mean_train_seconds_per_fold, fold_rmses, n_failed_folds).
+    """
+    tscv = TimeSeriesSplit(n_splits=n_splits, gap=CV_GAP)
     rmses = []
     times = []
+    n_failed = 0
     for tr_idx, va_idx in tscv.split(X):
-        Xt, Xv = X[tr_idx], X[va_idx]
-        yt, yv = y[tr_idx], y[va_idx]
-        train = lgb.Dataset(Xt, label=yt)
-        valid = lgb.Dataset(Xv, label=yv, reference=train)
         try:
             t0 = time.perf_counter()
-            model = lgb.train(
-                params,
-                train,
-                num_boost_round=num_boost_round,
-                valid_sets=[valid],
-                callbacks=[lgb.early_stopping(stopping_rounds=50, verbose=False)],
-            )
+            model = _train_with_es(params, X[tr_idx], y[tr_idx], num_boost_round)
             t1 = time.perf_counter()
-            pred = model.predict(Xv)
-            rmse = float(np.sqrt(mean_squared_error(yv, pred)))
-            rmses.append(rmse)
+            pred = model.predict(X[va_idx])
+            rmses.append(float(np.sqrt(mean_squared_error(y[va_idx], pred))))
             times.append(t1 - t0)
         except Exception:
             rmses.append(float("inf"))
-            times.append(0.0)
-    return float(np.mean(rmses)), float(np.mean(times))
+            n_failed += 1
+    mean_time = float(np.mean(times)) if times else 0.0
+    return float(np.mean(rmses)), mean_time, rmses, n_failed
 
 
 def evaluate_ensemble_cv_timed(X, y, params, n_models: int, base_seed: int,
                                n_splits: int, num_boost_round: int):
-    """5-fold time-series CV with a K-way naive seed-ensemble of LightGBMs.
+    """Time-series CV with a K-way naive seed-ensemble of LightGBMs.
 
     Each ensemble member uses identical hyperparameters but a per-member seed
     offset, so bagging / feature-fraction / extra_trees randomness diverges
     across members. Predictions are averaged. Total tree budget per fold is
     `n_models * num_boost_round`, matching MoE's K * num_boost_round.
+    Same ES-tail / gap protocol as `evaluate_cv_timed`.
 
-    Returns (rmse_mean_over_folds, mean_total_train_seconds_per_fold).
+    Returns (rmse_mean, mean_total_train_seconds_per_fold, fold_rmses, n_failed_folds).
     """
-    tscv = TimeSeriesSplit(n_splits=n_splits)
+    tscv = TimeSeriesSplit(n_splits=n_splits, gap=CV_GAP)
     rmses = []
     times = []
+    n_failed = 0
     for tr_idx, va_idx in tscv.split(X):
-        Xt, Xv = X[tr_idx], X[va_idx]
-        yt, yv = y[tr_idx], y[va_idx]
         try:
             t0 = time.perf_counter()
             preds = np.zeros(len(va_idx), dtype=np.float64)
-            ok = True
             for k in range(n_models):
                 p = dict(params)
                 # `seed` is LightGBM's master seed and propagates to bagging /
@@ -156,27 +208,17 @@ def evaluate_ensemble_cv_timed(X, y, params, n_models: int, base_seed: int,
                 # per-member is the cleanest way to diverge member k from j.
                 p["seed"] = base_seed + 1009 * k  # arbitrary multiplier to
                                                   # avoid 1-step adjacency
-                train = lgb.Dataset(Xt, label=yt)
-                valid = lgb.Dataset(Xv, label=yv, reference=train)
-                model = lgb.train(
-                    p,
-                    train,
-                    num_boost_round=num_boost_round,
-                    valid_sets=[valid],
-                    callbacks=[lgb.early_stopping(stopping_rounds=50, verbose=False)],
-                )
-                preds += model.predict(Xv)
+                model = _train_with_es(p, X[tr_idx], y[tr_idx], num_boost_round)
+                preds += model.predict(X[va_idx])
             t1 = time.perf_counter()
-            if not ok:
-                raise RuntimeError("ensemble member failed")
             preds /= n_models
-            rmse = float(np.sqrt(mean_squared_error(yv, preds)))
-            rmses.append(rmse)
+            rmses.append(float(np.sqrt(mean_squared_error(y[va_idx], preds))))
             times.append(t1 - t0)
         except Exception:
             rmses.append(float("inf"))
-            times.append(0.0)
-    return float(np.mean(rmses)), float(np.mean(times))
+            n_failed += 1
+    mean_time = float(np.mean(times)) if times else 0.0
+    return float(np.mean(rmses)), mean_time, rmses, n_failed
 
 
 # =============================================================================
@@ -201,8 +243,12 @@ def make_naive_lightgbm_objective(X, y, cfg: BenchmarkConfig, trial_log: list):
             "bagging_freq": trial.suggest_int("bagging_freq", 0, 7),
             "extra_trees": trial.suggest_categorical("extra_trees", [True, False]),
         }
-        rmse, train_s = evaluate_cv_timed(X, y, params, cfg.n_splits, cfg.num_boost_round)
-        trial_log.append({"variant": "naive-lightgbm", "rmse": rmse, "train_s": train_s, "params": dict(trial.params)})
+        rmse, train_s, fold_rmses, n_failed = evaluate_cv_timed(
+            X, y, params, cfg.n_splits, cfg.num_boost_round)
+        trial_log.append({"variant": "naive-lightgbm", "rmse": rmse, "train_s": train_s,
+                          "fold_rmses": fold_rmses, "n_failed_folds": n_failed,
+                          "params": dict(trial.params),
+                          "lgbm_params": dict(params)})
         return rmse
 
     return objective
@@ -235,9 +281,12 @@ def make_naive_ensemble_objective(X, y, cfg: BenchmarkConfig, trial_log: list):
             "bagging_freq": trial.suggest_int("bagging_freq", 0, 7),
             "extra_trees": trial.suggest_categorical("extra_trees", [True, False]),
         }
-        rmse, train_s = evaluate_ensemble_cv_timed(
+        rmse, train_s, fold_rmses, n_failed = evaluate_ensemble_cv_timed(
             X, y, params, n_models, cfg.seed, cfg.n_splits, cfg.num_boost_round)
-        trial_log.append({"variant": "naive-ensemble", "rmse": rmse, "train_s": train_s, "params": dict(trial.params)})
+        trial_log.append({"variant": "naive-ensemble", "rmse": rmse, "train_s": train_s,
+                          "fold_rmses": fold_rmses, "n_failed_folds": n_failed,
+                          "params": dict(trial.params),
+                          "lgbm_params": dict(params), "n_models": n_models})
         return rmse
 
     return objective
@@ -293,7 +342,12 @@ def make_moe_objective(X, y, cfg: BenchmarkConfig, trial_log: list,
             "extra_trees": trial.suggest_categorical("extra_trees", [True, False]),
             "mixture_init": trial.suggest_categorical("mixture_init", INIT_CHOICES),
             "mixture_num_experts": num_experts,
-            "mixture_e_step_alpha": trial.suggest_float("mixture_e_step_alpha", 0.1, 3.0),
+            # NOTE (audit fix): mixture_e_step_alpha used to be searched here
+            # (0.1–3.0), but it is IGNORED whenever mixture_estimate_variance
+            # is true — which is the default and was never in the search
+            # space. Every trial therefore carried a dead dimension that
+            # wasted TPE budget and produced meaningless fANOVA / quartile
+            # rows for `mixture_e_step_alpha` in past reports.
             "mixture_e_step_mode": trial.suggest_categorical("mixture_e_step_mode", E_STEP_MODES),
             "mixture_warmup_iters": trial.suggest_int("mixture_warmup_iters", 5, 50),
             "mixture_balance_factor": trial.suggest_int("mixture_balance_factor", 2, 10),
@@ -380,8 +434,12 @@ def make_moe_objective(X, y, cfg: BenchmarkConfig, trial_log: list,
             params["mixture_refit_trigger"] = refit_mode
             params["mixture_refit_decay_rate"] = refit_decay
 
-        rmse, train_s = evaluate_cv_timed(X, y, params, cfg.n_splits, cfg.num_boost_round)
-        trial_log.append({"variant": "moe", "rmse": rmse, "train_s": train_s, "params": dict(trial.params)})
+        rmse, train_s, fold_rmses, n_failed = evaluate_cv_timed(
+            X, y, params, cfg.n_splits, cfg.num_boost_round)
+        trial_log.append({"variant": "moe", "rmse": rmse, "train_s": train_s,
+                          "fold_rmses": fold_rmses, "n_failed_folds": n_failed,
+                          "params": dict(trial.params),
+                          "lgbm_params": dict(params)})
         return rmse
 
     return objective
@@ -526,7 +584,7 @@ def aggregate_variant(name: str, trials: list[dict], study) -> dict:
     out["categorical_stats"] = {p: categorical_value_stats(trials, p) for p in cat_params}
 
     num_params = (
-        ["mixture_num_experts", "mixture_e_step_alpha", "mixture_diversity_lambda",
+        ["mixture_num_experts", "mixture_diversity_lambda",
          "mixture_warmup_iters", "mixture_balance_factor", "learning_rate",
          "num_leaves", "max_depth", "min_data_in_leaf"]
         if name == "moe"
@@ -545,39 +603,72 @@ def render_markdown(results: dict, out_path: str, slice_paths: dict):
     lines = []
     lines.append("# Comparative Study Report — naive vs naive-ensemble vs MoE\n")
     cfg = results.get("config", {})
-    lines.append(f"- **Trials per (variant × dataset)**: {cfg.get('trials')}\n")
-    lines.append(f"- **Datasets**: {cfg.get('datasets')}\n")
-    lines.append(f"- **n_splits**: {cfg.get('splits')}, **rounds**: {cfg.get('rounds')}\n")
+    lines.append(f"- **Trials per (variant × dataset × seed)**: {cfg.get('trials')}\n")
+    lines.append(f"- **Datasets**: {cfg.get('datasets')}, **seeds**: {cfg.get('seeds')}\n")
+    lines.append(f"- **n_splits**: {cfg.get('splits')} (gap={cfg.get('cv_gap')}), "
+                 f"**rounds**: {cfg.get('rounds')}, "
+                 f"**holdout**: final {cfg.get('holdout_frac', 0):.0%} (never seen by Optuna), "
+                 f"**ES**: chronological tail {cfg.get('es_fraction', 0):.0%} of each train window\n")
+    prov = results.get("provenance", {})
+    if prov:
+        lines.append(f"- **Build**: commit `{prov.get('git_commit', '?')[:12]}`"
+                     f"{' (dirty)' if prov.get('git_dirty') else ''}, "
+                     f"lib sha256 `{prov.get('lib_sha256', '?')[:12]}…`, "
+                     f"package `{prov.get('lightgbm_moe_package', '?')}`\n")
     lines.append("\n---\n")
 
-    # Headline table
-    lines.append("## Headline: which variant wins?\n")
-    lines.append("| Dataset | Variant | best RMSE | median RMSE | median train s/fold | wall s |")
+    # Headline: holdout metric (mean ± std across seeds)
+    lines.append("## Headline: holdout RMSE (chronological tail, evaluated once per seed)\n")
+    lines.append("Selection happened on CV inside the search region; this table is the "
+                 "unbiased comparison. `cv_best` is the (optimistic) selection metric, "
+                 "shown for reference.\n")
+    lines.append("| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |")
     lines.append("|---|---|---|---|---|---|")
-    for ds_name, ds in results.items():
-        if not isinstance(ds, dict) or "naive-lightgbm" not in ds:
-            continue
-        for v in ("naive-lightgbm", "naive-ensemble", "moe"):
+    for ds_name, variants in results.get("summary", {}).items():
+        for v, e in variants.items():
+            per_seed = e.get("per_seed", {})
+            crash = np.mean([s.get("crash_rate", 0) for s in per_seed.values()]) if per_seed else 0
+            retrain = np.mean([s.get("retrain_s") or 0 for s in per_seed.values()]) if per_seed else 0
+            hm = e.get("holdout_mean")
+            hs = e.get("holdout_std", 0)
+            hm_str = f"**{hm:.5f}** ± {hs:.5f}" if hm is not None else "—"
+            cb = e.get("cv_best_mean")
+            cb_str = f"{cb:.5f}" if cb is not None else "—"
+            lines.append(f"| {ds_name} | {v} | {hm_str} | {cb_str} | "
+                         f"{crash:.1%} | {retrain:.2f} |")
+    lines.append("\n")
+
+    # Secondary: CV selection-metric table per run
+    lines.append("## Selection metric per run (CV over the search region)\n")
+    lines.append("| Run | Variant | cv best | cv median | median train s/fold | wall s |")
+    lines.append("|---|---|---|---|---|---|")
+    for run_tag, ds in results.get("runs", {}).items():
+        for v in ds.get("_variants", []):
             r = ds.get(v, {})
             lines.append(
-                f"| {ds_name} | {v} | {r.get('rmse_best', float('nan')):.4f} "
+                f"| {run_tag} | {v} | {r.get('rmse_best', float('nan')):.4f} "
                 f"| {r.get('rmse_median', float('nan')):.4f} "
                 f"| {r.get('train_s_median', 0):.3f} | {r.get('wall_s', 0):.0f} |"
             )
     lines.append("\n")
 
-    # Per-dataset detail
-    for ds_name, ds in results.items():
-        if not isinstance(ds, dict) or "naive-lightgbm" not in ds:
-            continue
-        lines.append(f"\n---\n\n## {ds_name}  (X={ds.get('X_shape')})\n")
+    # Per-run detail
+    for run_tag, ds in results.get("runs", {}).items():
+        ds_name = run_tag
+        lines.append(f"\n---\n\n## {run_tag}  (search X={ds.get('X_search_shape')}, "
+                     f"holdout n={ds.get('n_holdout')})\n")
 
-        for v in ("naive-lightgbm", "naive-ensemble", "moe"):
+        for v in ds.get("_variants", []):
             r = ds.get(v, {})
             if not r:
                 continue
             lines.append(f"\n### {v}\n")
-            lines.append(f"- best RMSE: **{r.get('rmse_best', float('nan')):.4f}**, "
+            hold = r.get("holdout", {})
+            if hold:
+                lines.append(f"- **holdout RMSE: {hold.get('holdout_rmse', float('nan')):.5f}** "
+                             f"(winner retrained in {hold.get('retrain_s', 0):.2f}s, "
+                             f"cv score of winner: {hold.get('cv_rmse_of_winner', float('nan')):.4f})")
+            lines.append(f"- cv best RMSE: {r.get('rmse_best', float('nan')):.4f}, "
                          f"median: {r.get('rmse_median', float('nan')):.4f}, "
                          f"p10: {r.get('rmse_p10', float('nan')):.4f}")
             lines.append(f"- train: median {r.get('train_s_median', 0):.3f}s/fold, "
@@ -639,21 +730,22 @@ def render_markdown(results: dict, out_path: str, slice_paths: dict):
                     lines.append(f"| `{p}` | {cells[0]} | {cells[1]} | {cells[2]} | {cells[3]} | **{best_q}** {rng_str} |")
 
             # E. Slice plot reference
-            sp = slice_paths.get(f"{ds_name}/{v}")
+            sp = slice_paths.get(f"{run_tag}/{v}")
             if sp:
                 lines.append(f"\n#### E. Slice plot\n")
-                lines.append(f"![{ds_name}/{v}]({os.path.basename(sp)})\n")
+                lines.append(f"![{run_tag}/{v}]({os.path.basename(sp)})\n")
 
     # Overall recommendations summary
     lines.append("\n---\n\n## Overall recommendations\n")
     moe_recs = []
-    for ds_name, ds in results.items():
-        if not isinstance(ds, dict) or "moe" not in ds:
-            continue
-        cat = ds["moe"].get("categorical_stats", {})
-        for p, info in cat.items():
-            if info.get("best") and info["best"].get("significant"):
-                moe_recs.append((ds_name, p, info["best"]["value"], info["best"]["delta_mean"], info["best"]["p_value"]))
+    for run_tag, ds in results.get("runs", {}).items():
+        moe_keys = [v for v in ds.get("_variants", []) if v.startswith("moe")]
+        for mk in moe_keys:
+            cat = ds.get(mk, {}).get("categorical_stats", {})
+            for p, info in cat.items():
+                if info.get("best") and info["best"].get("significant"):
+                    moe_recs.append((run_tag, p, info["best"]["value"],
+                                     info["best"]["delta_mean"], info["best"]["p_value"]))
     if moe_recs:
         lines.append("**Categorical settings that are statistically significant winners (p<0.01):**\n")
         lines.append("| dataset | param | best value | Δ vs runner-up | p |")
@@ -669,15 +761,118 @@ def render_markdown(results: dict, out_path: str, slice_paths: dict):
 
 
 # =============================================================================
+# Holdout evaluation (audit fix — the selection metric is not the headline)
+# =============================================================================
+# The old protocol reported "best RMSE" = the minimum over N Optuna trials of
+# the SAME CV score the optimizer minimized. That is a selection metric, not
+# a performance estimate: comparing minima across variants with differently
+# sized / differently noisy search spaces rewards whichever space buys more
+# lottery tickets (winner's curse). The headline metric is now a
+# chronological holdout — the final `holdout_frac` of every series is never
+# seen by Optuna; after the search, the best-CV config is retrained once on
+# the search region (with the same ES-tail protocol) and scored once on the
+# holdout.
+
+
+def chronological_split(X, y, holdout_frac: float):
+    n_hold = int(len(X) * holdout_frac)
+    if n_hold < 10:
+        raise SystemExit(f"holdout too small ({n_hold} rows) — reduce --holdout-frac")
+    cut = len(X) - n_hold
+    return X[:cut], y[:cut], X[cut:], y[cut:]
+
+
+def best_finite_trial(trial_log: list) -> dict | None:
+    finite = [t for t in trial_log if np.isfinite(t["rmse"])]
+    return min(finite, key=lambda t: t["rmse"]) if finite else None
+
+
+def holdout_eval(best: dict, X_search, y_search, X_hold, y_hold, cfg) -> dict:
+    """Retrain the winning config on the full search region, score the holdout once."""
+    try:
+        t0 = time.perf_counter()
+        if best["variant"] == "naive-ensemble":
+            preds = np.zeros(len(X_hold), dtype=np.float64)
+            for k in range(best["n_models"]):
+                p = dict(best["lgbm_params"])
+                p["seed"] = cfg.seed + 1009 * k
+                model = _train_with_es(p, X_search, y_search, cfg.num_boost_round)
+                preds += model.predict(X_hold)
+            preds /= best["n_models"]
+            t1 = time.perf_counter()
+            pred_s = 0.0  # ensemble latency folded into retrain timing
+        else:
+            model = _train_with_es(dict(best["lgbm_params"]), X_search, y_search,
+                                   cfg.num_boost_round)
+            t1 = time.perf_counter()
+            preds = model.predict(X_hold)
+            pred_s = time.perf_counter() - t1
+        return {
+            "holdout_rmse": float(np.sqrt(mean_squared_error(y_hold, preds))),
+            "retrain_s": round(t1 - t0, 4),
+            "predict_s": round(pred_s, 4),
+            "cv_rmse_of_winner": best["rmse"],
+        }
+    except Exception as e:
+        return {"holdout_rmse": float("nan"), "error": str(e)[:200]}
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def collect_provenance() -> dict:
+    """Everything needed to reproduce / attribute a run: build, code, data."""
+    prov = {
+        "python": sys.version.split()[0],
+        "numpy": np.__version__,
+        "optuna": optuna.__version__,
+        "platform": platform.platform(),
+        "lightgbm_moe_package": os.path.dirname(os.path.abspath(lgb.__file__)),
+    }
+    lib_path = os.path.join(os.path.dirname(os.path.abspath(lgb.__file__)),
+                            "lib", "lib_lightgbm.so")
+    if os.path.exists(lib_path):
+        prov["lib_sha256"] = _sha256(lib_path)
+    try:
+        prov["git_commit"] = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=os.path.dirname(os.path.abspath(__file__)), text=True).strip()
+        prov["git_dirty"] = bool(subprocess.check_output(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            cwd=os.path.dirname(os.path.abspath(__file__)), text=True).strip())
+    except Exception:
+        pass
+    cache_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data_cache")
+    if os.path.isdir(cache_dir):
+        prov["data_cache"] = {
+            f: {"sha256": _sha256(os.path.join(cache_dir, f)),
+                "bytes": os.path.getsize(os.path.join(cache_dir, f))}
+            for f in sorted(os.listdir(cache_dir)) if f.endswith(".csv")
+        }
+    return prov
+
+
+# =============================================================================
 # Driver
 # =============================================================================
-def run_study(dataset_name: str, X, y, n_trials: int, n_jobs: int, cfg: BenchmarkConfig, slice_dir: str) -> tuple[dict, dict]:
+def run_study(dataset_name: str, X_search, y_search, X_hold, y_hold,
+              n_trials: int, n_jobs: int, cfg: BenchmarkConfig, slice_dir: str,
+              run_tag: str) -> tuple[dict, dict]:
     print(f"\n{'=' * 60}")
-    print(f"  Dataset: {dataset_name}  X={X.shape}  trials={n_trials}  n_jobs={n_jobs}")
+    print(f"  Run: {run_tag}  search={X_search.shape}  holdout={len(X_hold)}  "
+          f"trials={n_trials}  n_jobs={n_jobs}")
     print(f"{'=' * 60}")
 
-    out = {"dataset": dataset_name, "X_shape": list(X.shape), "y_stats": {"mean": float(y.mean()), "std": float(y.std())}}
+    out = {"dataset": dataset_name, "seed": cfg.seed,
+           "X_search_shape": list(X_search.shape), "n_holdout": int(len(X_hold)),
+           "y_stats": {"mean": float(y_search.mean()), "std": float(y_search.std())}}
     slice_paths: dict = {}
+    X, y = X_search, y_search  # Optuna objectives close over the search region only
 
     # When refit ablation is requested, the moe variant is renamed to "moe-refit"
     # so two runs (--moe-refit-mode off vs --moe-refit-mode <other>) produce
@@ -704,6 +899,7 @@ def run_study(dataset_name: str, X, y, n_trials: int, n_jobs: int, cfg: Benchmar
         # Match by prefix so "moe" selects "moe-refit-elbo" too.
         all_variants = [v for v in all_variants
                          if any(v[0] == s or v[0].startswith(s + "-") for s in selected_variants)]
+    out["_variants"] = [v[0] for v in all_variants]
     for variant, make_obj in all_variants:
         print(f"\n  → {variant} ({n_trials} trials)...")
         trial_log: list = []
@@ -715,16 +911,23 @@ def run_study(dataset_name: str, X, y, n_trials: int, n_jobs: int, cfg: Benchmar
 
         agg = aggregate_variant(variant, trial_log, study)
         agg["wall_s"] = round(wall, 1)
+
+        # Holdout: retrain the CV winner once, score the untouched tail once.
+        best = best_finite_trial(trial_log)
+        if best is not None:
+            agg["holdout"] = holdout_eval(best, X_search, y_search, X_hold, y_hold, cfg)
         out[variant] = agg
         out[f"{variant}_trials"] = trial_log
 
         # Slice plot
-        sp_path = os.path.join(slice_dir, f"slice_{dataset_name}_{variant}.png")
-        if make_slice_plot(study, sp_path, f"{dataset_name} / {variant}"):
-            slice_paths[f"{dataset_name}/{variant}"] = sp_path
+        sp_path = os.path.join(slice_dir, f"slice_{run_tag}_{variant}.png")
+        if make_slice_plot(study, sp_path, f"{run_tag} / {variant}"):
+            slice_paths[f"{run_tag}/{variant}"] = sp_path
 
-        print(f"    best RMSE = {agg.get('rmse_best', float('nan')):.4f}, "
-              f"median train = {agg.get('train_s_median', 0):.3f}s/fold, "
+        hold = agg.get("holdout", {})
+        print(f"    cv-best RMSE = {agg.get('rmse_best', float('nan')):.4f}, "
+              f"holdout RMSE = {hold.get('holdout_rmse', float('nan')):.4f}, "
+              f"crash rate = {1 - agg.get('n_finite', 0) / max(1, agg.get('n_trials', 1)):.1%}, "
               f"wall = {wall:.0f}s")
 
     return out, slice_paths
@@ -740,6 +943,39 @@ DATASET_GENERATORS = {
 }
 
 
+def summarize_across_seeds(results: dict) -> dict:
+    """Cross-seed summary: per (dataset, variant), holdout RMSE mean ± std.
+
+    The holdout number is the headline; cv_best is retained as the selection
+    metric for reference. With a single seed the std fields are 0 and should
+    be read as "no variance estimate", not "no variance".
+    """
+    summary: dict = {}
+    for run_tag, run in results.get("runs", {}).items():
+        ds = run["dataset"]
+        for v in run.get("_variants", []):
+            agg = run.get(v, {})
+            hold = agg.get("holdout", {})
+            entry = summary.setdefault(ds, {}).setdefault(v, {"per_seed": {}})
+            entry["per_seed"][str(run["seed"])] = {
+                "holdout_rmse": hold.get("holdout_rmse"),
+                "cv_best": agg.get("rmse_best"),
+                "crash_rate": round(1 - agg.get("n_finite", 0) / max(1, agg.get("n_trials", 1)), 4),
+                "retrain_s": hold.get("retrain_s"),
+            }
+    for ds, variants in summary.items():
+        for v, entry in variants.items():
+            hs = [s["holdout_rmse"] for s in entry["per_seed"].values()
+                  if s["holdout_rmse"] is not None and np.isfinite(s["holdout_rmse"])]
+            cs = [s["cv_best"] for s in entry["per_seed"].values() if s["cv_best"] is not None]
+            if hs:
+                entry["holdout_mean"] = round(float(np.mean(hs)), 6)
+                entry["holdout_std"] = round(float(np.std(hs)), 6)
+            if cs:
+                entry["cv_best_mean"] = round(float(np.mean(cs)), 6)
+    return summary
+
+
 def main():
     p = argparse.ArgumentParser()
     p.add_argument("--trials", type=int, default=500)
@@ -751,7 +987,14 @@ def main():
     p.add_argument("--n-jobs", type=int, default=1)
     p.add_argument("--rounds", type=int, default=100)
     p.add_argument("--splits", type=int, default=5)
-    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--seeds", type=str, default="42",
+                   help="comma-separated seeds; each seed redraws synthetic/hmm "
+                        "data AND reseeds the TPE sampler + models. Multi-seed "
+                        "runs report holdout mean±std — single-seed numbers "
+                        "have no variance estimate.")
+    p.add_argument("--holdout-frac", type=float, default=0.2,
+                   help="chronological tail fraction never seen by Optuna; the "
+                        "CV winner is retrained on the rest and scored on it once")
     p.add_argument(
         "--datasets",
         type=str,
@@ -782,10 +1025,7 @@ def main():
                         "useful with --moe-refit-mode to skip naive baselines on ablation runs")
     args = p.parse_args()
 
-    cfg = BenchmarkConfig(n_trials=args.trials, seed=args.seed, n_splits=args.splits, num_boost_round=args.rounds)
-    cfg.moe_refit_mode = args.moe_refit_mode
-    cfg.moe_refit_decay = args.moe_refit_decay
-    cfg.variants = [v.strip() for v in args.variants.split(",")] if args.variants else None
+    seeds = [int(s.strip()) for s in args.seeds.split(",")]
     selected = [s.strip() for s in args.datasets.split(",")]
     unknown = [s for s in selected if s not in DATASET_GENERATORS]
     if unknown:
@@ -795,15 +1035,32 @@ def main():
     os.makedirs(out_dir, exist_ok=True)
     slice_dir = out_dir
 
-    results = {"config": {"trials": args.trials, "n_jobs": args.n_jobs, "rounds": args.rounds,
-                          "splits": args.splits, "seed": args.seed, "datasets": selected}}
+    results = {
+        "config": {"trials": args.trials, "n_jobs": args.n_jobs, "rounds": args.rounds,
+                   "splits": args.splits, "seeds": seeds, "holdout_frac": args.holdout_frac,
+                   "datasets": selected, "es_fraction": ES_FRACTION, "cv_gap": CV_GAP,
+                   "moe_refit_mode": args.moe_refit_mode},
+        "provenance": collect_provenance(),
+        "runs": {},
+    }
     all_slice_paths: dict = {}
 
-    for ds_name in selected:
-        X, y, _ = DATASET_GENERATORS[ds_name](cfg.seed)
-        ds_out, sp = run_study(ds_name, X, y, args.trials, args.n_jobs, cfg, slice_dir)
-        results[ds_name] = ds_out
-        all_slice_paths.update(sp)
+    for seed in seeds:
+        cfg = BenchmarkConfig(n_trials=args.trials, seed=seed, n_splits=args.splits,
+                              num_boost_round=args.rounds)
+        cfg.moe_refit_mode = args.moe_refit_mode
+        cfg.moe_refit_decay = args.moe_refit_decay
+        cfg.variants = [v.strip() for v in args.variants.split(",")] if args.variants else None
+        for ds_name in selected:
+            X, y, _ = DATASET_GENERATORS[ds_name](seed)
+            X_search, y_search, X_hold, y_hold = chronological_split(X, y, args.holdout_frac)
+            run_tag = f"{ds_name}@s{seed}"
+            ds_out, sp = run_study(ds_name, X_search, y_search, X_hold, y_hold,
+                                   args.trials, args.n_jobs, cfg, slice_dir, run_tag)
+            results["runs"][run_tag] = ds_out
+            all_slice_paths.update(sp)
+
+    results["summary"] = summarize_across_seeds(results)
 
     with open(args.out, "w") as f:
         json.dump(results, f, indent=2, default=str)

--- a/examples/comparative_study.py
+++ b/examples/comparative_study.py
@@ -86,9 +86,11 @@ if _PKG_DIR and not os.path.abspath(lgb.__file__).startswith(os.path.abspath(_PK
 
 sys.path.insert(0, os.path.dirname(__file__))
 from benchmark import (  # noqa: E402
+    OPENML_CONTROL_DATASETS,
     BenchmarkConfig,
     generate_fred_gdp_data,
     generate_hmm_data,
+    generate_openml_control_data,
     generate_sp500_basic_data,
     generate_sp500_data,
     generate_synthetic_data,
@@ -941,6 +943,11 @@ DATASET_GENERATORS = {
     "vix": lambda seed: generate_vix_data(seed=seed),
     "hmm": lambda seed: generate_hmm_data(seed=seed),
 }
+# Non-regime CONTROL group (Grinsztajn 2022 regression track, i.i.d. tabular).
+# MoE's honest claim requires showing it does no harm here.
+for _name, _did in OPENML_CONTROL_DATASETS.items():
+    DATASET_GENERATORS[_name] = (
+        lambda seed, _n=_name, _d=_did: generate_openml_control_data(_n, _d, seed=seed))
 
 
 def summarize_across_seeds(results: dict) -> dict:

--- a/include/LightGBM/c_api.h
+++ b/include/LightGBM/c_api.h
@@ -1651,7 +1651,10 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterIsMixture(BoosterHandle handle,
  * \param nrow Number of rows
  * \param ncol Number of columns
  * \param is_row_major 1 for row-major, 0 for column-major
- * \param parameter Other parameters for prediction
+ * \param parameter Other parameters for prediction; supports
+ *                  ``start_iteration_predict`` / ``num_iteration_predict``
+ *                  (in MoE iteration units; the gate range is scaled
+ *                  internally) and ``predict_disable_shape_check``
  * \param[out] out_len Length of output result
  * \param[out] out_result Pointer to array with regime indices (int32)
  * \return 0 when succeed, -1 when failure happens
@@ -1676,7 +1679,10 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictRegime(BoosterHandle handle,
  * \param nrow Number of rows
  * \param ncol Number of columns
  * \param is_row_major 1 for row-major, 0 for column-major
- * \param parameter Other parameters for prediction
+ * \param parameter Other parameters for prediction; supports
+ *                  ``start_iteration_predict`` / ``num_iteration_predict``
+ *                  (in MoE iteration units; the gate range is scaled
+ *                  internally) and ``predict_disable_shape_check``
  * \param[out] out_len Length of output result
  * \param[out] out_result Pointer to array with regime probabilities (nrow x num_experts)
  * \return 0 when succeed, -1 when failure happens
@@ -1701,7 +1707,10 @@ LIGHTGBM_C_EXPORT int LGBM_BoosterPredictRegimeProba(BoosterHandle handle,
  * \param nrow Number of rows
  * \param ncol Number of columns
  * \param is_row_major 1 for row-major, 0 for column-major
- * \param parameter Other parameters for prediction
+ * \param parameter Other parameters for prediction; supports
+ *                  ``start_iteration_predict`` / ``num_iteration_predict``
+ *                  (in MoE iteration units; the gate range is scaled
+ *                  internally) and ``predict_disable_shape_check``
  * \param[out] out_len Length of output result
  * \param[out] out_result Pointer to array with expert predictions (nrow x num_experts)
  * \return 0 when succeed, -1 when failure happens

--- a/include/LightGBM/config.h
+++ b/include/LightGBM/config.h
@@ -1143,9 +1143,8 @@ struct Config {
   #pragma region Mixture-of-Experts Parameters
   #endif  // __NVCC__
 
-  // desc = set this to ``true`` to enable Mixture-of-Experts (MoE) mode
-  // desc = when enabled, LightGBM trains K expert GBDTs and 1 gate GBDT
-  // desc = the final prediction is a weighted combination of expert predictions
+  // desc = informational flag written into saved mixture model headers; it does **not** enable MoE mode
+  // desc = MoE training is enabled by setting ``boosting=mixture`` — setting only ``mixture_enable=true`` trains a plain GBDT and a warning is emitted
   bool mixture_enable = false;
 
   // check = >=2
@@ -1166,13 +1165,15 @@ struct Config {
   int mixture_gate_iters_per_round = 1;
 
   // type = enum
-  // options = uniform, quantile, random, balanced_kmeans, gmm, tree_hierarchical
+  // options = uniform, quantile, random, balanced_kmeans, kmeans_features, gmm, gmm_features, tree_hierarchical
   // desc = initialization method for expert responsibilities
   // desc = ``uniform``: all experts start with equal responsibility (default, may cause collapse)
   // desc = ``quantile``: assign samples to experts based on label quantiles
   // desc = ``random``: randomly assign samples to experts
-  // desc = ``balanced_kmeans``: use Balanced K-Means clustering on features (recommended)
-  // desc = ``gmm``: use Gaussian Mixture Model for soft clustering (theoretical EM alignment)
+  // desc = ``balanced_kmeans``: use Balanced K-Means clustering on features + label
+  // desc = ``kmeans_features``: Balanced K-Means on raw features only (regime discovery in X-space)
+  // desc = ``gmm``: use Gaussian Mixture Model on features + label (theoretical EM alignment)
+  // desc = ``gmm_features``: GMM on raw features only (recommended when the regime is a function of X)
   // desc = ``tree_hierarchical``: train a deep tree, then hierarchically cluster leaves by mean y
   std::string mixture_init = "uniform";
 
@@ -1246,6 +1247,9 @@ struct Config {
   //        ``r_ik`` *before* appending the next tree, restoring the closed-form
   //        M-step on each tree's existing partition structure
   // desc = default ``false`` keeps the v0.6.0 append-only behavior bit-identical
+  // desc = **early stopping caveat**: refit mutates past trees in place, so the model
+  //        restored/saved at the best iteration includes refit passes that fired after
+  //        that iteration — close to, but not identical to, the exact best-iteration model
   // desc = see issue #37 for the design rationale
   bool mixture_refit_leaves = false;
 
@@ -1384,14 +1388,6 @@ struct Config {
   // desc = ignored when ``mixture_regrow_oldest_trees=false``
   std::string mixture_regrow_mode = "replace";
 
-  // type = enum
-  // options = value, value_and_regime, all
-  // desc = output mode for mixture prediction
-  // desc = ``value``: only output predicted value (yhat)
-  // desc = ``value_and_regime``: output value and argmax regime
-  // desc = ``all``: output value, regime probabilities, and expert predictions
-  std::string mixture_predict_output = "value";
-
   // desc = max depth for gate GBDT (shallower than experts for regularization)
   // check = >0
   int mixture_gate_max_depth = 3;
@@ -1474,15 +1470,6 @@ struct Config {
   // desc = recommended range: 0.1-0.5
   double mixture_diversity_lambda = 0.0;
 
-  // check = >=0.0
-  // check = <1.0
-  // desc = dropout rate for experts during training
-  // desc = at each iteration, experts are randomly dropped with this probability
-  // desc = dropped experts receive zero gradients (not updated) for that iteration
-  // desc = helps prevent expert collapse by forcing all experts to be useful
-  // desc = 0.0 means no dropout (default)
-  // desc = recommended range: 0.1-0.3
-  // desc = note: at least one expert is always kept (never drops all experts)
   // type = enum
   // options = gbdt, none, leaf_reuse
   // desc = gate model type for Mixture-of-Experts routing
@@ -1498,6 +1485,15 @@ struct Config {
   // desc = higher = faster training, lower = better inference routing
   int mixture_gate_retrain_interval = 10;
 
+  // check = >=0.0
+  // check = <1.0
+  // desc = dropout rate for experts during training
+  // desc = at each iteration, experts are randomly dropped with this probability
+  // desc = dropped experts receive zero gradients (not updated) for that iteration
+  // desc = helps prevent expert collapse by forcing all experts to be useful
+  // desc = 0.0 means no dropout (default)
+  // desc = recommended range: 0.1-0.3
+  // desc = note: at least one expert is always kept (never drops all experts)
   double mixture_expert_dropout_rate = 0.0;
 
   // type = enum

--- a/python-package/lightgbm_moe/auto_k.py
+++ b/python-package/lightgbm_moe/auto_k.py
@@ -2,6 +2,7 @@
 """Auto-K selection for MoE models — choose the optimal number of experts via information criteria or CV."""
 
 import copy
+import re
 import warnings
 
 import numpy as np
@@ -69,10 +70,19 @@ def select_num_experts(
     if p.get("boosting") != "mixture":
         raise ValueError("select_num_experts requires boosting='mixture' in params")
 
+    # The same Dataset is trained repeatedly (once per K candidate; cv_rmse
+    # additionally subsets rows per fold), which requires the raw data to
+    # survive the first construction. With the default free_raw_data=True the
+    # second candidate fails with "Cannot call `get_data` after freed raw
+    # data" — keep the raw data alive for the duration of the search.
+    if getattr(train_set, "free_raw_data", False):
+        train_set.free_raw_data = False
+
     k_values = list(k_range)
     criterion_values = []
     models = []
     details = []
+    errors = []
 
     for k in k_values:
         p_k = copy.deepcopy(p)
@@ -90,13 +100,16 @@ def select_num_experts(
             criterion_values.append(float("inf"))
             details.append({"error": str(e)})
             models.append(None)
+            errors.append(e)
             continue
 
         criterion_values.append(crit)
         details.append(detail)
 
     if all(v == float("inf") for v in criterion_values):
-        raise ValueError("All K candidates failed during evaluation")
+        # Include the first underlying error so systematic failures
+        # (same root cause for every K) are not masked.
+        raise ValueError(f"All K candidates failed during evaluation. First error: {errors[0]}")
 
     best_idx = int(np.argmin(criterion_values))
     best_k = k_values[best_idx]
@@ -145,7 +158,7 @@ def _eval_cv_rmse(params, train_set, num_boost_round, nfold, seed, callbacks):
         raise RuntimeError(f"Could not find RMSE metric in cv results. Keys: {list(cv_result.keys())}")
 
     best_rmse = min(cv_result[rmse_key])
-    best_iter = int(np.argmin(cv_result[rmse_key]))
+    best_iter = int(np.argmin(cv_result[rmse_key])) + 1  # 1-based iteration count
 
     detail = {
         "cv_rmse": best_rmse,
@@ -179,9 +192,11 @@ def _eval_ic(params, train_set, num_boost_round, valid_sets, callbacks, criterio
     preds = model.predict(X)
     mse = float(np.mean((preds - y) ** 2))
 
-    # Effective number of parameters: total leaf count across all trees
-    model_dump = model.dump_model()
-    n_params = _count_leaves(model_dump)
+    # Effective number of parameters: total leaf count across all trees.
+    # Parsed from the model string — dump_model() is not implemented for
+    # mixture models, while model_to_string() embeds standard LightGBM tree
+    # text in the [gate_model] / [expert_model_k] sections.
+    n_params = _count_leaves_from_model_str(model.model_to_string())
 
     # Log-likelihood under Gaussian assumption
     log_lik = -N / 2.0 * np.log(2 * np.pi * max(mse, 1e-15)) - N / 2.0
@@ -214,24 +229,15 @@ def _eval_ic(params, train_set, num_boost_round, valid_sets, callbacks, criterio
     return float(crit_val), detail, model
 
 
-def _count_leaves(model_dump):
-    """Count total number of leaves across all trees in a dumped model."""
-    total = 0
-    for tree_info in model_dump.get("tree_info", []):
-        total += _count_leaves_in_tree(tree_info.get("tree_structure", {}))
-    return total
+def _count_leaves_from_model_str(model_str):
+    """Count total number of leaves across all trees in a saved model string.
 
-
-def _count_leaves_in_tree(node):
-    """Recursively count leaves in a single tree node."""
-    if "leaf_value" in node:
-        return 1
-    count = 0
-    if "left_child" in node:
-        count += _count_leaves_in_tree(node["left_child"])
-    if "right_child" in node:
-        count += _count_leaves_in_tree(node["right_child"])
-    return count
+    Each tree block in LightGBM model text contains a ``num_leaves=N`` line;
+    for mixture models these blocks appear inside every [gate_model] and
+    [expert_model_k] section, so summing N over all matches gives the total
+    leaf count of the whole ensemble.
+    """
+    return sum(int(m) for m in re.findall(r"^num_leaves=(\d+)$", model_str, flags=re.MULTILINE))
 
 
 def _print_table(k_values, criterion_values, details, best_idx, criterion):

--- a/python-package/lightgbm_moe/basic.py
+++ b/python-package/lightgbm_moe/basic.py
@@ -4789,19 +4789,75 @@ class Booster:
         )
         return out.value
 
+    def _moe_data_to_array(self, data: _LGBM_PredictDataType) -> np.ndarray:
+        """Convert MoE prediction input to a contiguous 2-D numpy array.
+
+        int8 arrays are preserved; pandas DataFrames are processed with the
+        booster's stored pandas_categorical mapping — the same path
+        ``predict()`` uses — so pandas-categorical columns are encoded
+        consistently with training.
+        """
+        if isinstance(data, np.ndarray):
+            if data.dtype == np.int8:
+                return np.ascontiguousarray(data)
+            return np.ascontiguousarray(data, dtype=np.float64)
+        elif PANDAS_INSTALLED and isinstance(data, pd_DataFrame):
+            df_array = _data_from_pandas(
+                data=data,
+                feature_name="auto",
+                categorical_feature="auto",
+                pandas_categorical=self.pandas_categorical,
+            )[0]
+            return np.ascontiguousarray(df_array, dtype=np.float64)
+        else:
+            raise TypeError(f"Unsupported data type: {type(data)}")
+
+    def _moe_pred_parameter_str(
+        self,
+        start_iteration: int,
+        num_iteration: Optional[int],
+        kwargs: Dict[str, Any],
+    ) -> str:
+        """Build the C API parameter string for MoE prediction methods.
+
+        Mirrors ``predict()`` semantics for ``num_iteration=None``: use the
+        best iteration when one exists and ``start_iteration <= 0``, otherwise
+        no limit (-1). Remaining kwargs are appended as extra parameters.
+        """
+        if num_iteration is None:
+            if start_iteration <= 0:
+                num_iteration = self.best_iteration
+            else:
+                num_iteration = -1
+        pred_parameter = f"start_iteration_predict={start_iteration} num_iteration_predict={num_iteration}"
+        extra = _param_dict_to_str(kwargs)
+        if extra:
+            pred_parameter += " " + extra
+        return pred_parameter
+
     def predict_regime(
         self,
         data: _LGBM_PredictDataType,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
         **kwargs: Any,
     ) -> np.ndarray:
         """Predict regime (argmax of gate probabilities) for MoE model.
 
         Parameters
         ----------
-        data : numpy array, pandas DataFrame, scipy.sparse or pyarrow Table
+        data : numpy 2-D array or pandas DataFrame
             Data source for prediction.
+        start_iteration : int, optional (default=0)
+            Start index of the iteration to predict.
+            If <= 0, starts from the first iteration.
+        num_iteration : int or None, optional (default=None)
+            Total number of iterations used in the prediction.
+            If None, if the best iteration exists and start_iteration <= 0, the best iteration is used;
+            otherwise, all iterations from ``start_iteration`` are used (no limits).
+            If <= 0, all iterations from ``start_iteration`` are used (no limits).
         **kwargs
-            Other parameters for the prediction.
+            Other parameters for the prediction, forwarded to the C API parameter string.
 
         Returns
         -------
@@ -4816,16 +4872,8 @@ class Booster:
         if not self.is_mixture():
             raise LightGBMError("predict_regime can only be used with MoE models")
 
-        # Convert data to numpy array, preserving int8
-        if isinstance(data, np.ndarray):
-            if data.dtype == np.int8:
-                data_array = np.ascontiguousarray(data)
-            else:
-                data_array = np.ascontiguousarray(data, dtype=np.float64)
-        elif PANDAS_INSTALLED and isinstance(data, pd_DataFrame):
-            data_array = np.ascontiguousarray(data.values, dtype=np.float64)
-        else:
-            raise TypeError(f"Unsupported data type: {type(data)}")
+        data_array = self._moe_data_to_array(data)
+        pred_parameter = self._moe_pred_parameter_str(start_iteration, num_iteration, kwargs)
 
         nrow, ncol = data_array.shape
 
@@ -4847,7 +4895,7 @@ class Booster:
                 ctypes.c_int32(nrow),
                 ctypes.c_int32(ncol),
                 ctypes.c_int(1),  # is_row_major
-                ctypes.c_char_p(b""),
+                _c_str(pred_parameter),
                 ctypes.byref(out_len),
                 out_result.ctypes.data_as(ctypes.POINTER(ctypes.c_int32)),
             )
@@ -4858,16 +4906,26 @@ class Booster:
     def predict_regime_proba(
         self,
         data: _LGBM_PredictDataType,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
         **kwargs: Any,
     ) -> np.ndarray:
         """Predict regime probabilities (gate output) for MoE model.
 
         Parameters
         ----------
-        data : numpy array, pandas DataFrame, scipy.sparse or pyarrow Table
+        data : numpy 2-D array or pandas DataFrame
             Data source for prediction.
+        start_iteration : int, optional (default=0)
+            Start index of the iteration to predict.
+            If <= 0, starts from the first iteration.
+        num_iteration : int or None, optional (default=None)
+            Total number of iterations used in the prediction.
+            If None, if the best iteration exists and start_iteration <= 0, the best iteration is used;
+            otherwise, all iterations from ``start_iteration`` are used (no limits).
+            If <= 0, all iterations from ``start_iteration`` are used (no limits).
         **kwargs
-            Other parameters for the prediction.
+            Other parameters for the prediction, forwarded to the C API parameter string.
 
         Returns
         -------
@@ -4884,16 +4942,8 @@ class Booster:
 
         num_experts = self.num_experts()
 
-        # Convert data to numpy array, preserving int8
-        if isinstance(data, np.ndarray):
-            if data.dtype == np.int8:
-                data_array = np.ascontiguousarray(data)
-            else:
-                data_array = np.ascontiguousarray(data, dtype=np.float64)
-        elif PANDAS_INSTALLED and isinstance(data, pd_DataFrame):
-            data_array = np.ascontiguousarray(data.values, dtype=np.float64)
-        else:
-            raise TypeError(f"Unsupported data type: {type(data)}")
+        data_array = self._moe_data_to_array(data)
+        pred_parameter = self._moe_pred_parameter_str(start_iteration, num_iteration, kwargs)
 
         nrow, ncol = data_array.shape
 
@@ -4915,7 +4965,7 @@ class Booster:
                 ctypes.c_int32(nrow),
                 ctypes.c_int32(ncol),
                 ctypes.c_int(1),  # is_row_major
-                ctypes.c_char_p(b""),
+                _c_str(pred_parameter),
                 ctypes.byref(out_len),
                 out_result.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             )
@@ -4926,16 +4976,26 @@ class Booster:
     def predict_expert_pred(
         self,
         data: _LGBM_PredictDataType,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
         **kwargs: Any,
     ) -> np.ndarray:
         """Predict individual expert predictions for MoE model.
 
         Parameters
         ----------
-        data : numpy array, pandas DataFrame, scipy.sparse or pyarrow Table
+        data : numpy 2-D array or pandas DataFrame
             Data source for prediction.
+        start_iteration : int, optional (default=0)
+            Start index of the iteration to predict.
+            If <= 0, starts from the first iteration.
+        num_iteration : int or None, optional (default=None)
+            Total number of iterations used in the prediction.
+            If None, if the best iteration exists and start_iteration <= 0, the best iteration is used;
+            otherwise, all iterations from ``start_iteration`` are used (no limits).
+            If <= 0, all iterations from ``start_iteration`` are used (no limits).
         **kwargs
-            Other parameters for the prediction.
+            Other parameters for the prediction, forwarded to the C API parameter string.
 
         Returns
         -------
@@ -4952,16 +5012,8 @@ class Booster:
 
         num_experts = self.num_experts()
 
-        # Convert data to numpy array, preserving int8
-        if isinstance(data, np.ndarray):
-            if data.dtype == np.int8:
-                data_array = np.ascontiguousarray(data)
-            else:
-                data_array = np.ascontiguousarray(data, dtype=np.float64)
-        elif PANDAS_INSTALLED and isinstance(data, pd_DataFrame):
-            data_array = np.ascontiguousarray(data.values, dtype=np.float64)
-        else:
-            raise TypeError(f"Unsupported data type: {type(data)}")
+        data_array = self._moe_data_to_array(data)
+        pred_parameter = self._moe_pred_parameter_str(start_iteration, num_iteration, kwargs)
 
         nrow, ncol = data_array.shape
 
@@ -4983,7 +5035,7 @@ class Booster:
                 ctypes.c_int32(nrow),
                 ctypes.c_int32(ncol),
                 ctypes.c_int(1),  # is_row_major
-                ctypes.c_char_p(b""),
+                _c_str(pred_parameter),
                 ctypes.byref(out_len),
                 out_result.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             )
@@ -5076,6 +5128,8 @@ class Booster:
     def predict_regime_proba_markov(
         self,
         data: _LGBM_PredictDataType,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
         **kwargs: Any,
     ) -> np.ndarray:
         """Predict regime probabilities with Markov smoothing for MoE model.
@@ -5086,10 +5140,18 @@ class Booster:
 
         Parameters
         ----------
-        data : numpy array, pandas DataFrame, scipy.sparse or pyarrow Table
+        data : numpy 2-D array or pandas DataFrame
             Data source for prediction. Should be sorted in time order.
+        start_iteration : int, optional (default=0)
+            Start index of the iteration to predict.
+            If <= 0, starts from the first iteration.
+        num_iteration : int or None, optional (default=None)
+            Total number of iterations used in the prediction.
+            If None, if the best iteration exists and start_iteration <= 0, the best iteration is used;
+            otherwise, all iterations from ``start_iteration`` are used (no limits).
+            If <= 0, all iterations from ``start_iteration`` are used (no limits).
         **kwargs
-            Other parameters for the prediction.
+            Other parameters for the prediction, forwarded to ``predict_regime_proba``.
 
         Returns
         -------
@@ -5112,18 +5174,11 @@ class Booster:
 
         num_experts = self.num_experts()
 
-        # Convert data to numpy array
-        if isinstance(data, np.ndarray):
-            data_array = np.ascontiguousarray(data, dtype=np.float64)
-        elif PANDAS_INSTALLED and isinstance(data, pd_DataFrame):
-            data_array = np.ascontiguousarray(data.values, dtype=np.float64)
-        else:
-            raise TypeError(f"Unsupported data type: {type(data)}")
-
-        nrow, ncol = data_array.shape
-
-        # Get base regime probabilities
-        base_proba = self.predict_regime_proba(data)
+        # Get base regime probabilities (data conversion happens there)
+        base_proba = self.predict_regime_proba(
+            data, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
+        )
+        nrow = base_proba.shape[0]
 
         # Get lambda from model params
         params = self.params
@@ -5147,6 +5202,8 @@ class Booster:
     def predict_markov(
         self,
         data: _LGBM_PredictDataType,
+        start_iteration: int = 0,
+        num_iteration: Optional[int] = None,
         **kwargs: Any,
     ) -> np.ndarray:
         """Make predictions with Markov-style regime switching for MoE model.
@@ -5157,10 +5214,18 @@ class Booster:
 
         Parameters
         ----------
-        data : numpy array, pandas DataFrame, scipy.sparse or pyarrow Table
+        data : numpy 2-D array or pandas DataFrame
             Data source for prediction. Should be sorted in time order.
+        start_iteration : int, optional (default=0)
+            Start index of the iteration to predict.
+            If <= 0, starts from the first iteration.
+        num_iteration : int or None, optional (default=None)
+            Total number of iterations used in the prediction.
+            If None, if the best iteration exists and start_iteration <= 0, the best iteration is used;
+            otherwise, all iterations from ``start_iteration`` are used (no limits).
+            If <= 0, all iterations from ``start_iteration`` are used (no limits).
         **kwargs
-            Other parameters for the prediction.
+            Other parameters for the prediction, forwarded to the underlying prediction calls.
 
         Returns
         -------
@@ -5176,10 +5241,14 @@ class Booster:
             raise LightGBMError("predict_markov can only be used with MoE models")
 
         # Get expert predictions
-        expert_preds = self.predict_expert_pred(data)  # (nrow, n_experts)
+        expert_preds = self.predict_expert_pred(
+            data, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
+        )  # (nrow, n_experts)
 
         # Get Markov-smoothed regime probabilities
-        regime_proba = self.predict_regime_proba_markov(data)  # (nrow, n_experts)
+        regime_proba = self.predict_regime_proba_markov(
+            data, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
+        )  # (nrow, n_experts)
 
         # Weighted sum: prediction = sum_k(proba[k] * expert[k])
         return (regime_proba * expert_preds).sum(axis=1)

--- a/python-package/lightgbm_moe/diagnostics.py
+++ b/python-package/lightgbm_moe/diagnostics.py
@@ -31,7 +31,9 @@ def diagnose_moe(model, X, y, print_report=True):
     regime_proba = model.predict_regime_proba(X)
     expert_preds = model.predict_expert_pred(X)
     moe_preds = model.predict(X)
-    regime_pred = model.predict_regime(X)
+    # argmax of gate probabilities — identical to predict_regime(X),
+    # without a redundant prediction pass.
+    regime_pred = np.argmax(regime_proba, axis=1)
     K = regime_proba.shape[1]
 
     # =========================================================================

--- a/python-package/lightgbm_moe/lib
+++ b/python-package/lightgbm_moe/lib
@@ -1,0 +1,1 @@
+/home/mokumoku/Develop/LightGBM-MoE/python-package/.venv/lib/python3.11/site-packages/lightgbm_moe/lib

--- a/python-package/lightgbm_moe/pruning.py
+++ b/python-package/lightgbm_moe/pruning.py
@@ -18,14 +18,17 @@ class PrunedMoEModel:
         Boolean mask of shape ``(K_orig,)`` indicating which experts are active.
     merge_weights : dict
         Mapping ``{survivor_idx: {orig_idx: weight, ...}}`` for merged experts.
+    merged_into : dict
+        Mapping ``{victim_idx: survivor_idx}`` for merged (not pruned) experts.
     pruning_report : dict
         Summary of the pruning/merging operations performed.
     """
 
-    def __init__(self, original_model, active_mask, merge_weights=None, pruning_report=None):
+    def __init__(self, original_model, active_mask, merge_weights=None, merged_into=None, pruning_report=None):
         self.original_model = original_model
         self.active_mask = np.asarray(active_mask, dtype=bool)
         self.merge_weights = merge_weights or {}
+        self.merged_into = merged_into or {}
         self.pruning_report = pruning_report or {}
 
     def num_experts(self):
@@ -39,11 +42,19 @@ class PrunedMoEModel:
     def predict_regime_proba(self, X):
         """Return gate probabilities for active experts only, renormalised.
 
+        Merge victims donate their gate mass to their survivor (so merging
+        two identical experts is prediction-preserving); mass of genuinely
+        pruned experts is redistributed proportionally via renormalisation.
+
         Returns
         -------
         np.ndarray of shape ``(N, K_active)``
         """
         full_proba = self.original_model.predict_regime_proba(X)  # (N, K_orig)
+        if self.merged_into:
+            full_proba = full_proba.copy()
+            for victim, survivor in self.merged_into.items():
+                full_proba[:, survivor] += full_proba[:, victim]
         active_proba = full_proba[:, self.active_mask]  # (N, K_active)
         row_sums = active_proba.sum(axis=1, keepdims=True)
         row_sums = np.maximum(row_sums, 1e-15)
@@ -168,24 +179,29 @@ def prune_experts(
             survivor, victim = j, i
 
         active[victim] = False
+        # Transitive remap (union-find style): experts previously merged into
+        # the new victim now belong to its survivor, so chained merges
+        # (A -> B, then B -> C) never lose A's membership.
+        for prev_victim, prev_surv in merged_into.items():
+            if prev_surv == victim:
+                merged_into[prev_victim] = survivor
         merged_into[victim] = survivor
 
-        # Build merge weight map for the survivor
-        # Collect all experts that are now merged into this survivor
-        group = [survivor]
-        for prev_victim, prev_surv in merged_into.items():
-            if prev_surv == survivor and prev_victim != victim:
-                group.append(prev_victim)
-        group.append(victim)
+        actions.append(f"  E{victim}: merged into E{survivor} (corr={corr:.2f})")
 
+    # Build merge weight maps once all merges are resolved, so every key is an
+    # active survivor and each weight dict covers the survivor plus all of its
+    # (transitively) merged victims.
+    survivor_groups = {}
+    for victim, survivor in merged_into.items():
+        survivor_groups.setdefault(survivor, [survivor]).append(victim)
+    for survivor, group in survivor_groups.items():
         total_util = sum(utilization[g] for g in group)
         if total_util > 0:
             weights = {g: float(utilization[g] / total_util) for g in group}
         else:
             weights = {g: 1.0 / len(group) for g in group}
         merge_weights[survivor] = weights
-
-        actions.append(f"  E{victim}: merged into E{survivor} (corr={corr:.2f})")
 
     # Safety: ensure at least one expert remains
     if not active.any():
@@ -221,6 +237,7 @@ def prune_experts(
         original_model=model,
         active_mask=active,
         merge_weights=merge_weights,
+        merged_into=merged_into,
         pruning_report=report,
     )
 
@@ -256,6 +273,7 @@ def merge_experts(
 
     active = np.ones(K, dtype=bool)
     merge_weights = {}
+    merged_into = {}
     actions = []
 
     for group in expert_groups:
@@ -273,6 +291,7 @@ def merge_experts(
 
         for v in victims:
             active[v] = False
+            merged_into[v] = survivor
             actions.append(f"  E{v}: merged into E{survivor}")
 
     active_indices_final = list(np.where(active)[0])
@@ -292,6 +311,7 @@ def merge_experts(
         original_model=model,
         active_mask=active,
         merge_weights=merge_weights,
+        merged_into=merged_into,
         pruning_report=report,
     )
 

--- a/python-package/lightgbm_moe/viz.py
+++ b/python-package/lightgbm_moe/viz.py
@@ -297,10 +297,24 @@ class RegimeEvolutionRecorder:
         # --- Panel ② tape: argmax(r) over iterations -----------------------
         ax_tape = fig.add_subplot(gs[1, :])
         # imshow with sample on x, snapshot on y. extent so x lines up with
-        # whatever x_for_top uses; for tabular it's just rank.
+        # whatever x_for_top uses; for tabular it's just rank. Note that
+        # imshow assumes uniformly spaced samples, so a non-uniform
+        # time_axis is approximated by stretching it linearly over the extent.
         x_left, x_right = (0.0, float(num_data))
-        if resolved_mode == "timeseries" and np.issubdtype(time_x.dtype, np.number):
-            x_left, x_right = float(time_x[0]), float(time_x[-1])
+        datetime_axis = False
+        if resolved_mode == "timeseries":
+            if np.issubdtype(time_x.dtype, np.number):
+                x_left, x_right = float(time_x[0]), float(time_x[-1])
+            else:
+                # Datetime axes: convert to matplotlib's float date units so
+                # the tape shares x-coordinates with the top panel.
+                try:
+                    from matplotlib.dates import date2num
+
+                    x_left, x_right = float(date2num(time_x[0])), float(date2num(time_x[-1]))
+                    datetime_axis = True
+                except (TypeError, ValueError):
+                    pass  # unknown dtype — keep the (0, N) fallback
         ax_tape.imshow(
             argmax_plot,
             aspect="auto",
@@ -310,6 +324,8 @@ class RegimeEvolutionRecorder:
             extent=(x_left, x_right, num_snap - 0.5, -0.5),
             origin="upper",
         )
+        if datetime_axis:
+            ax_tape.xaxis_date()
         ax_tape.set_yticks(range(num_snap))
         ax_tape.set_yticklabels(
             [f"iter={it}" for it in self.iterations],

--- a/src/boosting/boosting.cpp
+++ b/src/boosting/boosting.cpp
@@ -37,7 +37,7 @@ bool Boosting::LoadFileToBoosting(Boosting* boosting, const char* filename) {
 
 Boosting* Boosting::CreateBoosting(const std::string& type, const char* filename) {
   if (filename == nullptr || filename[0] == '\0') {
-    Log::Info("CreateBoosting: type=%s, no filename", type.c_str());
+    Log::Debug("CreateBoosting: type=%s, no filename", type.c_str());
     if (type == std::string("gbdt")) {
       return new GBDT();
     } else if (type == std::string("dart")) {
@@ -54,7 +54,7 @@ Boosting* Boosting::CreateBoosting(const std::string& type, const char* filename
   } else {
     std::unique_ptr<Boosting> ret;
     std::string model_type = GetBoostingTypeFromModelFile(filename);
-    Log::Warning("CreateBoosting: type=%s, model_type=%s, file=%s", type.c_str(), model_type.c_str(), filename);
+    Log::Debug("CreateBoosting: type=%s, model_type=%s, file=%s", type.c_str(), model_type.c_str(), filename);
     if (model_type == std::string("tree")) {
       if (type == std::string("gbdt")) {
         ret.reset(new GBDT());
@@ -69,10 +69,10 @@ Boosting* Boosting::CreateBoosting(const std::string& type, const char* filename
       }
       LoadFileToBoosting(ret.get(), filename);
     } else if (model_type == std::string("mixture")) {
-      Log::Warning("CreateBoosting: Creating MixtureGBDT for mixture model");
+      Log::Debug("CreateBoosting: Creating MixtureGBDT for mixture model");
       ret.reset(new MixtureGBDT());
       LoadFileToBoosting(ret.get(), filename);
-      Log::Warning("CreateBoosting: MixtureGBDT loaded successfully");
+      Log::Debug("CreateBoosting: MixtureGBDT loaded successfully");
     } else {
       Log::Fatal("Unknown model format or submodel type in model file %s", filename);
     }

--- a/src/boosting/gbdt.cpp
+++ b/src/boosting/gbdt.cpp
@@ -849,6 +849,16 @@ void GBDT::UpdateScore(const Tree* tree, const int cur_tree_id) {
     train_score_updater_->AddScore(tree, cur_tree_id);
   }
 
+  // Sparse activation (MoE hard M-step): the tree-learner AddScore above only
+  // reaches samples inside the learner's partition, and with bagging disabled
+  // the out-of-bag branch is a no-op — samples excluded via SetBaggingData
+  // would keep stale training scores forever. Add the new tree's output for
+  // the recorded complement explicitly. Empty outside MoE sparse activation.
+  if (!moe_score_complement_.empty() && !data_sample_strategy_->is_use_subset()) {
+    train_score_updater_->AddScore(tree, moe_score_complement_.data(),
+                                   static_cast<data_size_t>(moe_score_complement_.size()),
+                                   cur_tree_id);
+  }
 
   // update validation score
   for (auto& score_updater : valid_score_updater_) {

--- a/src/boosting/gbdt.h
+++ b/src/boosting/gbdt.h
@@ -294,11 +294,39 @@ class GBDT : public GBDTBase {
    * before TrainOneIter makes the tree learner build histograms only for the
    * specified sample indices. Score updates still cover all samples.
    *
+   * The "score updates cover all samples" half of that contract is why
+   * moe_score_complement_ exists: UpdateScore's fast path adds the new
+   * tree's contribution via the tree learner, which only reaches samples
+   * inside the learner's data partition, and the out-of-bag branch is dead
+   * when bagging is off (bag_data_cnt == num_data). Before the v0.8.1 audit
+   * fix, every sample OUTSIDE the subset silently kept a stale training
+   * score forever — under MoE hard M-step (the default) the E-step then
+   * computed responsibilities from frozen expert predictions for every
+   * non-assigned sample, and training metrics diverged from predict().
+   * We record the complement here and UpdateScore adds each new tree's
+   * output for those rows explicitly.
+   *
    * \param used_indices Array of sample indices to train on
    * \param num_used Number of indices
    */
   void SetBaggingData(const data_size_t* used_indices, data_size_t num_used) {
     tree_learner_->SetBaggingData(nullptr, used_indices, num_used);
+    moe_score_complement_.clear();
+    if (used_indices != nullptr && num_used < num_data_) {
+      if (static_cast<data_size_t>(moe_used_mark_.size()) != num_data_) {
+        moe_used_mark_.resize(num_data_);
+      }
+      std::fill(moe_used_mark_.begin(), moe_used_mark_.end(), 0);
+      for (data_size_t i = 0; i < num_used; ++i) {
+        moe_used_mark_[used_indices[i]] = 1;
+      }
+      moe_score_complement_.reserve(num_data_ - num_used);
+      for (data_size_t i = 0; i < num_data_; ++i) {
+        if (!moe_used_mark_[i]) {
+          moe_score_complement_.push_back(i);
+        }
+      }
+    }
   }
 
   /*!
@@ -750,6 +778,13 @@ class GBDT : public GBDTBase {
 
   /*! \brief Number of training data */
   data_size_t num_data_;
+  /*! \brief Sparse-activation (MoE hard M-step) score-complement bookkeeping:
+   *  samples excluded from the current SetBaggingData subset. UpdateScore
+   *  adds each new tree's contribution for these rows so their training
+   *  scores stay current (see SetBaggingData). Empty when no subset active. */
+  std::vector<data_size_t> moe_score_complement_;
+  /*! \brief Scratch mark buffer for building moe_score_complement_ */
+  std::vector<uint8_t> moe_used_mark_;
   /*! \brief Number of trees per iterations */
   int num_tree_per_iteration_;
   /*! \brief Number of class */

--- a/src/boosting/mixture_gbdt.cpp
+++ b/src/boosting/mixture_gbdt.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
+#include <iomanip>
 #include <limits>
 #include <map>
 #include <memory>
@@ -32,6 +33,20 @@
 namespace LightGBM {
 
 constexpr double kMixtureEpsilon = 1e-12;
+
+namespace {
+
+/*! \brief Shared no-op early-stop instance for the per-row predict paths.
+ * Constructing one per Predict* call showed up as per-row overhead when the
+ * C API loops these functions over full matrices (the instance is stateless
+ * for "none", so a single shared const object is thread-safe). */
+const PredictionEarlyStopInstance& NoEarlyStopInstance() {
+  static const PredictionEarlyStopInstance kNoEarlyStop =
+      CreatePredictionEarlyStopInstance("none", PredictionEarlyStopConfig());
+  return kNoEarlyStop;
+}
+
+}  // anonymous namespace
 
 MixtureGBDT::MixtureGBDT()
     : num_experts_(4),
@@ -73,6 +88,50 @@ void MixtureGBDT::Init(const Config* config, const Dataset* train_data,
   // Store original config
   config_ = std::unique_ptr<Config>(new Config(*config));
   num_experts_ = config_->mixture_num_experts;
+  gate_iters_per_round_ = std::max(1, config_->mixture_gate_iters_per_round);
+
+  // Validate enum-valued mixture params loudly. Every one of these used to
+  // fall through to a silent default on a typo (e.g. mixture_init=gmm_feature
+  // trained with uniform init and no diagnostic) — only refit_trigger warned.
+  {
+    auto check_enum = [](const char* name, const std::string& value,
+                         std::initializer_list<const char*> valid) {
+      for (const char* v : valid) {
+        if (value == v) return;
+      }
+      std::string valid_str;
+      for (const char* v : valid) {
+        if (!valid_str.empty()) valid_str += ", ";
+        valid_str += v;
+      }
+      Log::Warning("MixtureGBDT: unknown %s '%s' — falling back to default "
+                   "behavior. Valid values: %s.",
+                   name, value.c_str(), valid_str.c_str());
+    };
+    check_enum("mixture_init", config_->mixture_init,
+               {"uniform", "quantile", "random", "balanced_kmeans",
+                "kmeans_features", "gmm", "gmm_features", "tree_hierarchical"});
+    check_enum("mixture_gate_type", config_->mixture_gate_type,
+               {"gbdt", "none", "leaf_reuse"});
+    check_enum("mixture_r_smoothing", config_->mixture_r_smoothing,
+               {"none", "ema", "markov", "momentum"});
+    check_enum("mixture_e_step_mode", config_->mixture_e_step_mode,
+               {"em", "gate_only", "loss_only"});
+    check_enum("mixture_e_step_loss", config_->mixture_e_step_loss,
+               {"auto", "l2", "l1", "quantile"});
+    check_enum("mixture_routing_mode", config_->mixture_routing_mode,
+               {"token_choice", "expert_choice"});
+    check_enum("mixture_expert_choice_score", config_->mixture_expert_choice_score,
+               {"gate", "loss", "combined"});
+    check_enum("mixture_dropout_schedule", config_->mixture_dropout_schedule,
+               {"constant", "linear", "cosine"});
+    check_enum("mixture_progressive_mode", config_->mixture_progressive_mode,
+               {"none", "evomoe"});
+    check_enum("mixture_refit_trigger", config_->mixture_refit_trigger,
+               {"always", "elbo", "every_n"});
+    check_enum("mixture_regrow_mode", config_->mixture_regrow_mode,
+               {"replace", "delete"});
+  }
 
   // v0.7 leaf-refit incompatibility guard: leaf_reuse gate derives routing
   // from expert-tree leaf statistics, but RefitExpertsAndGate only refits the
@@ -108,6 +167,23 @@ void MixtureGBDT::Init(const Config* config, const Dataset* train_data,
         "an asymmetric update. Forcing mixture_regrow_oldest_trees=false. "
         "Use gate_type='gbdt' to enable regrow.");
     config_->mixture_regrow_oldest_trees = false;
+  }
+
+  // Best-iteration semantics caveat: refit/regrow mutate PAST trees in place
+  // (leaf values and, with regrow, split structures). Early stopping can
+  // remove trees appended after the best iteration, but it cannot restore
+  // what refit rewrote — so the "best iteration" model returned after
+  // stopping is the best iteration's TREE SET with LATER refit passes baked
+  // into it, not the exact model that achieved the best validation score.
+  // The same applies to truncated saves (Python's post-train round-trip
+  // saves up to best_iteration). Warn once so the semantics are explicit.
+  if (config_->mixture_refit_leaves && config_->early_stopping_round > 0) {
+    Log::Warning(
+        "MixtureGBDT: mixture_refit_leaves=true with early stopping — refit "
+        "rewrites past trees in place, so the model restored/saved at the "
+        "best iteration includes refit passes that fired AFTER that "
+        "iteration. It is usually close to (often better than) the exact "
+        "best-iteration model, but not identical to it.");
   }
 
   // Get feature info
@@ -654,7 +730,9 @@ void MixtureGBDT::InitResponsibilitiesBalancedKMeans(const label_t* labels,
 
   std::vector<double> X(static_cast<size_t>(N) * D);
   std::vector<double> feat_mean(D, 0.0);
-  std::vector<double> feat_std(D, 1.0);
+  // Accumulators start at 0; the old init of 1.0 leaked into the variance
+  // sum and inflated every per-dim std by sqrt(1/N) worth of bias.
+  std::vector<double> feat_std(D, 0.0);
 
   std::vector<BinIterator*> iters(num_features, nullptr);
   for (int f = 0; f < num_features; ++f) {
@@ -936,7 +1014,7 @@ void MixtureGBDT::InitResponsibilitiesGMM(const label_t* labels,
 
   // Compute global mean and std for normalization
   std::vector<double> global_mean(D, 0.0);
-  std::vector<double> global_std(D, 1.0);
+  std::vector<double> global_std(D, 0.0);
 
   for (data_size_t i = 0; i < N; ++i) {
     for (int d = 0; d < D; ++d) {
@@ -970,7 +1048,8 @@ void MixtureGBDT::InitResponsibilitiesGMM(const label_t* labels,
   std::vector<double> variances(static_cast<size_t>(K) * D);  // K x D (diagonal covariance)
   std::vector<double> weights(K, 1.0 / K);                    // Mixing coefficients
 
-  // Sort indices by last feature (label)
+  // Sort indices by the last dimension (the label when include_label=true,
+  // otherwise the last raw feature) purely for quantile seeding
   std::vector<data_size_t> sorted_idx(N);
   std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
   std::sort(sorted_idx.begin(), sorted_idx.end(),
@@ -1319,12 +1398,20 @@ void MixtureGBDT::ComputeGateProbForInference(const double* gate_raw,
   // `mixture_balance_factor` (which drives expert_bias_) or temperature
   // annealing produce a routing at inference that does not match the routing
   // used during training — silently degrading test metrics.
-  std::vector<double> scores(num_experts_);
+  double scores_buf[64];
+  std::vector<double> scores_heap;
+  double* scores;
+  if (num_experts_ <= 64) {
+    scores = scores_buf;
+  } else {
+    scores_heap.resize(num_experts_);
+    scores = scores_heap.data();
+  }
   const double inv_T = 1.0 / std::max(gate_temperature_, kMixtureEpsilon);
   for (int k = 0; k < num_experts_; ++k) {
     scores[k] = (gate_raw[k] + expert_bias_[k]) * inv_T;
   }
-  Softmax(scores.data(), num_experts_, gate_prob);
+  Softmax(scores, num_experts_, gate_prob);
 }
 
 void MixtureGBDT::Softmax(const double* scores, int n, double* probs) const {
@@ -1742,21 +1829,35 @@ void MixtureGBDT::EStep() {
     }
   }
 
+  // Integer mode dispatch hoisted out of the hot loop (string compares per
+  // (i, k) pair are measurable at N·K per iteration).
+  const int mode_kind = (mode == "gate_only") ? 1 : (mode == "loss_only") ? 2 : 0;
+
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
   for (data_size_t i = 0; i < num_data_; ++i) {
-    std::vector<double> scores(num_experts_);
+    // Stack buffer for K ≤ 64 — avoids a heap alloc per sample per iteration
+    // (same pattern as MStepGate).
+    double scores_buf[64];
+    std::vector<double> scores_heap;
+    double* scores;
+    if (num_experts_ <= 64) {
+      scores = scores_buf;
+    } else {
+      scores_heap.resize(num_experts_);
+      scores = scores_heap.data();
+    }
 
     for (int k = 0; k < num_experts_; ++k) {
       double score = 0.0;
 
-      if (mode == "gate_only") {
+      if (mode_kind == 1) {
         // Prior π_k(x) = bias-free softmax of gate logits. The load-balance
         // bias is a routing nudge (DeepSeek), not a probabilistic prior;
         // mixing it into the responsibility softmax forces the gate to
         // learn to undo bias each iter — defeats the point.
         const double gate_prob = gate_proba_no_bias_[i * num_experts_ + k];
         score = std::log(gate_prob + kMixtureEpsilon);
-      } else if (mode == "loss_only") {
+      } else if (mode_kind == 2) {
         const double expert_p = expert_pred_sm_[i * num_experts_ + k];
         const double loss = ComputePointwiseLoss(labels[i], expert_p);
         if (estimate_var) {
@@ -1781,7 +1882,7 @@ void MixtureGBDT::EStep() {
       scores[k] = score - load_penalty[k];
     }
 
-    Softmax(scores.data(), num_experts_, responsibilities_.data() + i * num_experts_);
+    Softmax(scores, num_experts_, responsibilities_.data() + i * num_experts_);
   }
 }
 
@@ -1792,36 +1893,58 @@ void MixtureGBDT::UpdateExpertVariances() {
   // Standard MoE M-step for the noise scale (per Jordan-Jacobs):
   //   σ_k² = Σ_i r_ik (y_i - f_k(x_i))² / Σ_i r_ik
   //   b_k  = Σ_i r_ik |y_i - f_k(x_i)| / Σ_i r_ik       (Laplace)
-  // Using a sample-major reduction with per-thread accumulators to avoid the
-  // false-sharing pitfall when num_experts_ is small.
+  // Sample-major reduction with per-thread accumulators (avoids false
+  // sharing on small num_experts_), merged serially at the end. Runs every
+  // iteration, so the O(N·K) pass is worth parallelizing.
+  const int loss_kind = (e_step_loss_type_ == "l1") ? 1
+                        : (e_step_loss_type_ == "quantile") ? 2 : 0;
+  const int num_threads = OMP_NUM_THREADS();
+  std::vector<std::vector<double>> tl_num(num_threads,
+                                          std::vector<double>(num_experts_, 0.0));
+  std::vector<std::vector<double>> tl_den(num_threads,
+                                          std::vector<double>(num_experts_, 0.0));
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    const int tid = omp_get_thread_num();
+    auto& num_acc_t = tl_num[tid];
+    auto& den_acc_t = tl_den[tid];
+    #pragma omp for schedule(static)
+    for (data_size_t i = 0; i < num_data_; ++i) {
+      const double y = static_cast<double>(labels[i]);
+      for (int k = 0; k < num_experts_; ++k) {
+        const double r = responsibilities_[i * num_experts_ + k];
+        const double f = expert_pred_sm_[i * num_experts_ + k];
+        const double diff = y - f;
+        // Per loss type, accumulate the residual term whose units match the
+        // "scale" the E-step then divides by — i.e. the unitless ratio
+        //   loss / scale  must equal the log-density exponent.
+        //   l2:        scale = σ² = E[diff²],            E-step uses diff²/(2σ²)
+        //   l1:        scale = b  = E[|diff|],           E-step uses |diff|/b
+        //   quantile:  scale = E[pinball],               E-step uses pinball/scale
+        // The earlier code fell into (diff*diff) for *anything other than l1*,
+        // so quantile users got `pinball / E[diff²]` — dimensionally O(1/diff)
+        // and silently temperature-coupled to the y-scale.
+        double residual_term;
+        if (loss_kind == 1) {
+          residual_term = std::fabs(diff);
+        } else if (loss_kind == 2) {
+          residual_term = ComputePointwiseLoss(y, f);  // pinball loss
+        } else {
+          residual_term = diff * diff;
+        }
+        num_acc_t[k] += r * residual_term;
+        den_acc_t[k] += r;
+      }
+    }
+  }
+
   std::vector<double> num_acc(num_experts_, 0.0);
   std::vector<double> den_acc(num_experts_, 0.0);
-
-  for (data_size_t i = 0; i < num_data_; ++i) {
-    const double y = static_cast<double>(labels[i]);
+  for (int t = 0; t < num_threads; ++t) {
     for (int k = 0; k < num_experts_; ++k) {
-      const double r = responsibilities_[i * num_experts_ + k];
-      const double f = expert_pred_sm_[i * num_experts_ + k];
-      const double diff = y - f;
-      // Per loss type, accumulate the residual term whose units match the
-      // "scale" the E-step then divides by — i.e. the unitless ratio
-      //   loss / scale  must equal the log-density exponent.
-      //   l2:        scale = σ² = E[diff²],            E-step uses diff²/(2σ²)
-      //   l1:        scale = b  = E[|diff|],           E-step uses |diff|/b
-      //   quantile:  scale = E[pinball],               E-step uses pinball/scale
-      // The earlier code fell into (diff*diff) for *anything other than l1*,
-      // so quantile users got `pinball / E[diff²]` — dimensionally O(1/diff)
-      // and silently temperature-coupled to the y-scale.
-      double residual_term;
-      if (e_step_loss_type_ == "l1") {
-        residual_term = std::fabs(diff);
-      } else if (e_step_loss_type_ == "quantile") {
-        residual_term = ComputePointwiseLoss(y, f);  // pinball loss
-      } else {
-        residual_term = diff * diff;
-      }
-      num_acc[k] += r * residual_term;
-      den_acc[k] += r;
+      num_acc[k] += tl_num[t][k];
+      den_acc[k] += tl_den[t][k];
     }
   }
 
@@ -1945,6 +2068,32 @@ void MixtureGBDT::ComputeAffinityScores() {
   const label_t* labels = train_data_->metadata().label();
   const double alpha = config_->mixture_e_step_alpha;
   const std::string& score_type = config_->mixture_expert_choice_score;
+  const bool estimate_var = config_->mixture_estimate_variance;
+
+  // Same per-expert log-density terms as EStep. Before this, Expert-Choice
+  // silently ignored mixture_estimate_variance (default true) and always
+  // used the legacy fixed-alpha energy — so the y-scale-dependent alpha
+  // problem PR #24 fixed for Token-Choice persisted here, and the σ_k² that
+  // UpdateExpertVariances kept estimating fed the ELBO diagnostic but not
+  // the actual routing objective. Affinity now uses
+  // log π_k + log p(y | f_k, σ_k²), consistent with the E-step posterior.
+  std::vector<double> log_norm(num_experts_, 0.0);
+  std::vector<double> inv_scale(num_experts_, alpha);
+  if (estimate_var) {
+    for (int k = 0; k < num_experts_; ++k) {
+      const double s = std::max(expert_variance_[k], kMixtureEpsilon);
+      if (e_step_loss_type_ == "l1") {
+        log_norm[k]  = -std::log(2.0 * s);
+        inv_scale[k] = 1.0 / s;
+      } else if (e_step_loss_type_ == "l2") {
+        log_norm[k]  = -0.5 * std::log(s);
+        inv_scale[k] = 1.0 / (2.0 * s);
+      } else {
+        log_norm[k]  = 0.0;
+        inv_scale[k] = 1.0 / s;
+      }
+    }
+  }
 
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
   for (data_size_t i = 0; i < num_data_; ++i) {
@@ -1962,7 +2111,11 @@ void MixtureGBDT::ComputeAffinityScores() {
       if (score_type == "loss" || score_type == "combined") {
         double expert_p = expert_pred_sm_[i * num_experts_ + k];
         double loss = ComputePointwiseLoss(labels[i], expert_p);
-        score -= alpha * loss;
+        if (estimate_var) {
+          score += log_norm[k] - inv_scale[k] * loss;
+        } else {
+          score -= alpha * loss;
+        }
       }
 
       // Note: expert_bias_ is already applied in Forward() via gate softmax.
@@ -2579,6 +2732,14 @@ bool MixtureGBDT::ShouldRefit() const {
     if (elbo_history_.size() < 2) return false;
     const int W = std::max(2, config_->mixture_elbo_window);
 
+    // Cooldown: after a fire, stay quiet for W iters. A normally-converged
+    // run plateaus its ELBO permanently; without this the plateau detector
+    // fires every remaining iteration and each fire replays every tree —
+    // the tail of training degenerates to O(T²) for no benefit. W iters
+    // also lets the window refill with post-refit ELBO values, so the next
+    // decision is made on data that reflects the refit's effect.
+    if (moe_iter - last_refit_moe_iter_ < W) return false;
+
     // Drop detection — usable as soon as we have ≥2 samples; references the
     // window's earliest (t-W) and latest (t) values.
     const double elbo_t = elbo_history_.back();
@@ -2613,9 +2774,12 @@ bool MixtureGBDT::ShouldRefit() const {
     const int n = std::max(1, config_->mixture_refit_every_n);
     return (moe_iter % n) == 0;
   } else {
-    Log::Warning("MixtureGBDT: unknown mixture_refit_trigger '%s' — "
-                 "treating as 'always'. Valid: always, elbo, every_n.",
-                 trigger.c_str());
+    if (!refit_trigger_warned_) {
+      Log::Warning("MixtureGBDT: unknown mixture_refit_trigger '%s' — "
+                   "treating as 'always'. Valid: always, elbo, every_n.",
+                   trigger.c_str());
+      refit_trigger_warned_ = true;
+    }
     return true;
   }
 }
@@ -2753,7 +2917,9 @@ void MixtureGBDT::RefitExpertsAndGate() {
       // The callback is stateless w.r.t. which slot is being rebuilt because
       // GetPredictAt always returns the current backbone (RegrowTreeAt
       // / DeleteTreeAt arranges for the score to be at f^{(slot-1)}).
-      auto cb = make_expert_callback(k);
+      // "delete" mode never invokes it, so skip constructing it there.
+      GradHessCb cb;
+      if (!use_delete) cb = make_expert_callback(k);
       for (int s_step = 0; s_step < M_k; ++s_step) {
         // For "delete", subsequent trees shift down so the oldest is always
         // slot 0. For "replace", we walk slot 0, 1, ..., M_k-1 in order.
@@ -2775,7 +2941,8 @@ void MixtureGBDT::RefitExpertsAndGate() {
       if (T_g > min_rem) {
         const int M_g = std::min(M_per_fire, T_g - min_rem);
         if (M_g > 0) {
-          auto cb = make_gate_callback();
+          GradHessCb cb;
+          if (!use_delete) cb = make_gate_callback();
           for (int s_step = 0; s_step < M_g; ++s_step) {
             const int target_slot = use_delete ? 0 : s_step;
             if (use_delete) {
@@ -3135,27 +3302,39 @@ void MixtureGBDT::MStepGateLeafReuse() {
     #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
     for (data_size_t i = 0; i < num_data_; ++i) {
       // Bias-free softmax q_k = softmax(z_k / T) for the gradient target.
-      std::vector<double> scores(num_experts_);
+      // Stack buffers for K ≤ 64 (same pattern as MStepGate) — this loop
+      // runs every iteration in leaf_reuse mode and was allocating three
+      // heap vectors per sample.
+      double scores_buf[64];
+      double q_buf[64];
+      std::vector<double> heap_buf;
+      double* scores;
+      double* q;
+      if (num_experts_ <= 64) {
+        scores = scores_buf;
+        q = q_buf;
+      } else {
+        heap_buf.resize(2 * num_experts_);
+        scores = heap_buf.data();
+        q = heap_buf.data() + num_experts_;
+      }
       for (int k = 0; k < num_experts_; ++k) {
         scores[k] = gate_raw_lr[k * num_data_ + i] * inv_T_lr;
       }
-      std::vector<double> q(num_experts_);
-      Softmax(scores.data(), num_experts_, q.data());
+      Softmax(scores, num_experts_, q);
 
-      // Resolve target distribution from the leaf assignment.
+      // Resolve target distribution from the leaf assignment. Out-of-range
+      // leaves (shouldn't happen) fall back to a uniform target, handled
+      // inline below via a null target pointer.
       const int leaf = sample_leaf[i];
-      const double* target;
-      std::vector<double> uniform_buf;
-      if (leaf >= 0 && leaf < num_leaves) {
-        target = leaf_expert_sum_buf_.data() + static_cast<size_t>(leaf) * num_experts_;
-      } else {
-        uniform_buf.assign(num_experts_, uniform_prob_lr);
-        target = uniform_buf.data();
-      }
+      const double* target = (leaf >= 0 && leaf < num_leaves)
+          ? leaf_expert_sum_buf_.data() + static_cast<size_t>(leaf) * num_experts_
+          : nullptr;
 
       for (int k = 0; k < num_experts_; ++k) {
         const size_t idx = i + static_cast<size_t>(k) * num_data_;
-        const double base_grad = (q[k] - target[k]) * inv_T_lr;
+        const double target_k = (target != nullptr) ? target[k] : uniform_prob_lr;
+        const double base_grad = (q[k] - target_k) * inv_T_lr;
         const double reg_grad =
             dirichlet_lambda_lr * (q[k] - uniform_prob_lr) * inv_T_lr;
         gate_grad_lr[idx] = static_cast<score_t>(base_grad + reg_grad);
@@ -3245,8 +3424,14 @@ bool MixtureGBDT::TrainOneIter(const score_t* gradients, const score_t* hessians
     }
   }
 
-  // Forward pass - compute expert predictions and gate probabilities
-  Forward();
+  // Forward pass - compute expert predictions and gate probabilities.
+  // Skipped when the end-of-iteration refresh below already computed the
+  // identical state (forward_fresh_ is only set when temperature annealing
+  // is off, so no input to Forward changed between there and here).
+  if (!forward_fresh_) {
+    Forward();
+  }
+  forward_fresh_ = false;
 
   // E-step: update responsibilities
   // Skip E-step for first few iterations to allow experts to differentiate
@@ -3290,6 +3475,7 @@ bool MixtureGBDT::TrainOneIter(const score_t* gradients, const score_t* hessians
     // the post-refit expert_pred_ / gate_proba_.
     if (ShouldRefit()) {
       RefitExpertsAndGate();
+      last_refit_moe_iter_ = moe_iter;  // start the elbo-trigger cooldown
       Forward();
     }
   }
@@ -3383,6 +3569,18 @@ bool MixtureGBDT::TrainOneIter(const score_t* gradients, const score_t* hessians
     }
   }
 
+  // Refresh training-side buffers so yhat_ reflects the post-M-step model.
+  // Without this, training metrics (GetEvalAt(0) / OutputMetric) were
+  // evaluated on the START-of-iteration yhat_ while validation metrics used
+  // the fresh post-M-step ForwardValid below — train and valid logs were
+  // silently offset by one iteration. When annealing is off, the next
+  // TrainOneIter reuses this Forward via forward_fresh_ so the per-iter
+  // forward count is unchanged; with annealing on, the next iteration's
+  // temperature differs and Forward must rerun there.
+  Forward();
+  forward_fresh_ = (config_->mixture_gate_temperature_init ==
+                    config_->mixture_gate_temperature_final);
+
   ++iter_;
 
   // Update validation predictions
@@ -3434,9 +3632,18 @@ void MixtureGBDT::RollbackOneIter() {
       for (int k = 0; k < num_experts_; ++k) {
         experts_[k]->RollbackOneIter();
       }
-      gate_->RollbackOneIter();
+      // The gate accumulates gate_iters_per_round_ GBDT iterations per MoE
+      // iteration (MStepGate / MStepGateLeafReuse loop that many times), so
+      // one MoE-iteration rollback must remove that many gate iterations.
+      // Rolling back only one left the gate with g-1 extra tree blocks per
+      // rolled-back iteration — early stopping then restored a routing that
+      // never coexisted with the restored experts.
+      for (int g = 0; g < gate_iters_per_round_; ++g) {
+        gate_->RollbackOneIter();
+      }
     }
     --iter_;
+    forward_fresh_ = false;  // buffers no longer match the model
   }
 }
 
@@ -3592,25 +3799,34 @@ int MixtureGBDT::NumPredictOneRow(int start_iteration, int num_iteration,
 
 void MixtureGBDT::Predict(const double* features, double* output,
                           const PredictionEarlyStopInstance* earlyStop) const {
-  // Create a no-op early stop instance if none provided
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-  const PredictionEarlyStopInstance* early_stop_ptr = earlyStop ? earlyStop : &no_early_stop;
+  const PredictionEarlyStopInstance* early_stop_ptr =
+      earlyStop ? earlyStop : &NoEarlyStopInstance();
 
-  // Get expert predictions
-  std::vector<double> expert_preds(num_experts_);
+  // Stack buffers for K ≤ 64: this function runs once per row inside the
+  // C API's parallel predict loop, so per-call heap allocations are pure
+  // per-row overhead.
+  double stack_buf[3 * 64];
+  std::vector<double> heap_buf;
+  double* expert_preds;
+  double* gate_raw;
+  double* gate_prob;
+  if (num_experts_ <= 64) {
+    expert_preds = stack_buf;
+    gate_raw = stack_buf + num_experts_;
+    gate_prob = stack_buf + 2 * num_experts_;
+  } else {
+    heap_buf.resize(3 * static_cast<size_t>(num_experts_));
+    expert_preds = heap_buf.data();
+    gate_raw = heap_buf.data() + num_experts_;
+    gate_prob = heap_buf.data() + 2 * num_experts_;
+  }
+
   for (int k = 0; k < num_experts_; ++k) {
     experts_[k]->Predict(features, &expert_preds[k], early_stop_ptr);
   }
+  gate_->PredictRaw(features, gate_raw, early_stop_ptr);
+  ComputeGateProbForInference(gate_raw, gate_prob);
 
-  // Get gate probabilities
-  std::vector<double> gate_raw(num_experts_);
-  gate_->PredictRaw(features, gate_raw.data(), early_stop_ptr);
-
-  std::vector<double> gate_prob(num_experts_);
-  ComputeGateProbForInference(gate_raw.data(), gate_prob.data());
-
-  // Compute weighted sum
   double sum = 0.0;
   for (int k = 0; k < num_experts_; ++k) {
     sum += gate_prob[k] * expert_preds[k];
@@ -3625,10 +3841,8 @@ void MixtureGBDT::PredictRaw(const double* features, double* output,
 
 void MixtureGBDT::PredictByMap(const std::unordered_map<int, double>& features, double* output,
                                const PredictionEarlyStopInstance* early_stop) const {
-  // Create a no-op early stop instance if none provided
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-  const PredictionEarlyStopInstance* early_stop_ptr = early_stop ? early_stop : &no_early_stop;
+  const PredictionEarlyStopInstance* early_stop_ptr =
+      early_stop ? early_stop : &NoEarlyStopInstance();
 
   std::vector<double> expert_preds(num_experts_);
   for (int k = 0; k < num_experts_; ++k) {
@@ -3654,15 +3868,21 @@ void MixtureGBDT::PredictRawByMap(const std::unordered_map<int, double>& feature
 }
 
 void MixtureGBDT::PredictRegime(const double* features, int* output) const {
-  // Create a no-op early stop instance
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-
-  std::vector<double> gate_raw(num_experts_);
-  gate_->PredictRaw(features, gate_raw.data(), &no_early_stop);
-
-  std::vector<double> gate_prob(num_experts_);
-  ComputeGateProbForInference(gate_raw.data(), gate_prob.data());
+  // Stack buffers for K <= 64 — called once per row from the C API loop.
+  double stack_buf[2 * 64];
+  std::vector<double> heap_buf;
+  double* gate_raw;
+  double* gate_prob;
+  if (num_experts_ <= 64) {
+    gate_raw = stack_buf;
+    gate_prob = stack_buf + num_experts_;
+  } else {
+    heap_buf.resize(2 * static_cast<size_t>(num_experts_));
+    gate_raw = heap_buf.data();
+    gate_prob = heap_buf.data() + num_experts_;
+  }
+  gate_->PredictRaw(features, gate_raw, &NoEarlyStopInstance());
+  ComputeGateProbForInference(gate_raw, gate_prob);
 
   // Find argmax
   int best_k = 0;
@@ -3677,31 +3897,28 @@ void MixtureGBDT::PredictRegime(const double* features, int* output) const {
 }
 
 void MixtureGBDT::PredictRegimeProba(const double* features, double* output) const {
-  // Create a no-op early stop instance
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-
-  std::vector<double> gate_raw(num_experts_);
-  gate_->PredictRaw(features, gate_raw.data(), &no_early_stop);
-  ComputeGateProbForInference(gate_raw.data(), output);
+  double gate_raw_buf[64];
+  std::vector<double> heap_buf;
+  double* gate_raw;
+  if (num_experts_ <= 64) {
+    gate_raw = gate_raw_buf;
+  } else {
+    heap_buf.resize(num_experts_);
+    gate_raw = heap_buf.data();
+  }
+  gate_->PredictRaw(features, gate_raw, &NoEarlyStopInstance());
+  ComputeGateProbForInference(gate_raw, output);
 }
 
 void MixtureGBDT::PredictExpertPred(const double* features, double* output) const {
-  // Create a no-op early stop instance
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-
   for (int k = 0; k < num_experts_; ++k) {
-    experts_[k]->Predict(features, &output[k], &no_early_stop);
+    experts_[k]->Predict(features, &output[k], &NoEarlyStopInstance());
   }
 }
 
 void MixtureGBDT::PredictWithPrevProba(const double* features, const double* prev_proba,
                                         double* output) const {
-  // Create a no-op early stop instance
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-  const PredictionEarlyStopInstance* early_stop_ptr = &no_early_stop;
+  const PredictionEarlyStopInstance* early_stop_ptr = &NoEarlyStopInstance();
 
   // Get expert predictions
   std::vector<double> expert_preds(num_experts_);
@@ -3742,13 +3959,9 @@ void MixtureGBDT::PredictWithPrevProba(const double* features, const double* pre
 
 void MixtureGBDT::PredictRegimeProbaWithPrevProba(const double* features, const double* prev_proba,
                                                    double* output) const {
-  // Create a no-op early stop instance
-  PredictionEarlyStopInstance no_early_stop = CreatePredictionEarlyStopInstance(
-      "none", PredictionEarlyStopConfig());
-
   // Get current gate probabilities
   std::vector<double> gate_raw(num_experts_);
-  gate_->PredictRaw(features, gate_raw.data(), &no_early_stop);
+  gate_->PredictRaw(features, gate_raw.data(), &NoEarlyStopInstance());
   ComputeGateProbForInference(gate_raw.data(), output);
 
   // Blend with prev_proba if provided and in Markov mode
@@ -3848,6 +4061,9 @@ void MixtureGBDT::ResetTrainingData(const Dataset* train_data,
 
   // Monotonicity baseline is invalidated when retraining on new data.
   prev_marginal_log_lik_ = -1e300;
+  elbo_history_.clear();
+  last_refit_moe_iter_ = -1000000;
+  forward_fresh_ = false;
 
   InitResponsibilities();
 }
@@ -3867,10 +4083,68 @@ void MixtureGBDT::ResetConfig(const Config* config) {
                  "incompatible mixture_gate_type='leaf_reuse'. See Init for rationale.");
     config_->mixture_regrow_oldest_trees = false;
   }
+  gate_iters_per_round_ = std::max(1, config_->mixture_gate_iters_per_round);
+
+  // Rebuild the derived expert / gate configs with the same transformations
+  // Init applies, instead of handing experts the RAW user config. Passing
+  // `config` straight through re-enabled per-expert bagging (which Init
+  // disables deliberately — bagging_fraction<1 overwrites MStepExperts'
+  // SetBaggingData restriction and reintroduces the degenerate-histogram
+  // crash of issue #16) and wiped the per-expert symmetry-breaking seeds and
+  // per-expert hyperparameter overrides. The gate conversely received the
+  // STALE gate_config_, ignoring whatever the caller just changed.
+  expert_config_ = std::unique_ptr<Config>(new Config(*config_));
+  expert_config_->bagging_fraction = 1.0;
+  expert_config_->bagging_freq = 0;
+  expert_config_->pos_bagging_fraction = 1.0;
+  expert_config_->neg_bagging_fraction = 1.0;
+  if (expert_config_->use_quantized_grad) {
+    expert_config_->quant_train_renew_leaf = true;
+  }
+  const bool per_max_depth = !config_->mixture_expert_max_depths.empty();
+  const bool per_num_leaves = !config_->mixture_expert_num_leaves.empty();
+  const bool per_min_data = !config_->mixture_expert_min_data_in_leaf.empty();
+  const bool per_min_gain = !config_->mixture_expert_min_gain_to_split.empty();
+  const bool per_extra_trees = !config_->mixture_expert_extra_trees.empty();
   for (int k = 0; k < num_experts_; ++k) {
-    experts_[k]->ResetConfig(config);
+    expert_configs_[k] = std::unique_ptr<Config>(new Config(*expert_config_));
+    expert_configs_[k]->seed = config_->seed + k + 1;
+    if (per_max_depth && k < static_cast<int>(config_->mixture_expert_max_depths.size())) {
+      expert_configs_[k]->max_depth = config_->mixture_expert_max_depths[k];
+    }
+    if (per_num_leaves && k < static_cast<int>(config_->mixture_expert_num_leaves.size())) {
+      expert_configs_[k]->num_leaves = config_->mixture_expert_num_leaves[k];
+    }
+    if (per_min_data && k < static_cast<int>(config_->mixture_expert_min_data_in_leaf.size())) {
+      expert_configs_[k]->min_data_in_leaf = config_->mixture_expert_min_data_in_leaf[k];
+    }
+    if (per_min_gain && k < static_cast<int>(config_->mixture_expert_min_gain_to_split.size())) {
+      expert_configs_[k]->min_gain_to_split = config_->mixture_expert_min_gain_to_split[k];
+    }
+    if (per_extra_trees && k < static_cast<int>(config_->mixture_expert_extra_trees.size())) {
+      expert_configs_[k]->extra_trees = (config_->mixture_expert_extra_trees[k] != 0);
+    }
+    // In progressive mode before SpawnExpertsFromSeed, experts_ is empty —
+    // the rebuilt expert_configs_ are picked up at spawn time instead.
+    if (k < static_cast<int>(experts_.size())) {
+      experts_[k]->ResetConfig(expert_configs_[k].get());
+    }
+  }
+
+  gate_config_ = std::unique_ptr<Config>(new Config(*config_));
+  gate_config_->objective = "multiclass";
+  gate_config_->num_class = num_experts_;
+  gate_config_->max_depth = config_->mixture_gate_max_depth;
+  gate_config_->num_leaves = config_->mixture_gate_num_leaves;
+  gate_config_->learning_rate = config_->mixture_gate_learning_rate;
+  gate_config_->lambda_l2 = config_->mixture_gate_lambda_l2;
+  if (gate_config_->use_quantized_grad) {
+    gate_config_->quant_train_renew_leaf = true;
   }
   gate_->ResetConfig(gate_config_.get());
+
+  // Model state changed shape of derived params; force a fresh Forward.
+  forward_fresh_ = false;
 }
 
 void MixtureGBDT::AddValidDataset(const Dataset* valid_data,
@@ -3978,11 +4252,20 @@ bool MixtureGBDT::SaveModelToFile(int start_iteration, int num_iterations,
 std::string MixtureGBDT::SaveModelToString(int start_iteration, int num_iterations,
                                             int feature_importance_type) const {
   std::stringstream ss;
+  // Full round-trip precision for the scalar header values. Tree blocks are
+  // serialized at full precision by GBDT::SaveModelToString, but the default
+  // stream precision here was 6 significant digits — and `lgb.train`
+  // performs a save→load round-trip on EVERY trained booster (engine.py),
+  // so bias / temperature / variance were silently truncated on every model,
+  // drifting the loaded model's routing ~1e-6-relative from the in-memory
+  // model that was validated during training.
+  ss << std::setprecision(std::numeric_limits<double>::max_digits10);
 
   // Mixture header
   ss << "mixture\n";
   ss << "mixture_enable=1\n";
   ss << "mixture_num_experts=" << num_experts_ << "\n";
+  ss << "mixture_gate_iters_per_round=" << gate_iters_per_round_ << "\n";
   ss << "mixture_e_step_alpha=" << config_->mixture_e_step_alpha << "\n";
   ss << "mixture_e_step_loss=" << e_step_loss_type_ << "\n";
   ss << "mixture_e_step_mode=" << config_->mixture_e_step_mode << "\n";
@@ -4011,9 +4294,18 @@ std::string MixtureGBDT::SaveModelToString(int start_iteration, int num_iteratio
   }
   ss << "\n";
 
-  // Gate model
+  // Gate model. The gate accumulates gate_iters_per_round_ GBDT iterations
+  // per MoE iteration, so an iteration RANGE expressed in MoE units must be
+  // scaled before it is applied to the gate — otherwise a truncated save
+  // (e.g. Python's automatic best_iteration save after early stopping) cuts
+  // the gate to 1/g of the trees matching the kept experts and silently
+  // changes routing.
+  const int gate_start = (start_iteration > 0)
+      ? start_iteration * gate_iters_per_round_ : start_iteration;
+  const int gate_num = (num_iterations > 0)
+      ? num_iterations * gate_iters_per_round_ : num_iterations;
   ss << "[gate_model]\n";
-  ss << gate_->SaveModelToString(start_iteration, num_iterations, feature_importance_type);
+  ss << gate_->SaveModelToString(gate_start, gate_num, feature_importance_type);
   ss << "\n";
 
   // Expert models
@@ -4061,9 +4353,31 @@ bool MixtureGBDT::LoadModelFromString(const char* buffer, size_t len) {
     }
   }
 
-  // Extract parameters
+  // Extract parameters. Header numerics come from an untrusted file, so
+  // parse defensively: a corrupted / hand-edited header should fail with a
+  // clean Fatal, not throw std::invalid_argument out of the loader or (worse)
+  // accept num_experts=0 and hit UB in Softmax at predict time.
   if (params.count("mixture_num_experts")) {
-    num_experts_ = std::stoi(params["mixture_num_experts"]);
+    int parsed_k = 0;
+    if (!Common::AtoiAndCheck(params["mixture_num_experts"].c_str(), &parsed_k)) {
+      Log::Fatal("Invalid mixture model header: mixture_num_experts='%s' is not an integer",
+                 params["mixture_num_experts"].c_str());
+      return false;
+    }
+    num_experts_ = parsed_k;
+  }
+  if (num_experts_ < 1) {
+    Log::Fatal("Invalid mixture model header: mixture_num_experts=%d (must be >= 1)",
+               num_experts_);
+    return false;
+  }
+  if (params.count("mixture_gate_iters_per_round")) {
+    int parsed_g = 1;
+    if (Common::AtoiAndCheck(params["mixture_gate_iters_per_round"].c_str(), &parsed_g)) {
+      gate_iters_per_round_ = std::max(1, parsed_g);
+    }
+  } else {
+    gate_iters_per_round_ = 1;  // pre-0.8.1 models did not serialize this
   }
   if (params.count("mixture_e_step_loss")) {
     e_step_loss_type_ = params["mixture_e_step_loss"];
@@ -4075,7 +4389,9 @@ bool MixtureGBDT::LoadModelFromString(const char* buffer, size_t len) {
   expert_variance_.assign(num_experts_, 1.0);
   gate_temperature_ = 1.0;
   if (params.count("mixture_gate_temperature")) {
-    gate_temperature_ = std::stod(params["mixture_gate_temperature"]);
+    try {
+      gate_temperature_ = std::stod(params["mixture_gate_temperature"]);
+    } catch (...) { /* keep default */ }
   }
   auto parse_csv_doubles = [&](const std::string& csv,
                                std::vector<double>* out, int expected) {
@@ -4331,7 +4647,14 @@ void MixtureGBDT::InitPredict(int start_iteration, int num_iteration, bool is_pr
   for (int k = 0; k < num_experts_; ++k) {
     experts_[k]->InitPredict(start_iteration, num_iteration, is_pred_contrib);
   }
-  gate_->InitPredict(start_iteration, num_iteration, is_pred_contrib);
+  // Iteration ranges arrive in MoE units; the gate holds gate_iters_per_round_
+  // GBDT iterations per MoE iteration (see SaveModelToString for the same
+  // scaling and the failure mode without it).
+  const int gate_start = (start_iteration > 0)
+      ? start_iteration * gate_iters_per_round_ : start_iteration;
+  const int gate_num = (num_iteration > 0)
+      ? num_iteration * gate_iters_per_round_ : num_iteration;
+  gate_->InitPredict(gate_start, gate_num, is_pred_contrib);
 }
 
 double MixtureGBDT::GetLeafValue(int tree_idx, int leaf_idx) const {
@@ -4355,7 +4678,7 @@ int MixtureGBDT::GetNumLeavesForTree(int tree_idx) const {
 }
 
 std::string MixtureGBDT::GetLoadedParam() const {
-  Log::Warning("MixtureGBDT::GetLoadedParam called, loaded_parameter_=%s", loaded_parameter_.c_str());
+  Log::Debug("MixtureGBDT::GetLoadedParam called, loaded_parameter_=%s", loaded_parameter_.c_str());
   return loaded_parameter_;
 }
 

--- a/src/boosting/mixture_gbdt.h
+++ b/src/boosting/mixture_gbdt.h
@@ -458,6 +458,43 @@ class MixtureGBDT : public GBDTBase {
   /*! \brief E-step loss type (l2, l1, quantile) */
   std::string e_step_loss_type_;
 
+  /*! \brief Gate GBDT iterations per MoE round (mixture_gate_iters_per_round).
+   *
+   * The gate accumulates `gate_iters_per_round_` GBDT iterations for every
+   * single MoE iteration, so "iteration i" means different tree offsets for
+   * the gate vs the experts whenever this is > 1. Every place that maps an
+   * iteration RANGE onto the gate must scale by this factor or the gate is
+   * silently truncated to 1/g of the trees that match the experts:
+   *   - SaveModelToString (truncated save, e.g. best_iteration via Python)
+   *   - InitPredict (predict with num_iteration)
+   *   - RollbackOneIter (early stopping rollback)
+   * Serialized in the model header so a loaded model keeps the scaling. */
+  int gate_iters_per_round_ = 1;
+
+  /*! \brief MoE iteration at which RefitExpertsAndGate last fired. Used by
+   * ShouldRefit's "elbo" trigger as a cooldown: a converged run plateaus its
+   * ELBO permanently, and without a cooldown the plateau detector fires every
+   * remaining iteration — each fire is a full O(total_trees · N) replay, so
+   * the tail of training degenerates to quadratic cost for zero benefit
+   * (refitting an already-refit fixed point is a no-op). After a fire, the
+   * elbo trigger stays quiet for `mixture_elbo_window` iterations so the
+   * window refills with post-refit values before it can fire again. */
+  int last_refit_moe_iter_ = -1000000;
+
+  /*! \brief Warn-once flag for unknown mixture_refit_trigger values (the
+   * check lives in const ShouldRefit(), called every iteration). */
+  mutable bool refit_trigger_warned_ = false;
+
+  /*! \brief True when expert_pred_* / gate_proba_* / yhat_ already reflect
+   * the current model state, so the next TrainOneIter can skip its leading
+   * Forward(). Set by the end-of-iteration Forward() refresh (which exists so
+   * training metrics are computed on the post-M-step model, matching the
+   * cadence of validation metrics); only set when temperature annealing is
+   * off, because the start-of-iter Forward would otherwise use a different
+   * gate temperature. Invalidated by anything that mutates model state
+   * outside TrainOneIter (rollback, config/data reset). */
+  bool forward_fresh_ = false;
+
   /*! \brief Per-expert noise scale (size K).
    *
    * Interpretation depends on e_step_loss_type_:
@@ -466,9 +503,9 @@ class MixtureGBDT : public GBDTBase {
    *   - "quantile"→ pseudo-scale carrying the same role as σ_k² (no proper density)
    *
    * Updated each iter from responsibility-weighted residuals when
-   * mixture_estimate_variance=true. Initialized to a sensible default
-   * (overall residual scale / K) and floored with kMixtureVarianceFloor to
-   * prevent collapse.
+   * mixture_estimate_variance=true. Initialized to the marginal label
+   * variance (or Laplace scale) as a worst-case default and floored with
+   * kMixtureEpsilon to prevent collapse.
    */
   std::vector<double> expert_variance_;
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -468,6 +468,50 @@ class Booster {
     *out_len = single_row_predictor->num_pred_in_one_row;
   }
 
+  /*!
+   * \brief Shared driver for the MoE predict entry points
+   *        (PredictRegime / PredictRegimeProba / PredictExpertPred).
+   *
+   * Centralizes three things the original free-function loops skipped:
+   *  - feature-count validation (every standard predict path errors on
+   *    ncol mismatch; these paths used to read past the row buffer),
+   *  - booster locking (MixtureGBDT::InitPredict mutates prediction state
+   *    on the gate and every expert, so this takes the same UNIQUE_LOCK
+   *    the rest of the mutating API uses),
+   *  - parameter parsing (start_iteration_predict / num_iteration_predict
+   *    were accepted and silently ignored before).
+   * The per-row callback runs under an OMP exception guard so a throw
+   * becomes a clean error return instead of std::terminate.
+   */
+  template <typename PerRowFn>
+  void PredictMoERows(int32_t nrow, int ncol, const char* parameter,
+                      const char* caller_name, PerRowFn per_row_fn) {
+    auto mixture = dynamic_cast<LightGBM::MixtureGBDT*>(boosting_.get());
+    if (mixture == nullptr) {
+      Log::Fatal("%s can only be used with MoE models", caller_name);
+    }
+    auto param = Config::Str2Map(parameter);
+    Config config;
+    config.Set(param);
+    OMP_SET_NUM_THREADS(config.num_threads);
+    if (!config.predict_disable_shape_check && ncol != boosting_->MaxFeatureIdx() + 1) {
+      Log::Fatal("The number of features in data (%d) is not the same as it was in training data (%d).\n"
+                 "You can set ``predict_disable_shape_check=true`` to discard this error, but please be aware what you are doing.",
+                 ncol, boosting_->MaxFeatureIdx() + 1);
+    }
+    UNIQUE_LOCK(mutex_)
+    mixture->InitPredict(config.start_iteration_predict,
+                         config.num_iteration_predict, false);
+    OMP_INIT_EX();
+    #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
+    for (int32_t i = 0; i < nrow; ++i) {
+      OMP_LOOP_EX_BEGIN();
+      per_row_fn(mixture, i);
+      OMP_LOOP_EX_END();
+    }
+    OMP_THROW_EX();
+  }
+
   std::shared_ptr<Predictor> CreatePredictor(int start_iteration, int num_iteration, int predict_type, int ncol, const Config& config) const {
     if (!config.predict_disable_shape_check && ncol != boosting_->MaxFeatureIdx() + 1) {
       Log::Fatal("The number of features in data (%d) is not the same as it was in training data (%d).\n" \
@@ -2861,25 +2905,15 @@ int LGBM_BoosterPredictRegime(BoosterHandle handle,
                                int32_t* out_result) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  auto mixture = dynamic_cast<LightGBM::MixtureGBDT*>(ref_booster->GetMutableBoosting());
-  if (mixture == nullptr) {
-    Log::Fatal("LGBM_BoosterPredictRegime can only be used with MoE models");
-  }
-
-  // Initialize for prediction (required before PredictRaw calls)
-  mixture->InitPredict(0, -1, false);
-
-  // Get row accessor based on data type
   auto get_row = RowFunctionFromDenseMatrix(data, nrow, ncol, data_type, is_row_major);
-
-  // Predict regime for each row
-  #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-  for (int32_t i = 0; i < nrow; ++i) {
-    auto row = get_row(i);
-    int regime;
-    mixture->PredictRegime(row.data(), &regime);
-    out_result[i] = regime;
-  }
+  ref_booster->PredictMoERows(
+      nrow, ncol, parameter, "LGBM_BoosterPredictRegime",
+      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i) {
+        auto row = get_row(i);
+        int regime;
+        mixture->PredictRegime(row.data(), &regime);
+        out_result[i] = regime;
+      });
   *out_len = nrow;
   API_END();
 }
@@ -2895,26 +2929,21 @@ int LGBM_BoosterPredictRegimeProba(BoosterHandle handle,
                                     double* out_result) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  auto mixture = dynamic_cast<LightGBM::MixtureGBDT*>(ref_booster->GetMutableBoosting());
-  if (mixture == nullptr) {
-    Log::Fatal("LGBM_BoosterPredictRegimeProba can only be used with MoE models");
-  }
-
-  // Initialize for prediction (required before PredictRaw calls)
-  mixture->InitPredict(0, -1, false);
-
-  int num_experts = mixture->NumExperts();
-
-  // Get row accessor based on data type
   auto get_row = RowFunctionFromDenseMatrix(data, nrow, ncol, data_type, is_row_major);
-
-  // Predict regime probabilities for each row
-  #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-  for (int32_t i = 0; i < nrow; ++i) {
-    auto row = get_row(i);
-    mixture->PredictRegimeProba(row.data(), out_result + static_cast<size_t>(i) * num_experts);
+  int64_t total = 0;
+  ref_booster->PredictMoERows(
+      nrow, ncol, parameter, "LGBM_BoosterPredictRegimeProba",
+      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i) {
+        auto row = get_row(i);
+        mixture->PredictRegimeProba(
+            row.data(),
+            out_result + static_cast<size_t>(i) * mixture->NumExperts());
+      });
+  {
+    auto mixture = dynamic_cast<const LightGBM::MixtureGBDT*>(ref_booster->GetBoosting());
+    total = static_cast<int64_t>(nrow) * (mixture != nullptr ? mixture->NumExperts() : 0);
   }
-  *out_len = static_cast<int64_t>(nrow) * num_experts;
+  *out_len = total;
   API_END();
 }
 
@@ -2929,26 +2958,21 @@ int LGBM_BoosterPredictExpertPred(BoosterHandle handle,
                                    double* out_result) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  auto mixture = dynamic_cast<LightGBM::MixtureGBDT*>(ref_booster->GetMutableBoosting());
-  if (mixture == nullptr) {
-    Log::Fatal("LGBM_BoosterPredictExpertPred can only be used with MoE models");
-  }
-
-  // Initialize for prediction (required before PredictRaw calls)
-  mixture->InitPredict(0, -1, false);
-
-  int num_experts = mixture->NumExperts();
-
-  // Get row accessor based on data type
   auto get_row = RowFunctionFromDenseMatrix(data, nrow, ncol, data_type, is_row_major);
-
-  // Predict expert predictions for each row
-  #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-  for (int32_t i = 0; i < nrow; ++i) {
-    auto row = get_row(i);
-    mixture->PredictExpertPred(row.data(), out_result + static_cast<size_t>(i) * num_experts);
+  int64_t total = 0;
+  ref_booster->PredictMoERows(
+      nrow, ncol, parameter, "LGBM_BoosterPredictExpertPred",
+      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i) {
+        auto row = get_row(i);
+        mixture->PredictExpertPred(
+            row.data(),
+            out_result + static_cast<size_t>(i) * mixture->NumExperts());
+      });
+  {
+    auto mixture = dynamic_cast<const LightGBM::MixtureGBDT*>(ref_booster->GetBoosting());
+    total = static_cast<int64_t>(nrow) * (mixture != nullptr ? mixture->NumExperts() : 0);
   }
-  *out_len = static_cast<int64_t>(nrow) * num_experts;
+  *out_len = total;
   API_END();
 }
 

--- a/src/io/config.cpp
+++ b/src/io/config.cpp
@@ -320,6 +320,15 @@ bool CheckMultiClassObjective(const std::string& objective) {
 }
 
 void Config::CheckParamConflict(const std::unordered_map<std::string, std::string>& params) {
+  // mixture_enable never enabled anything — MoE is activated solely by
+  // boosting=mixture. Users following the old parameter doc trained a plain
+  // GBDT with every mixture_* param silently ignored; make that loud.
+  if (mixture_enable && boosting != std::string("mixture")) {
+    Log::Warning("mixture_enable=true has no effect: Mixture-of-Experts mode "
+                 "is enabled by setting boosting=mixture. Training will "
+                 "proceed as boosting=%s with all mixture_* parameters "
+                 "ignored.", boosting.c_str());
+  }
   // check if objective, metric, and num_class match
   int num_class_check = num_class;
   bool objective_type_multiclass = CheckMultiClassObjective(objective) || (objective == std::string("custom") && num_class_check > 1);

--- a/src/io/config_auto.cpp
+++ b/src/io/config_auto.cpp
@@ -354,7 +354,6 @@ const std::unordered_set<std::string>& Config::parameter_set() {
   "mixture_regrow_per_fire",
   "mixture_regrow_min_remaining",
   "mixture_regrow_mode",
-  "mixture_predict_output",
   "mixture_gate_max_depth",
   "mixture_gate_num_leaves",
   "mixture_gate_learning_rate",
@@ -804,7 +803,6 @@ void Config::GetMembersFromString(const std::unordered_map<std::string, std::str
 
   GetString(params, "mixture_regrow_mode", &mixture_regrow_mode);
 
-  GetString(params, "mixture_predict_output", &mixture_predict_output);
 
   GetInt(params, "mixture_gate_max_depth", &mixture_gate_max_depth);
   CHECK_GT(mixture_gate_max_depth, 0);
@@ -1050,7 +1048,6 @@ std::string Config::SaveMembersToString() const {
   str_buf << "[mixture_regrow_per_fire: " << mixture_regrow_per_fire << "]\n";
   str_buf << "[mixture_regrow_min_remaining: " << mixture_regrow_min_remaining << "]\n";
   str_buf << "[mixture_regrow_mode: " << mixture_regrow_mode << "]\n";
-  str_buf << "[mixture_predict_output: " << mixture_predict_output << "]\n";
   str_buf << "[mixture_gate_max_depth: " << mixture_gate_max_depth << "]\n";
   str_buf << "[mixture_gate_num_leaves: " << mixture_gate_num_leaves << "]\n";
   str_buf << "[mixture_gate_learning_rate: " << mixture_gate_learning_rate << "]\n";
@@ -1253,7 +1250,6 @@ const std::unordered_map<std::string, std::vector<std::string>>& Config::paramet
     {"mixture_regrow_per_fire", {}},
     {"mixture_regrow_min_remaining", {}},
     {"mixture_regrow_mode", {}},
-    {"mixture_predict_output", {}},
     {"mixture_gate_max_depth", {}},
     {"mixture_gate_num_leaves", {}},
     {"mixture_gate_learning_rate", {}},
@@ -1456,7 +1452,6 @@ const std::unordered_map<std::string, std::string>& Config::ParameterTypes() {
     {"mixture_regrow_per_fire", "int"},
     {"mixture_regrow_min_remaining", "int"},
     {"mixture_regrow_mode", "string"},
-    {"mixture_predict_output", "string"},
     {"mixture_gate_max_depth", "int"},
     {"mixture_gate_num_leaves", "int"},
     {"mixture_gate_learning_rate", "double"},

--- a/tests/python_package_test/test_benchmark_methodology.py
+++ b/tests/python_package_test/test_benchmark_methodology.py
@@ -1,0 +1,184 @@
+# coding: utf-8
+"""Methodology invariants for the comparative-study benchmark.
+
+These lock in the audit fixes from the v0.8.1 benchmark overhaul so they
+cannot silently regress:
+
+  1. Feature/target alignment — row t sees series[..t], target is series[t+1]
+     ("next-day" means next-day; the pre-audit code had an off-by-one that
+     made it two-steps-ahead with the most informative lag discarded).
+  2. Causality — features computed on a truncated series must equal the
+     corresponding prefix of features computed on the full series (no
+     full-sample statistics like the old `vix - vix.mean()` leak).
+  3. Seed handling — synthetic generators are reproducible for a fixed seed
+     and vary across seeds; no global np.random state is mutated.
+  4. Protocol helpers — the ES-tail split never trains on the scoring fold,
+     and the chronological holdout split is disjoint and ordered.
+
+Market-data tests use the cached CSVs under examples/data_cache and are
+skipped when the cache is absent (CI without network); the synthetic ones
+always run.
+"""
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_EXAMPLES = os.path.join(os.path.dirname(__file__), "..", "..", "examples")
+sys.path.insert(0, _EXAMPLES)
+
+import benchmark as bm  # noqa: E402
+
+_CACHE = os.path.join(_EXAMPLES, "data_cache")
+
+
+def _has_cache(name):
+    return os.path.exists(os.path.join(_CACHE, name))
+
+
+requires_vix = pytest.mark.skipif(not _has_cache("vix_VIX.csv"),
+                                  reason="vix cache not present")
+requires_sp500 = pytest.mark.skipif(not _has_cache("sp500_GSPC.csv"),
+                                    reason="sp500 cache not present")
+
+
+# ---------------------------------------------------------------------------
+# 1. Alignment: lag-1 = today, target = tomorrow
+# ---------------------------------------------------------------------------
+@requires_vix
+def test_vix_alignment_next_day():
+    X, y, _ = bm.generate_vix_data()
+    # lag columns: col0 = lag-1 = s[t], col1 = lag-2 = s[t-1]
+    # → next row's lag-2 equals this row's lag-1
+    assert np.allclose(X[1:, 1], X[:-1, 0])
+    # target is the NEXT value of the lag-1 column (truly next-day)
+    assert np.allclose(y[:-1], X[1:, 0])
+
+
+@requires_sp500
+def test_sp500_basic_alignment_next_day():
+    X, y, _ = bm.generate_sp500_basic_data()
+    assert np.allclose(X[1:, 1], X[:-1, 0])
+    assert np.allclose(y[:-1], X[1:, 0])
+
+
+@requires_sp500
+def test_sp500_enriched_alignment_next_day():
+    X, y, _ = bm.generate_sp500_data()
+    # col0 is the lag-1 return = today's return; target = tomorrow's return
+    assert np.allclose(y[:-1], X[1:, 0])
+
+
+def test_fred_style_alignment_ar():
+    # fred_gdp follows the AR convention: target growth_t, lags t-1..t-4.
+    # Reconstruct with a deterministic series to avoid the network fetch.
+    growth = np.sin(np.arange(300) * 0.7) + np.linspace(0, 1, 300)
+    lag_max = 4
+    n = len(growth) - lag_max
+    lags = np.column_stack([growth[lag_max - k - 1: lag_max - k - 1 + n]
+                            for k in range(lag_max)])
+    y = growth[lag_max:]
+    # lag k=0 must be the value immediately before the target
+    assert np.allclose(lags[:, 0], growth[lag_max - 1: lag_max - 1 + n])
+    assert np.allclose(y[:-1], lags[1:, 0])
+
+
+# ---------------------------------------------------------------------------
+# 2. Causality: truncation invariance (catches any full-sample statistic)
+# ---------------------------------------------------------------------------
+@requires_vix
+def test_vix_features_do_not_depend_on_future():
+    close = bm._yf_download_close("^VIX", "2010-01-01", "2024-12-31", "vix_VIX")
+    vix = close.to_numpy(dtype=np.float64)
+
+    def features_up_to(n_keep):
+        v = vix[:n_keep]
+        em = np.cumsum(v) / np.arange(1, len(v) + 1)
+        c = v.copy()
+        c[1:] -= em[:-1]
+        c[0] = 0.0
+        return bm._add_ts_features(c)
+
+    full = features_up_to(len(vix))
+    part = features_up_to(500)
+    # If any feature used a full-sample statistic (the old vix.mean() leak),
+    # the prefix would differ.
+    assert np.allclose(full[:500], part)
+
+
+def test_ts_features_exclusive_of_current_index():
+    rng = np.random.default_rng(0)
+    y = rng.standard_normal(200)
+    feats = bm._add_ts_features(y)
+    # Changing y[i] must not change feats[i] (row i sees only y[:i]).
+    y2 = y.copy()
+    y2[100] += 100.0
+    feats2 = bm._add_ts_features(y2)
+    assert np.allclose(feats[100], feats2[100])
+    # ...but must change some later row.
+    assert not np.allclose(feats[101], feats2[101])
+
+
+# ---------------------------------------------------------------------------
+# 3. Seeds: reproducible, varying, and no global RNG pollution
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("gen", [bm.generate_synthetic_data, bm.generate_hmm_data])
+def test_synthetic_generators_seed_contract(gen):
+    X1, y1, _ = gen(seed=42)
+    X2, y2, _ = gen(seed=42)
+    X3, y3, _ = gen(seed=43)
+    assert np.allclose(X1, X2) and np.allclose(y1, y2)
+    assert not np.allclose(y1, y3)
+
+
+def test_generators_do_not_touch_global_rng():
+    np.random.seed(12345)
+    expected = np.random.RandomState(12345).rand(4)
+    bm.generate_synthetic_data(seed=7)
+    bm.generate_hmm_data(seed=7)
+    got = np.random.rand(4)
+    assert np.allclose(got, expected), (
+        "data generators mutated the global numpy RNG state")
+
+
+# ---------------------------------------------------------------------------
+# 4. Protocol helpers
+# ---------------------------------------------------------------------------
+def _load_study_module():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "comparative_study", os.path.join(_EXAMPLES, "comparative_study.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def study():
+    return _load_study_module()
+
+
+def test_es_tail_split_never_empty(study):
+    for n in (40, 100, 1000, 25):
+        cut = study._es_tail_split(n)
+        assert 0 < cut < n  # both fit and ES parts non-empty
+
+
+def test_chronological_split_disjoint_ordered(study):
+    X = np.arange(100).reshape(-1, 1).astype(float)
+    y = np.arange(100).astype(float)
+    Xs, ys, Xh, yh = study.chronological_split(X, y, 0.2)
+    assert len(Xh) == 20 and len(Xs) == 80
+    # holdout is strictly the chronological tail
+    assert ys.max() < yh.min()
+
+
+def test_cv_gap_embargo(study):
+    from sklearn.model_selection import TimeSeriesSplit
+    tscv = TimeSeriesSplit(n_splits=5, gap=study.CV_GAP)
+    X = np.zeros((200, 1))
+    for tr, va in tscv.split(X):
+        # at least a 1-row embargo between train end and valid start
+        assert va.min() - tr.max() >= study.CV_GAP + 1

--- a/tests/python_package_test/test_mixture.py
+++ b/tests/python_package_test/test_mixture.py
@@ -603,3 +603,201 @@ class TestMixtureRefitLeaves:
                 "sync with the refitted leaf values"
             ),
         )
+
+
+class _FakeMoEModel:
+    """Deterministic duck-typed stand-in for a trained MoE Booster.
+
+    Exposes exactly the interface prune_experts / merge_experts /
+    PrunedMoEModel consume, so merge/prune behavior can be tested without
+    relying on training to randomly produce correlated experts.
+    """
+
+    def __init__(self, expert_preds, regime_proba):
+        self._expert_preds = np.asarray(expert_preds, dtype=np.float64)
+        self._regime_proba = np.asarray(regime_proba, dtype=np.float64)
+
+    def is_mixture(self):
+        return True
+
+    def num_experts(self):
+        return self._expert_preds.shape[1]
+
+    def predict_regime_proba(self, X):
+        return self._regime_proba
+
+    def predict_regime(self, X):
+        return np.argmax(self._regime_proba, axis=1).astype(np.int32)
+
+    def predict_expert_pred(self, X):
+        return self._expert_preds
+
+    def predict(self, X):
+        return (self._regime_proba * self._expert_preds).sum(axis=1)
+
+
+class TestAutoKSelection:
+    """Test select_num_experts with IC-based criteria."""
+
+    def test_select_num_experts_bic(self):
+        """BIC criterion runs end-to-end (no dump_model dependency) and picks a candidate K."""
+        X, y, _ = make_toy_regression_data(n_samples=200)
+        train_data = lgb.Dataset(X, label=y, free_raw_data=False)
+
+        params = {
+            "boosting": "mixture",
+            "mixture_enable": True,
+            "objective": "regression",
+            "verbose": -1,
+            "num_leaves": 8,
+            "num_threads": 1,
+        }
+
+        best_k, results = lgb.select_num_experts(
+            params,
+            train_data,
+            k_range=[2, 3],
+            criterion="bic",
+            num_boost_round=10,
+            verbose=False,
+        )
+
+        assert best_k in (2, 3)
+        assert results["k_values"] == [2, 3]
+        # Every candidate must yield a finite BIC — inf means its evaluation failed.
+        assert all(np.isfinite(v) for v in results["criterion_values"])
+        # Parameter counts come from the model string and must be positive.
+        assert all(d["n_params"] > 0 for d in results["details"])
+
+
+class TestExpertPruning:
+    """Test prune_experts / merge_experts / PrunedMoEModel merge semantics."""
+
+    @staticmethod
+    def _make_chained_fake_model(n=400, seed=0):
+        """Three mutually-correlated experts with utilizations ~20/15/65%.
+
+        Noise levels are engineered so corr(E0, E1) > corr(E0, E2) and
+        corr(E1, E2): the merge order is then E1 -> E0 followed by
+        E0 -> E2 — a chained merge where survivor E0 later becomes a victim.
+        """
+        rng = np.random.RandomState(seed)
+        t = np.linspace(0.0, 1.0, n)
+        base = np.sin(2 * np.pi * t) + t
+        expert_preds = np.column_stack(
+            [
+                base + 1e-4 * rng.randn(n),  # E0: near-identical to E1
+                base + 1e-4 * rng.randn(n),  # E1
+                base + 5e-2 * rng.randn(n),  # E2: correlated, but less tightly
+            ]
+        )
+        # Gate: E0 wins the first 20% of rows, E1 the next 15%, E2 the rest.
+        regime_proba = np.full((n, 3), 0.1)
+        cut0 = int(n * 0.20)
+        cut1 = int(n * 0.35)
+        regime_proba[:cut0, 0] = 0.8
+        regime_proba[cut0:cut1, 1] = 0.8
+        regime_proba[cut1:, 2] = 0.8
+        regime_proba /= regime_proba.sum(axis=1, keepdims=True)
+        return _FakeMoEModel(expert_preds, regime_proba)
+
+    def test_prune_experts_chained_merge(self):
+        """Chained merges (E1 -> E0, then E0 -> E2) must not drop any expert."""
+        model = self._make_chained_fake_model()
+        X = np.zeros((400, 1))  # features are unused by the fake model
+
+        pruned = lgb.prune_experts(
+            model,
+            X,
+            correlation_threshold=0.95,
+            min_utilization=0.02,
+            print_report=False,
+        )
+
+        report = pruned.pruning_report
+        active = report["active_indices"]
+        # All three experts correlate, so the chain collapses everything into E2.
+        assert active == [2]
+        # merge_weights keys must all be active experts...
+        assert set(pruned.merge_weights).issubset(set(active))
+        # ...and the surviving group must cover the survivor plus ALL victims.
+        assert set(pruned.merge_weights[2]) == {0, 1, 2}
+        for survivor, weights in pruned.merge_weights.items():
+            assert survivor in weights
+            np.testing.assert_allclose(sum(weights.values()), 1.0, rtol=1e-12)
+        # No utilization mass lost: active groups cover ~100% of samples.
+        total_util = sum(u for u, _ in report["active_utilizations"].values())
+        np.testing.assert_allclose(total_util, 1.0, atol=1e-9)
+        # The pruned model still yields valid, normalised gate probabilities.
+        proba = pruned.predict_regime_proba(X)
+        assert proba.shape == (400, 1)
+        np.testing.assert_allclose(proba.sum(axis=1), 1.0, rtol=1e-9)
+        assert not np.any(np.isnan(pruned.predict(X)))
+
+    def test_pruned_model_merge_preserves_prediction(self):
+        """Merging two identical experts must leave the mixture prediction unchanged.
+
+        The victim's gate mass is donated to its survivor (not redistributed
+        proportionally over all experts), so E0 == E1 merged into one expert
+        is prediction-preserving even with a third, different expert present.
+        """
+        rng = np.random.RandomState(1)
+        n = 300
+        p = rng.randn(n)
+        q = p + 3.0 + rng.randn(n)  # a genuinely different third expert
+        expert_preds = np.column_stack([p, p, q])  # E0 == E1 exactly
+        raw = rng.rand(n, 3) + 0.1
+        regime_proba = raw / raw.sum(axis=1, keepdims=True)
+        model = _FakeMoEModel(expert_preds, regime_proba)
+        X = np.zeros((n, 1))
+
+        merged = lgb.merge_experts(model, X, [[0, 1]], print_report=False)
+
+        np.testing.assert_allclose(
+            merged.predict(X),
+            model.predict(X),
+            rtol=1e-12,
+            err_msg="merging two identical experts changed the mixture prediction",
+        )
+
+
+class TestMixtureIterationRange:
+    """Test start_iteration / num_iteration support in MoE predict methods."""
+
+    def test_predict_regime_num_iteration(self):
+        """num_iteration truncates the ensemble used by the MoE predict methods."""
+        X, y, _ = make_toy_regression_data(n_samples=300)
+        train_data = lgb.Dataset(X, label=y)
+
+        params = {
+            "boosting": "mixture",
+            "mixture_enable": True,
+            "mixture_num_experts": 3,
+            "objective": "regression",
+            "verbose": -1,
+            "num_leaves": 8,
+            "num_threads": 1,
+        }
+
+        bst = lgb.train(params, train_data, num_boost_round=30)
+
+        proba_early = bst.predict_regime_proba(X, num_iteration=5)
+        proba_full = bst.predict_regime_proba(X)
+
+        # Shape / validity hold regardless of the installed lib's support level.
+        assert proba_early.shape == proba_full.shape == (300, 3)
+        assert not np.any(np.isnan(proba_early))
+        np.testing.assert_allclose(proba_early.sum(axis=1), 1.0, rtol=1e-6)
+
+        # The sibling methods accept the same iteration-range arguments.
+        regimes_early = bst.predict_regime(X, num_iteration=5)
+        assert regimes_early.shape == (300,)
+        expert_early = bst.predict_expert_pred(X, num_iteration=5)
+        assert expert_early.shape == (300, 3)
+        assert not np.any(np.isnan(expert_early))
+
+        # Truncating to 5 of 30 iterations must change the gate output.
+        assert np.abs(proba_early - proba_full).max() > 1e-12, (
+            "num_iteration=5 produced gate probabilities identical to the full "
+            "model — start/num_iteration_predict appears to be ignored by the C side"
+        )


### PR DESCRIPTION
## Summary

Audit-fix release. A full review of the MoE implementation (C++ core, C API, config plumbing, Python package) surfaced one major training-correctness bug plus a set of serialization, API-hardening, and dead-parameter issues. All are fixed here, verified empirically, and covered by the existing + new test suites.

## Headline fix: stale sparse-activation training scores (default config affected)

`GBDT::SetBaggingData` only restricted the tree learner's data partition. `UpdateScore`'s fast path adds each new tree via the tree learner (partition samples only), and the out-of-bag branch is dead when bagging is disabled — so **every sample outside the subset kept a frozen training score forever**. Under `mixture_hard_m_step=true` (the default), the E-step computed responsibilities from stale expert predictions for every non-assigned sample, and `eval_train` diverged from `predict()` on the same data (0.22 RMSE gap in an 8-round repro; exact match after the fix).

`SetBaggingData` now records the subset complement and `UpdateScore` adds each new tree's contribution for those rows. Non-MoE paths are unaffected.

**Quality A/B vs v0.8.0** (3 synthetic regime datasets × 3 seeds, default hard M-step): 7/9 configs improve, mean RMSE −5%. Note: pre-0.8.1 hard-M-step benchmark numbers are not comparable to post-fix runs.

## Other fixes

**Serialization / model lifecycle** (`fix(moe)`)
- Gate scalars (`gate_temperature_`, `expert_bias_`, `expert_variance_`) now serialized at full precision — `lgb.train`'s internal save/load round-trip is bit-identical (was ~1e-6 routing drift on every trained model)
- `mixture_gate_iters_per_round` serialized; gate iteration ranges scaled in truncated save / `InitPredict` / `RollbackOneIter` (with `g>1`, best-iteration saves cut the gate to 1/g of the matching trees)
- `LoadModelFromString` validates header numerics (clean error instead of UB on corrupted files)
- `ResetConfig` rebuilds derived expert/gate configs (was handing experts the raw user config, re-enabling the issue #16 crash combination and wiping per-expert seeds)
- Expert-Choice affinity now uses the estimated σ_k² when `mixture_estimate_variance=true` (silently used the legacy y-scale-dependent alpha energy)
- Training metrics now evaluate the post-M-step model (train/valid logs were offset by one iteration)
- ELBO plateau refit trigger gets a cooldown (converged runs otherwise fire refit every remaining iteration — O(T²) tail)
- Enum-valued params warn on typos; warn-once for `refit_leaves` + early stopping semantics

**C API hardening** (`fix(c_api)`)
- MoE predict entry points: ncol validation (was an out-of-bounds heap read), booster locking (raced against training), `num_iteration`/`start_iteration` support, OMP exception guard

**Config cleanup** (`fix(config)`)
- Removed `mixture_predict_output` (registered + documented, never read anywhere)
- `mixture_enable` doc corrected + conflict warning (it never enabled MoE; users following the doc trained a plain GBDT silently)
- Repaired misplaced doc-annotation blocks; documented `kmeans_features` / `gmm_features` init options

**Python package** (`fix(python)`)
- `select_num_experts`: BIC/AIC/ICL (including the default) never worked — `dump_model()` is a Fatal stub for mixture models; parameter counts now parsed from `model_to_string()`. Also survives Dataset reuse across K candidates
- `prune_experts`: chained merges silently dropped experts (utilization no longer summed to 1); transitive victim→survivor remapping + gate-mass folding makes identical-expert merges prediction-preserving
- Regime/expert predicts: pandas-categorical handling, `num_iteration` support, honest docstrings
- 4 new tests covering the above

## Verification

- `test_mixture.py`: 26 passed (incl. new tests); `test_engine.py`: 164 passed (upstream regression)
- Empirical checks: save/load round-trip bit-identical; truncated-save gate/expert tree alignment at `g=2`; ncol mismatch raises cleanly; markov params survive round-trip; auto_k both criteria end-to-end; `eval_train == rmse(predict(train))` to 1e-9 for both hard/soft M-step
- v0.8.0 baseline built from a worktree for the quality A/B

🤖 Generated with [Claude Code](https://claude.com/claude-code)