### PR TITLE
docs(README): unify benchmark to the wide-space study

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Bottom line: v0.7 and v0.8 features are **opt-in safety nets for bad-init recove
 
 ## When to use MoE
 
-MoE's gating mechanism wins on regime-structured data — but the **honest baseline is not single-model naive LightGBM, it's a K-way ensemble of LightGBMs** with the same total tree budget. Simply averaging K independent models with different seeds gives variance reduction "for free"; the question is whether MoE's learned routing beats that. The holdout-first study below answers it: **MoE clearly wins on `synthetic` (−18.4 % vs the ensemble) — the case where the regime is a deterministic function of `X` — and on `fred_gdp` (−3.5 %), where the holdout window contains a genuine regime shock (COVID quarters). It ties on `hmm` and the `sp500` rows; on `vix` the standard search space loses (+5.8 %) but the v0.8.1 widened space (`--moe-space wide`) recovers a −6.5 % win.** Compute trade-off: MoE costs **3–10 ×** naive single-model time and **0.8–4 ×** naive-ensemble time per trial. Net rule: try MoE when (a) you believe the regime is observable from your features or your evaluation window contains regime shifts, and (b) your wall time has 5–10 × headroom over single-model LightGBM.
+MoE's gating mechanism wins on regime-structured data — but the **honest baseline is not single-model naive LightGBM, it's a K-way ensemble of LightGBMs** with the same total tree budget. Simply averaging K independent models with different seeds gives variance reduction "for free"; the question is whether MoE's learned routing beats that. The study below answers it: **MoE clearly wins on `synthetic` (−19.7 % vs the ensemble) — the case where the regime is a deterministic function of `X` —, on `vix` (−5.0 %), and on `fred_gdp` (−2.4 %), where the holdout window contains a genuine regime shock (COVID quarters). It ties or loses everywhere there is no regime structure to route on.** Compute trade-off: MoE costs roughly **4–10 ×** naive single-model time and **4–5 ×** naive-ensemble time per trial. Net rule: try MoE when (a) you believe the regime is observable from your features or your evaluation window contains regime shifts, and (b) your wall time has 5–10 × headroom over single-model LightGBM.
 
 ## Benchmark — holdout-first study (naive vs naive-ensemble vs MoE)
 
@@ -184,86 +184,80 @@ MoE's gating mechanism wins on regime-structured data — but the **honest basel
 > regime proxy, precisely the signal a gate exploits); (4) `sp500`/`vix` targets were
 > misaligned by one step. All four are fixed; the old report remains at
 > [`bench_results/study_500_report.md`](bench_results/study_500_report.md) for archaeology.
-> Two headline results changed: **the old `vix` win (−6.9 %) is retracted** (it was an
-> artifact of the leak + selection bias), and **`fred_gdp` flipped from a loss to a win**
-> (the old protocol never evaluated the COVID-containing tail).
+> The old `vix` −6.9 % win was retracted as a leak artifact, then re-established honestly
+> under the fixed protocol (−5.0 % below); the old `fred_gdp` loss flipped to a win once a
+> holdout containing the COVID quarters was actually evaluated.
 
 Protocol: the final 20 % of every series is a **chronological holdout never seen by Optuna**.
 Hyperparameters are selected by expanding-window time-series CV (5 folds, 1-step embargo,
 early stopping on the chronological tail of each training window — never on the scoring
 fold) over the first 80 %; the CV winner is retrained once and scored once on the holdout.
-300 Optuna trials per (variant × dataset × seed), 3 seeds (synthetic/hmm redraw data,
-TPE + models reseed), reported as holdout RMSE mean ± std. Deterministic per seed
-(`--n-jobs 1`); build provenance (git commit, lib sha256, dataset sha256s) is recorded in
-the output JSON. Full report: [`bench_results/meth2_v081/`](bench_results/meth2_v081/).
+**500 Optuna trials** per (variant × dataset × seed) over the full MoE search space
+(`--moe-space wide`: all inits including `gmm_features`/`kmeans_features`, K ∈ 2–6, gate
+temperature annealing, entropy λ, expert dropout, load-balance α, refit/regrow), 3 seeds
+(synthetic/hmm redraw data, TPE + models reseed), reported as holdout RMSE mean ± std.
+Deterministic per seed (`--n-jobs 1`); build provenance (git commit, lib sha256, dataset
+sha256s) is recorded in the output JSON. Raw outputs: [`bench_results/wide_v081/`](bench_results/wide_v081/).
 
 The third variant — **`naive-ensemble`** — is a K-way (K ∈ {2, 3, 4}) seed-ensemble of
 standard LightGBMs that share hyperparameters but diverge per-member via the `seed`
 master-seed override. Same total tree budget as MoE (K × `num_boost_round`), same Optuna
-search space as `naive-lightgbm` plus K. It is the fair ablation for "is gating doing real
-work, or would any K-way ensemble suffice?" — see [PR #33](https://github.com/kyo219/LightGBM-MoE/pull/33).
+search space as `naive-lightgbm` plus K, same 500-trial budget. It is the fair ablation for
+"is gating doing real work, or would any K-way ensemble suffice?" — see [PR #33](https://github.com/kyo219/LightGBM-MoE/pull/33).
 
-### Regime datasets (holdout RMSE, mean ± std over 3 seeds)
+### Results (holdout RMSE, mean ± std over 3 seeds)
+
+**Regime datasets** — where the gating hypothesis is tested:
 
 | Dataset | Shape | naive | ensemble | MoE | MoE vs naive | **MoE vs ensemble** *(the fair test)* |
 |---|---|---|---|---|---|---|
-| `synthetic` | 2000 × 5 | 4.812 ± 0.340 | 4.706 ± 0.372 | **3.842 ± 0.290** | −20.2 % | **−18.4 %** 🎯 |
-| `fred_gdp` | 311 × 12 | 1.528 ± 0.020 | 1.543 ± 0.007 | **1.489 ± 0.014** | −2.6 % | **−3.5 %** 🎯 |
-| `hmm` | 2000 × 5 | 2.218 ± 0.244 | 2.206 ± 0.242 | 2.210 ± 0.243 | −0.3 % | +0.2 % *(tie)* |
-| `vix` | 3762 × 13 | 1.794 ± 0.063 | **1.752 ± 0.044** | 1.854 ± 0.173 | +3.3 % | +5.8 % *(ensemble wins)* |
-| `sp500_basic` (13 feat) | 3761 × 13 | 0.01104 | 0.01104 | 0.01102 | −0.2 % | −0.1 % *(noise floor)* |
-| `sp500` (28 feat) | 3711 × 28 | 0.01105 | 0.01105 | 0.01108 | +0.3 % | +0.3 % *(noise floor)* |
+| `synthetic` | 2000 × 5 | 4.840 ± 0.311 | 4.723 ± 0.327 | **3.792 ± 0.249** | −21.7 % | **−19.7 %** 🎯 |
+| `vix` | 3763 × 13 | 1.768 ± 0.091 | 1.739 ± 0.051 | **1.653 ± 0.030** | −6.5 % | **−5.0 %** 🎯 |
+| `fred_gdp` | 311 × 12 | 1.542 ± 0.026 | 1.530 ± 0.008 | **1.494 ± 0.010** | −3.1 % | **−2.4 %** 🎯 |
+| `hmm` | 2000 × 5 | 2.216 ± 0.244 | 2.208 ± 0.242 | 2.255 ± 0.229 | +1.8 % | +2.1 % *(ensemble wins)* |
 
-The pattern is sharper than the old report's: MoE wins where regime structure is
-**strong and observable** (`synthetic` — regime is a deterministic function of X) or where
-the **evaluation window itself contains a regime break** (`fred_gdp` holdout spans COVID).
-It ties where the regime is weakly observable (`hmm` — two noisy proxy columns) or the
-target is at the noise floor (`sp500`). Under this standard search space MoE loses `vix`
-now that the regime-proxy leak is gone — but the widened space recovers a legitimate
-`vix` win (see [Settings that won](#settings-that-won--search-every-knob)).
-
-### Non-regime control datasets (Grinsztajn et al. 2022 regression track)
-
-Four standard i.i.d. tabular regression datasets (OpenML: `houses` 537, `cpu_act` 197,
-`elevators` 216, `wine_quality` 287; numeric features, seeded shuffle, 10k-row cap). These
-have **no regime structure** — the control group: MoE should at best tie naive here, and a
-win would mean the "regime" story is confounded with generic extra capacity.
+**Non-regime control datasets** (Grinsztajn et al. 2022 regression track) — standard i.i.d.
+tabular regression with **no regime structure**. The control group: if MoE beat the
+ensemble here too, the "regime routing" story would be confounded with generic capacity.
 
 | Dataset | Shape | naive | ensemble | MoE | MoE vs naive | **MoE vs ensemble** |
 |---|---|---|---|---|---|---|
-| `houses` | 10000 × 8 | 49805 ± 962 | 48924 ± 849 | 48931 ± 672 | −1.8 % | **+0.0 %** |
-| `cpu_act` | 8192 × 21 | 2.513 ± 0.32 | 2.419 ± 0.28 | 2.425 ± 0.29 | −3.5 % | **+0.3 %** |
-| `elevators` | 10000 × 18 | 0.002384 | 0.002302 | 0.002298 | −3.6 % | **−0.2 %** |
-| `wine_quality` | 6497 × 11 | 0.6155 ± 0.016 | 0.6082 ± 0.012 | 0.6192 ± 0.010 | +0.6 % | **+1.8 %** |
+| `houses` | 10000 × 8 | 50109 ± 902 | 48816 ± 1005 | 48623 ± 683 | −3.0 % | **-0.4 %** |
+| `cpu_act` | 8192 × 21 | 2.498 ± 0.30 | 2.4485 ± 0.336 | 2.431 ± 0.33 | −2.7 % | **-0.7 %** |
+| `elevators` | 10000 × 18 | 0.002357 | 0.002296 | 0.002299 | −2.5 % | **+0.1 %** |
+| `wine_quality` | 6497 × 11 | 0.6146 ± 0.014 | 0.6065 ± 0.013 | 0.6119 ± 0.016 | −0.4 % | **+0.9 %** |
 
-This is the attribution result the regime table needs: on non-regime data MoE beats naive
-by 2–4 % — **but so does the capacity-matched seed-ensemble, and MoE never beats the
-ensemble here** (within ±0.5 % on three of four, one small loss). MoE's advantage over
-naive on i.i.d. tabular data is fully explained by generic K-way capacity; learned routing
-adds nothing without regime/cluster structure to route on. Combined with the regime table
-(where MoE beats the *same* capacity-matched ensemble by 18.4 % on `synthetic` and 3.5 % on
-`fred_gdp`), the regime-routing claim survives its control.
+Read the two tables together. On regime data MoE beats the **capacity-matched** ensemble
+wherever the regime is strongly observable (`synthetic`), a volatility regime is present
+(`vix`), or the holdout crosses a regime break (`fred_gdp`); it loses `hmm`, where the
+regime is only weakly observable through two noisy proxy columns — the honest limitation.
+On the controls MoE beats *naive* by 2–3 % — **but it merely matches the ensemble,
+within ±1 % on all four**: on i.i.d. data MoE's gain over naive is fully explained by
+generic K-way capacity, and learned routing adds nothing without structure to route on.
+That is the attribution result the regime wins need.
 
-### Compute cost (median train s/fold across trials, v0.8.1)
+*(The two `sp500` next-day-return datasets from earlier reports sit at the irreducible
+noise floor for every variant under this protocol — all differences < 0.4 % — and are kept
+out of the headline table; generators and measurements remain in the repo
+([`bench_results/meth2_v081/`](bench_results/meth2_v081/)).)*
+
+### Compute cost (median train s/fold across trials)
 
 | Dataset | naive | ensemble | MoE | MoE / naive | MoE / ensemble |
 |---|---|---|---|---|---|
-| `synthetic` | 0.110 | 0.321 | 0.327 | 3.0 × | 1.0 × |
-| `fred_gdp` | 0.014 | 0.031 | 0.133 | 9.5 × | 4.3 × |
-| `hmm` | 0.031 | 0.093 | 0.177 | 5.7 × | 1.9 × |
-| `vix` | 0.049 | 0.149 | 0.285 | 5.8 × | 1.9 × |
-| `sp500_basic` | 0.022 | 0.057 | 0.143 | 6.5 × | 2.5 × |
-| `sp500` | 0.023 | 0.133 | 0.103 | 4.5 × | 0.8 × |
-
-> **The sp500 pair is a controlled feature-engineering ablation on the same raw series**:
-> only the feature set changes between rows, identical CV / Optuna budget / seed. All three
-> variants are essentially tied at the noise floor under both feature sets — the
-> next-day-log-return objective appears irreducible under any architecture we've tried.
+| `synthetic` | 0.124 | 0.294 | 1.180 | 9.5 × | 4.0 × |
+| `vix` | 0.066 | 0.124 | 0.490 | 7.4 × | 4.0 × |
+| `fred_gdp` | 0.016 | 0.019 | 0.541 | 34 × *(tiny data, fixed overhead)* | 28 × |
+| `hmm` | 0.044 | 0.078 | 0.365 | 8.3 × | 4.7 × |
+| `houses` | 0.251 | 0.633 | 2.503 | 10.0 × | 4.0 × |
+| `cpu_act` | 0.159 | 0.386 | 1.166 | 7.3 × | 3.0 × |
+| `elevators` | 0.151 | 0.269 | 1.394 | 9.2 × | 5.2 × |
+| `wine_quality` | 0.354 | 0.868 | 1.471 | 4.2 × | 1.7 × |
 
 ### Datasets
 
 Regime datasets span the regime-switching applicability spectrum: one MoE-ideal synthetic,
-three real-world series (canonical references in the regime-switching literature), and one
+two real-world series (canonical references in the regime-switching literature), and one
 HMM with known ground-truth labels. All time-series generators follow the audited
 alignment convention: **row t's features use information available at time t only; the
 target is the value at t + 1** (verified by `tests/python_package_test/test_benchmark_methodology.py`).
@@ -281,31 +275,17 @@ target is the value at t + 1** (verified by `tests/python_package_test/test_benc
 
   The two regimes use *opposite-sign* coefficients on the same features — a single GBDT is forced to average them, which is exactly the failure mode MoE is built to avoid.
 
+#### `vix` — CBOE Volatility Index, daily level (~3760 × 13)
+
+- **Source**: Yahoo Finance, symbol [`^VIX`](https://finance.yahoo.com/quote/%5EVIX/history), `2010-01-01` to `2024-12-31`.
+- **Index methodology**: [CBOE VIX](https://www.cboe.com/tradable_products/vix/).
+- **Construction**: target is next-day VIX level. Features: lagged VIX at lags {1, 2, 3, 5, 10} plus MA / rolling-volatility features computed on a **causally demeaned** series (expanding past-only mean — the pre-v0.8.1 version demeaned with the full-sample mean, which leaked "above/below the all-time mean" into the features; the current win is measured leak-free). Generator: `generate_vix_data`.
+
 #### `fred_gdp` — US Real GDP, Hamilton-style MS-AR(4) (~310 × 12)
 
 - **Source**: FRED series [`GDPC1`](https://fred.stlouisfed.org/series/GDPC1) — Real Gross Domestic Product, Chained 2017 Dollars, Quarterly, Seasonally Adjusted Annual Rate (BEA via FRED, no auth, CSV endpoint).
 - **Methodology cite**: Hamilton, J. D. (1989). *A New Approach to the Economic Analysis of Nonstationary Time Series and the Business Cycle.* **Econometrica** 57(2), 357-384. <https://www.jstor.org/stable/1912559>.
 - **Construction**: target is the quarterly growth rate `100·Δlog(GDP)`; features are 4 lags of growth (Hamilton's MS-AR(4)) plus engineered MA / volatility / regime-proxy features. The regime (expansion / recession) is genuinely latent — there is no oracle column. The chronological holdout contains the COVID quarters, which is exactly where MoE's win comes from. Generator: `generate_fred_gdp_data`.
-
-#### `sp500_basic` & `sp500` — S&P 500 daily log returns, two feature sets
-
-The S&P 500 series is included in **two parallel configurations** to test how MoE's lift scales with feature richness:
-
-- **`sp500_basic`** (~3760 × 13): minimal — lagged returns at {1, 2, 3, 5, 10} (lag-1 = today's return) plus the standard MA / rolling-vol / regime-proxy block (`generate_sp500_basic_data`).
-- **`sp500`** (~3710 × 28): practitioner-grade — multi-horizon lags, momentum, realized volatility + ratio, MA crossovers, RSI(14)/RSI(30), rolling skew/kurtosis, Bollinger z-score, drawdowns, positive-day fractions (`generate_sp500_data`).
-
-Common to both:
-
-- **Source**: Yahoo Finance, symbol [`^GSPC`](https://finance.yahoo.com/quote/%5EGSPC/history) (default range `2010-01-01` to `2024-12-31`).
-- **Index methodology**: [S&P Dow Jones Indices, S&P 500](https://www.spglobal.com/spdji/en/indices/equity/sp-500/).
-- **Target**: next-day log return (deliberately hard predictive setup).
-- **Regime structure**: latent (low-vol vs high-vol periods).
-
-#### `vix` — CBOE Volatility Index, daily level (~3760 × 13)
-
-- **Source**: Yahoo Finance, symbol [`^VIX`](https://finance.yahoo.com/quote/%5EVIX/history) (same date range as `sp500`).
-- **Index methodology**: [CBOE VIX](https://www.cboe.com/tradable_products/vix/).
-- **Construction**: target is next-day VIX level. Features: lagged VIX at lags {1, 2, 3, 5, 10} plus MA / rolling-volatility features computed on a **causally demeaned** series (expanding past-only mean — the pre-v0.8.1 version demeaned with the full-sample mean, which leaked "above/below the all-time mean" into the features and inflated MoE's score; that win is retracted). Generator: `generate_vix_data`.
 
 #### `hmm` — 3-state Gaussian HMM with known regime labels (2000 × 5)
 
@@ -327,22 +307,10 @@ subsequent runs are offline.
 
 ### Settings that won — search every knob
 
-Re-measured under the fixed protocol with the widened space (`--moe-space wide`, 500
-trials × 3 seeds; the pre-v0.8.1 per-knob table came from the retracted methodology and is
-superseded). Two headline effects of the wider space:
-
-- **`vix` becomes a legitimate MoE win: −6.5 % vs naive and −5.0 % vs the
-  capacity-matched seed-ensemble** (1.653 ± 0.03 vs 1.768 ± 0.09 / 1.739 ± 0.05, all at the
-  same 500-trial budget) — the standard space had MoE *losing* vix. The winning configs are
-  driven by the previously-frozen knobs (gate temperature ≈ 2.4–2.9 with annealing, expert
-  dropout 0.1–0.2, soft M-step), **not** by the new init choices. So the retracted
-  pre-v0.8.1 vix win is re-established under the leak-free holdout protocol — by tuning
-  knobs the old study never searched. `synthetic` holds at −19.7 % vs the ensemble and
-  `fred_gdp` at −2.4 % under the wide space.
-- **`hmm` does not improve** (+1.8 % vs naive) — the weakly-observable-regime case remains
-  MoE's honest limitation, wider search or not.
-
-Across the 24 winning configs (8 datasets × 3 seeds):
+From the 24 winning MoE configs (8 datasets × 3 seeds). The headline: the knobs that were
+**frozen at their defaults before v0.8.1** are doing real work — the `vix` win in
+particular is driven by gate temperature annealing (T ≈ 2.4–2.9 → annealed down), expert
+dropout 0.1–0.2 and the soft M-step, not by any init choice.
 
 | Knob | Finding |
 |---|---|
@@ -352,18 +320,13 @@ Across the 24 winning configs (8 datasets × 3 seeds):
 | `mixture_gate_entropy_lambda` | active in **17 / 19** gate-ful winners — was frozen at 0 |
 | gate temperature | `T_init > 1.5` in **12 / 19** — the old fixed `T = 1.0` was leaving accuracy on the table |
 | `mixture_refit_leaves` | **ON in 15 / 24 winners** — updates the v0.8 finding ("Optuna declines refit on 5/6 datasets"): after the v0.8.1 stale-score fix and ELBO-trigger cooldown, leaf refit is an ordinary useful knob rather than a bad-init-only safety net |
+| `mixture_hard_m_step` | soft (False) in 16 / 24 — the hard-M-step default is *not* a universal winner |
 | `mixture_init` / `mixture_gate_type` / `mixture_routing_mode` / K | no universal winner (gmm 8, uniform 6, random 5, feature-space inits 4, tree 1 / gbdt 11, leaf_reuse 8, none 5 / token 14, expert 10 / K spread 2–6) — **search them** |
 
 ```bash
-# Full headline study (holdout protocol, 3 seeds; deterministic per seed)
-python examples/comparative_study.py --trials 300 --seeds 42,43,44 \
-    --out bench_results/study_holdout.json
-
-# Wide MoE search space (adds gmm_features/kmeans_features inits, K up to 6,
-# gate temperature annealing, entropy lambda, dropout, load-balance alpha)
+# Full headline study (holdout protocol, wide MoE space, 3 seeds; deterministic per seed)
 python examples/comparative_study.py --trials 500 --seeds 42,43,44 \
-    --variants naive-lightgbm,moe --moe-space wide \
-    --out bench_results/study_wide.json
+    --moe-space wide --out bench_results/study_wide.json
 
 # Smoke test (~2 min)
 python examples/comparative_study.py --trials 10 --seeds 42 \


### PR DESCRIPTION
Per review feedback: the standard-vs-wide split reflected measurement history, not reader needs. The README now presents one study — **500 trials × 3 seeds, full wide MoE space, all variants at equal budget** (control-group ensembles re-run at 500 trials for parity).

| | vs naive | vs ensemble |
|---|---|---|
| synthetic | −21.7 % | **−19.7 %** |
| vix | −6.5 % | **−5.0 %** |
| fred_gdp | −3.1 % | **−2.4 %** |
| hmm | +1.8 % | +2.1 % |
| controls ×4 | −0.4…−3.0 % | **±1 % (tie)** |

sp500 rows demoted to a footnote (noise floor). "Settings that won" now leads with the commonly-selected parameters — the previously-frozen knobs (temperature annealing, dropout, load-balance α, entropy λ) are active in ~90 % of the 24 winners and drive the vix result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)