### PR TITLE
chore: commit bench summaries/reports, sync README.ja.md, refresh Quick Start

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -47,8 +47,8 @@ import lightgbm_moe as lgb
 params = {
     'boosting': 'mixture',           # MoE モードを有効化
     'mixture_num_experts': 3,        # Expert 数
-    'mixture_gate_type': 'gbdt',     # 500-trial / 5-dataset スタディで全データセットで勝者
-    'mixture_routing_mode': 'token_choice',
+    'mixture_gate_type': 'gbdt',     # 勝者設定の最頻値 (11/24)。'leaf_reuse'/'none' も探索を
+    'mixture_routing_mode': 'token_choice',  # 最頻値 (14/24)。'expert_choice' も探索を
     'objective': 'regression',
     'metric': 'rmse',
     'verbose': -1,
@@ -73,26 +73,56 @@ expert_preds = model.predict_expert_pred(X_test)    # 各 expert の予測 (N, K
 
 ## MoE が効く条件
 
-下記 5 dataset (sp500 のみ feature set 違いで 2 パターン並列、計 6 行) / 500-trial スタディの結果: MoE は全 dataset で精度を改善するが、改善幅は sub-percent (`sp500_basic`: 実質 tie) から大きい (**`vix` −15.1 %**、regime 構造が一番くっきりしている) まで dataset 依存。注目すべきは **`sp500_basic` (13 特徴量) → `sp500` (28 特徴量) で MoE の優位性が伸びる** こと — 特徴量が regime をより観測可能にするほど MoE が強くなる、という構図が同じ生データで再現できる。計算コストも dataset 依存: 多くは **1.7–4.8 倍** だが、`fred_gdp` と enriched `sp500` は **0.85–2.2 倍** と軽く、特に enriched `sp500` では MoE のほうが naive より **速い**。ルール: 最後の数 % まで効かせたい *かつ* wall time に 2-5 倍の余裕がある場面で MoE を試す。
+MoE の gating が勝つのは regime 構造のあるデータ — ただし**正直なベースラインは単一の naive LightGBM ではなく、同じ総ツリー予算を持つ K-way LightGBM アンサンブル**です。seed を変えた K 個のモデルの単純平均は「タダで」分散低減を得られるので、問うべきは「学習されたルーティングがそれに勝つか」。下のスタディの答え: **regime が `X` の決定論的関数である `synthetic` で −19.7 %(vs アンサンブル)、`vix` で −5.0 %、holdout 期間に本物の regime ショック(COVID 四半期)を含む `fred_gdp` で −2.4 % 勝つ。ルーティングすべき regime 構造がない場所では引き分けか負け。** 計算コスト: MoE は naive の約 **4–10 倍**、アンサンブルの **4–5 倍**(trial あたり)。ルール: (a) regime が特徴量から観測可能だと信じられる、または評価期間に regime シフトが含まれる、かつ (b) wall time に単一 LightGBM の 5–10 倍の余裕がある場面で MoE を試す。
 
-## ベンチマーク — 500-trial スタディ (naive-lightgbm vs MoE、5 dataset)
+## ベンチマーク — holdout ファーストのスタディ (naive vs naive-ensemble vs MoE)
 
-5-fold time-series CV、500 Optuna trials × (variant × dataset)、5 dataset (synthetic 理想 → 実マクロ/金融 → controlled-latent)。完全レポート: [`bench_results/study_500_report.md`](bench_results/study_500_report.md)、方法論と dataset 別推奨: [docs/moe/benchmark.md](docs/moe/benchmark.md)。
+> **方法論ノート (v0.8.1)。** この表は v0.8.1 以前のベンチマークを置き換えるものです。旧版には監査で見つかった 4 つの欠陥がありました: (1) ヘッドラインが「500 Optuna trial の CV スコア最小値」— 選択指標そのものであり、探索空間が大きいほど有利になる winner's-curse バイアス付き推定値; (2) early stopping が採点フォールドで検証していた; (3) `vix` の特徴量が全期間平均をリークしていた(平均回帰系列に対する lookahead であり、まさに gate が悪用する regime プロキシ); (4) `sp500`/`vix` のターゲットが 1 ステップずれていた。4 つとも修正済み。旧レポートは [`bench_results/study_500_report.md`](bench_results/study_500_report.md) に記録として残置。**旧 `vix` の勝ち(−6.9 %)はリーク由来として撤回した上で、修正後プロトコルで正当に取り直し(下記 −5.0 %)**。旧 `fred_gdp` の負けは、COVID 四半期を含む holdout を実際に評価したら勝ちに反転しました。
 
-| Dataset | Shape | naive-lightgbm 最良 | MoE 最良 | Δ RMSE | 速度 (MoE / naive、fold あたり中央値秒) |
+プロトコル: 各系列の末尾 20 % は **Optuna が一度も見ない chronological holdout**。ハイパーパラメータは先頭 80 % 上の expanding-window 時系列 CV(5 fold、1 ステップ embargo、early stopping は各訓練窓の末尾で行い採点フォールドでは行わない)で選択し、CV 勝者を 1 回だけ再学習して holdout を 1 回だけ採点。**500 Optuna trials** × (variant × dataset × seed)、MoE は全探索空間(`--moe-space wide`: `gmm_features`/`kmeans_features` を含む全 init、K ∈ 2–6、gate 温度アニーリング、entropy λ、expert dropout、load-balance α、refit/regrow)、3 seeds(synthetic/hmm はデータ再抽選、TPE とモデルも再シード)、holdout RMSE mean ± std で報告。seed ごとに決定的(`--n-jobs 1`)。ビルドとデータの provenance(git commit、lib sha256、データ sha256)は出力 JSON に記録。生データ: [`bench_results/wide_v081/`](bench_results/wide_v081/)。
+
+第 3 の variant **`naive-ensemble`** は、ハイパーパラメータを共有し `seed` だけ member ごとに変えた K-way (K ∈ {2, 3, 4}) の標準 LightGBM アンサンブル。総ツリー予算は MoE と同じ (K × `num_boost_round`)、探索空間は `naive-lightgbm` + K、trial 数も同じ。「gating は本当に仕事をしているのか、それとも K-way アンサンブルなら何でもいいのか」に答えるフェアな ablation です — [PR #33](https://github.com/kyo219/LightGBM-MoE/pull/33)。
+
+### 結果 (holdout RMSE、3 seeds の mean ± std)
+
+**Regime データセット** — gating 仮説が試される場所:
+
+| Dataset | Shape | naive | ensemble | MoE | MoE vs naive | **MoE vs ensemble** *(フェアテスト)* |
+|---|---|---|---|---|---|---|
+| `synthetic` | 2000 × 5 | 4.840 ± 0.311 | 4.723 ± 0.327 | **3.792 ± 0.249** | −21.7 % | **−19.7 %** 🎯 |
+| `vix` | 3763 × 13 | 1.768 ± 0.091 | 1.739 ± 0.051 | **1.653 ± 0.030** | −6.5 % | **−5.0 %** 🎯 |
+| `fred_gdp` | 311 × 12 | 1.542 ± 0.026 | 1.530 ± 0.008 | **1.494 ± 0.010** | −3.1 % | **−2.4 %** 🎯 |
+| `hmm` | 2000 × 5 | 2.216 ± 0.244 | 2.208 ± 0.242 | 2.255 ± 0.229 | +1.8 % | +2.1 % *(ensemble 勝ち)* |
+
+**非 regime コントロールデータセット** (Grinsztajn et al. 2022 の回帰トラック) — regime 構造のない標準的な i.i.d. テーブルデータ回帰。対照群: もしここでも MoE がアンサンブルに勝つなら、「regime ルーティング」の主張は単なる容量効果と交絡していることになる。
+
+| Dataset | Shape | naive | ensemble | MoE | MoE vs naive | **MoE vs ensemble** |
+|---|---|---|---|---|---|---|
+| `houses` | 10000 × 8 | 50109 ± 902 | 48816 ± 1005 | 48623 ± 683 | −3.0 % | **−0.4 %** |
+| `cpu_act` | 8192 × 21 | 2.498 ± 0.30 | 2.4485 ± 0.336 | 2.431 ± 0.33 | −2.7 % | **−0.7 %** |
+| `elevators` | 10000 × 18 | 0.002357 | 0.002296 | 0.002299 | −2.5 % | **+0.1 %** |
+| `wine_quality` | 6497 × 11 | 0.6146 ± 0.014 | 0.6065 ± 0.013 | 0.6119 ± 0.016 | −0.4 % | **+0.9 %** |
+
+2 つの表はセットで読んでください。regime データでは、regime が強く観測可能な場合 (`synthetic`)、volatility regime がある場合 (`vix`)、holdout が regime 断絶をまたぐ場合 (`fred_gdp`) に **容量を揃えたアンサンブル**に勝ちます。負けるのは `hmm` — regime がノイズの多いプロキシ 2 列からしか観測できないケースで、これが正直な限界です。コントロール群では MoE は *naive* に 2–3 % 勝ちますが、**アンサンブルとは全 4 データセットで ±1 % 以内の互角**: i.i.d. データでの naive に対するゲインは K-way 容量で完全に説明でき、学習されたルーティングは構造がなければ何も足しません。これが regime での勝ちに必要な帰属(attribution)の証拠です。
+
+*(旧レポートにあった 2 つの `sp500` 翌日リターン系データセットは、本プロトコルではどの variant でも既約ノイズフロアに張り付き(全差分 < 0.4 %)、ヘッドライン表からは除外。generator と計測は repo に残っています — [`bench_results/meth2_v081/`](bench_results/meth2_v081/)。)*
+
+### 計算コスト (trial 横断の fold あたり学習時間中央値、秒)
+
+| Dataset | naive | ensemble | MoE | MoE / naive | MoE / ensemble |
 |---|---|---|---|---|---|
-| `synthetic` | 2000 × 5 | 4.9765 | **4.6651** | −6.3 % | 0.663 / 0.240 = **2.76 ×** |
-| `fred_gdp` | 311 × 12 | 0.9286 | **0.9128** | −1.7 % | 0.122 / 0.055 = **2.22 ×** |
-| `sp500_basic` (13 特徴量) | 3761 × 13 | **0.01003** | 0.01005 | +0.18 % *(naive 勝ち)* | 0.152 / 0.127 = **1.20 ×** |
-| `sp500` (28 特徴量、拡充版) | 3711 × 28 | 0.01002 | **0.00998** | −0.34 % | 0.134 / 0.158 = **0.85 ×** *(MoE が速い)* |
-| `vix` | 3762 × 13 | 2.8942 | **2.4574** | **−15.1 %** | 0.386 / 0.081 = **4.77 ×** |
-| `hmm` | 2000 × 5 | 2.1893 | **2.1096** | −3.6 % | 0.126 / 0.074 = **1.70 ×** |
-
-> **sp500 のペアは同じ生時系列での feature engineering アブレーション**: feature set だけ変えて CV / Optuna budget / seed は完全一致。13 特徴量だと `naive-lightgbm` が 0.18 % 勝つが、28 特徴量にすると MoE が 0.34 % 勝ち *かつ* 15 % 速く学習する。「basic → enriched」での反転は、本リポジトリ内で観察できる「MoE の優位性は regime が特徴量から観測可能になるほど大きくなる」最もクリーンなデモ。
+| `synthetic` | 0.124 | 0.294 | 1.180 | 9.5 × | 4.0 × |
+| `vix` | 0.066 | 0.124 | 0.490 | 7.4 × | 4.0 × |
+| `fred_gdp` | 0.016 | 0.019 | 0.541 | 34 × *(極小データで固定費支配)* | 28 × |
+| `hmm` | 0.044 | 0.078 | 0.365 | 8.3 × | 4.7 × |
+| `houses` | 0.251 | 0.632 | 2.503 | 10.0 × | 4.0 × |
+| `cpu_act` | 0.159 | 0.383 | 1.166 | 7.3 × | 3.0 × |
+| `elevators` | 0.151 | 0.270 | 1.394 | 9.2 × | 5.2 × |
+| `wine_quality` | 0.354 | 0.844 | 1.471 | 4.2 × | 1.7 × |
 
 ### Dataset の概要
 
-regime-switching の適用可能性スペクトラムをカバーする 5 dataset: MoE 理想合成 1 本、実時系列 3 本 (regime-switching 文献の canonical reference)、真の regime label が既知の HMM 1 本 (gate の regime recovery 評価用)。
+regime データセットは適用可能性スペクトラムをカバー: MoE 理想合成 1 本、実時系列 2 本 (regime-switching 文献の canonical reference)、真の regime label 既知の HMM 1 本。全時系列 generator は監査済みのアライメント規約に従います: **行 t の特徴量は時刻 t までに利用可能な情報のみ、ターゲットは t + 1 の値**(`tests/python_package_test/test_benchmark_methodology.py` で不変条件として検証)。
 
 #### `synthetic` — feature 由来 regime、MoE 理想ケース (2000 × 5)
 
@@ -107,67 +137,61 @@ regime-switching の適用可能性スペクトラムをカバーする 5 datase
 
   2 つの regime は同じ特徴量に **符号が逆** の係数を使うので、単一 GBDT は両者を平均せざるを得ない — MoE が解消できる構造の典型例。
 
-#### `fred_gdp` — US Real GDP、Hamilton 流 MS-AR(4) (~310 × 12)
-
-- **Source**: FRED 系列 [`GDPC1`](https://fred.stlouisfed.org/series/GDPC1) — Real Gross Domestic Product, Chained 2017 Dollars, Quarterly, Seasonally Adjusted Annual Rate (BEA via FRED, 認証不要 CSV エンドポイント)。
-- **メソドロジー出典**: Hamilton, J. D. (1989). *A New Approach to the Economic Analysis of Nonstationary Time Series and the Business Cycle.* **Econometrica** 57(2), 357-384. <https://www.jstor.org/stable/1912559>。
-- **構成**: target は四半期成長率 `100·Δlog(GDP)`、特徴量は成長率の lag 4 (Hamilton の MS-AR(4)) と派生 MA / volatility / regime-proxy。Regime (好況 / 不況) は完全に latent。Generator: `generate_fred_gdp_data`。
-
-#### `sp500_basic` & `sp500` — S&P 500 日次 log return、2 つの feature set
-
-S&P 500 系列は **2 通りの特徴量構成で並列に評価** しています — MoE の優位性が「regime が特徴量からどれだけ観測可能か」とどう連動するかを見るため:
-
-- **`sp500_basic`** (~3760 × 13): 最小構成 — lag {1, 2, 3, 5, 10} + 標準的な MA / ローリング vol / regime-proxy ブロック (`generate_sp500_basic_data`)。
-- **`sp500`** (~3710 × 28): プラクティショナーが実務で使うレベルの拡充版 — 複数 horizon の lag {1, 2, 3, 5, 10, 20, 60}、累積 momentum {5, 20, 60}、realized volatility {5, 20, 60} + short/long 比率、複数 window の MA と MA クロスオーバー、RSI(14)/RSI(30)、20 日のローリング歪度・尖度、Bollinger band z-score、20/60 日ローリング高値からの drawdown、5/20 日の正値率 (`generate_sp500_data`)。
-
-両者共通:
-
-- **Source**: Yahoo Finance、symbol [`^GSPC`](https://finance.yahoo.com/quote/%5EGSPC/history) (デフォルト `2010-01-01` から `2024-12-31`)。
-- **指数定義**: [S&P Dow Jones Indices, S&P 500](https://www.spglobal.com/spdji/en/indices/equity/sp-500/)。
-- **Target**: 翌日 log return (意図的に難しい予測設定)。
-- **Regime 構造**: latent (低 vol / 高 vol)。
-
-並列評価から見えること: 基本 feature set だと真の tie だが、拡充版になると MoE が sub-percent 勝つようになり *かつ* naive より速く学習する。**特徴量が regime をより予測可能にするにつれて、MoE の優位性は強くなる** — これは「MoE の優位性は regime が特徴量から観測可能なほど大きい」というテーゼと整合的。
-
 #### `vix` — CBOE Volatility Index 日次レベル (~3760 × 13)
 
-- **Source**: Yahoo Finance、symbol [`^VIX`](https://finance.yahoo.com/quote/%5EVIX/history) (`sp500` と同じ期間)。
+- **Source**: Yahoo Finance、symbol [`^VIX`](https://finance.yahoo.com/quote/%5EVIX/history)、`2010-01-01` から `2024-12-31`。
 - **指数定義**: [CBOE VIX](https://www.cboe.com/tradable_products/vix/)。
-- **構成**: target は翌日 VIX レベル。特徴量: VIX の lag {1, 2, 3, 5, 10} + MA / ローリング vol。`sp500` と同じ低 vol / 高 vol 構造を implied-vol レンズで見たもの。Generator: `generate_vix_data`。
+- **構成**: target は翌日 VIX レベル。特徴量: VIX の lag {1, 2, 3, 5, 10} + **因果的に中心化した系列**(過去のみの expanding mean で demean — v0.8.1 以前は全期間平均で demean しており「全期間平均より上か下か」が特徴量にリークしていた。現在の勝ちはリークなしで計測)上の MA / ローリング vol。Generator: `generate_vix_data`。
+
+#### `fred_gdp` — US Real GDP、Hamilton 流 MS-AR(4) (~310 × 12)
+
+- **Source**: FRED 系列 [`GDPC1`](https://fred.stlouisfed.org/series/GDPC1) — Real Gross Domestic Product, Chained 2017 Dollars, Quarterly, Seasonally Adjusted Annual Rate (BEA via FRED、認証不要 CSV エンドポイント)。
+- **メソドロジー出典**: Hamilton, J. D. (1989). *A New Approach to the Economic Analysis of Nonstationary Time Series and the Business Cycle.* **Econometrica** 57(2), 357-384. <https://www.jstor.org/stable/1912559>。
+- **構成**: target は四半期成長率 `100·Δlog(GDP)`、特徴量は成長率の lag 4 (Hamilton の MS-AR(4)) と派生 MA / volatility / regime-proxy。Regime (好況 / 不況) は完全に latent。chronological holdout が COVID 四半期を含み、MoE の勝ちはまさにそこから来ています。Generator: `generate_fred_gdp_data`。
 
 #### `hmm` — 真の regime label 既知の 3 状態 Gaussian HMM (2000 × 5)
 
 - **Source**: 本リポジトリ内の generator (`generate_hmm_data`)。
 - **メソドロジー出典**: Rabiner, L. R. (1989). *A Tutorial on Hidden Markov Models and Selected Applications in Speech Recognition.* **Proceedings of the IEEE** 77(2), 257-286. <https://www.cs.ubc.ca/~murphyk/Bayes/rabiner.pdf>。
-- **構成**: 隠れ状態は 3 状態 Markov 連鎖 (95% 対角の persistent transition); emission は Gauss で平均がよく分離 `{−3, 0, +3}`、scale `{0.4, 0.7, 1.0}`。5 本の特徴量のうち 2 本は隠れ状態の弱い線形シグナルを持ち (gate に多少の手がかりはあるが「タダ飯」ではない)、残り 3 本は純ノイズ。**真の regime label を返す** — RMSE だけでなく regime recovery 精度を測れる。
+- **構成**: 隠れ状態は 3 状態 Markov 連鎖 (95 % 対角の persistent transition); emission は Gauss で平均がよく分離 `{−3, 0, +3}`、scale `{0.4, 0.7, 1.0}`。5 本の特徴量のうち 2 本は隠れ状態の弱い線形シグナルを持ち、残りは純ノイズ。**真の regime label を返す** — RMSE だけでなく regime recovery 精度を測れる。
+
+#### コントロールデータセット — `houses`, `cpu_act`, `elevators`, `wine_quality`
+
+- **Source**: OpenML v1 オリジナル (data_id 537 / 197 / 216 / 287)。Grinsztajn, L., Oyallon, E., & Varoquaux, G. (2022). *Why do tree-based models still outperform deep learning on typical tabular data?* **NeurIPS Datasets & Benchmarks** の regression-on-numerical-features トラックから。
+- **前処理**(こちらで実施、明示): 数値列のみ、NaN 行除去、seed 付きシャッフル、10k 行キャップ (tabular-benchmark の「medium-sized」慣例)。行に時間的意味はないため、chronological split はここではランダム分割と同等に振る舞います。
 
 ### キャッシュ
 
-実時系列の取得 (FRED, yfinance) は `examples/data_cache/` 以下にキャッシュ (gitignore 済)。初回はネットワーク取得、以降はオフライン動作。
+実データの取得 (FRED, yfinance, OpenML) は `examples/data_cache/` 以下にキャッシュ (gitignore 済)。各キャッシュファイルの sha256 はスタディの出力 JSON に記録されるので、どのランがどのバイト列を見たか追跡できます。初回はネットワーク取得、以降はオフライン動作。
 
-### 全 dataset で勝った設定
+### 勝った設定 — 全ノブを探索せよ
 
-5 dataset 全部で絶対最良 (min) RMSE を出した唯一の categorical 設定は **`mixture_gate_type='gbdt'`** のみ。それ以外は dataset 依存 — 詳細表は [docs/moe/benchmark.md](docs/moe/benchmark.md) 参照。
+24 個の勝者 MoE 設定 (8 datasets × 3 seeds) から。ヘッドライン: **v0.8.1 以前はデフォルト値に凍結されていたノブ群が本当に仕事をしている** — 特に `vix` の勝ちは gate 温度アニーリング (T ≈ 2.4–2.9 から減衰)、expert dropout 0.1–0.2、soft M-step が主因で、init の選択ではありません。
 
-| パラメータ | 普遍? | 補足 |
-|---|---|---|
-| `mixture_gate_type` | **`gbdt`** | 全 dataset で最良 min RMSE。`leaf_reuse` と `none` は絶対最良を取れず |
-| `mixture_routing_mode` | **No** | synthetic は `token_choice`、fred_gdp / vix / hmm は `expert_choice` が勝った。両方探索すべき |
-| `mixture_num_experts` | やや 3-4 | Q4 quartile mean がほぼの dataset で最良だが差は小さい |
-| `mixture_diversity_lambda` | 0.0–0.5 を探索 | MoE の fANOVA importance で常に top-5、単一最適値はないが探索は必須 |
-
-dataset 依存の設定 (`mixture_e_step_mode`, `mixture_init`, `mixture_r_smoothing`, `mixture_hard_m_step`, `extra_trees`, `learning_rate`) は問題ごとに探索が必要 — 詳細表は [docs/moe/benchmark.md](docs/moe/benchmark.md) 参照。
+| ノブ | 知見 |
+|---|---|
+| `mixture_diversity_lambda` | **23 / 24** の勝者で有効 (> 0.02) — 引き続き唯一のほぼ普遍なノブ |
+| `mixture_expert_dropout_rate` | **21 / 24** で有効 (典型 0.05–0.2) — v0.8.1 以前は 0 に凍結 |
+| `mixture_load_balance_alpha` | **22 / 24** で有効 — 以前は 0 に凍結 |
+| `mixture_gate_entropy_lambda` | gate ありの勝者の **17 / 19** で有効 — 以前は 0 に凍結 |
+| gate 温度 | **12 / 19** で `T_init > 1.5` — 旧固定 `T = 1.0` は精度を取り損ねていた |
+| `mixture_refit_leaves` | **15 / 24 の勝者で ON** — v0.8 の知見(「Optuna は 5/6 データセットで refit を拒否」)を更新: v0.8.1 の stale-score 修正と ELBO トリガーのクールダウン以降、leaf refit は「bad-init 専用の安全網」ではなく普通に有効なノブ |
+| `mixture_hard_m_step` | 16 / 24 で soft (False) — hard M-step デフォルトは普遍の勝者では*ない* |
+| `mixture_init` / `mixture_gate_type` / `mixture_routing_mode` / K | 普遍の勝者なし (gmm 8, uniform 6, random 5, feature 系 init 4, tree 1 / gbdt 11, leaf_reuse 8, none 5 / token 14, expert 10 / K は 2–6 に分散) — **探索してください** |
 
 ```bash
-# Headline スタディ全体の再現 (12-core / 24-thread で約 30-40 分、6 行)
-python examples/comparative_study.py --trials 500 --out bench_results/study_500.json
+# Headline スタディの再現 (holdout プロトコル、wide MoE 空間、3 seeds; seed ごとに決定的)
+python examples/comparative_study.py --trials 500 --seeds 42,43,44 \
+    --moe-space wide --out bench_results/study_wide.json
 
-# 動作確認 (~1 分、6 行全体)
-python examples/comparative_study.py --trials 10 --n-jobs 2 --out bench_results/smoke.json
+# 動作確認 (~2 分)
+python examples/comparative_study.py --trials 10 --seeds 42 \
+    --datasets synthetic,fred_gdp --out bench_results/smoke.json
 
-# sp500 の feature ablation だけ再現
-python examples/comparative_study.py --trials 500 \
-    --datasets sp500_basic,sp500 --out bench_results/sp500_ablation.json
+# 同一プロトコルで 2 つのビルドを A/B
+LGBM_MOE_PACKAGE_DIR=/path/to/other/python-package \
+    python examples/comparative_study.py --trials 300 --seeds 42,43,44 \
+    --out bench_results/study_other_build.json
 ```
 
 ## ドキュメント

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ import lightgbm_moe as lgb
 params = {
     'boosting': 'mixture',           # Enable MoE mode
     'mixture_num_experts': 3,        # Number of experts (search 2-6 for your data)
-    'mixture_gate_type': 'gbdt',     # Best on 4/6 datasets; search 'leaf_reuse' too
-    'mixture_routing_mode': 'token_choice',  # Tied 3/3 with 'expert_choice' across datasets
+    'mixture_gate_type': 'gbdt',     # Most common winner (11/24); search 'leaf_reuse'/'none' too
+    'mixture_routing_mode': 'token_choice',  # Most common winner (14/24); search 'expert_choice' too
     'objective': 'regression',
     'metric': 'rmse',
     'verbose': -1,

--- a/bench_results/meth2_v080/ds_cpu_act_report.md
+++ b/bench_results/meth2_v080/ds_cpu_act_report.md
@@ -1,0 +1,501 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['cpu_act'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| cpu_act | naive-lightgbm | **2.51321** ± 0.31795 | 2.45180 | 0.0% | 0.22 |
+| cpu_act | moe | **2.49613** ± 0.29179 | 2.42641 | 0.0% | 2.20 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| cpu_act@s42 | naive-lightgbm | 2.5168 | 2.5887 | 0.160 | 263 |
+| cpu_act@s42 | moe | 2.4848 | 2.5813 | 1.170 | 2132 |
+| cpu_act@s43 | naive-lightgbm | 2.3606 | 2.4179 | 0.209 | 324 |
+| cpu_act@s43 | moe | 2.3174 | 2.3739 | 0.899 | 2620 |
+| cpu_act@s44 | naive-lightgbm | 2.4780 | 2.5416 | 0.167 | 260 |
+| cpu_act@s44 | moe | 2.4770 | 2.6136 | 1.005 | 3331 |
+
+
+
+---
+
+## cpu_act@s42  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.30096** (winner retrained in 0.14s, cv score of winner: 2.5168)
+- cv best RMSE: 2.5168, median: 2.5887, p10: 2.5383
+- train: median 0.160s/fold, mean 0.170s, p90 0.227s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.596 |
+| `min_data_in_leaf` | 0.197 |
+| `extra_trees` | 0.125 |
+| `feature_fraction` | 0.031 |
+| `num_leaves` | 0.025 |
+| `max_depth` | 0.015 |
+| `bagging_fraction` | 0.005 |
+| `bagging_freq` | 0.004 |
+| `lambda_l1` | 0.002 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 2.7237 | 0.5702 | 2.5168 |
+| True | 22 | 5.1620 | 2.8843 | 2.9974 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.5242 | 2.5987 | 2.6638 | 2.8232 | **Q2** [0.0878, 0.1015] |
+| `num_leaves` | 2.7932 | 2.6426 | 2.7366 | 3.4317 | **Q2** [17.0, 22.0] |
+| `max_depth` | 3.5982 | 2.7181 | — | 2.6996 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.8011 | 2.5874 | 2.6193 | 3.6265 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 3.1783 | 3.0481 | 2.5990 | 2.7845 | **Q3** [0.101, 0.2619] |
+| `lambda_l2` | 2.7125 | 2.6434 | 2.9249 | 3.3292 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 3.3781 | 2.7630 | 2.6453 | 2.8235 | **Q3** [0.86, 0.8808] |
+| `bagging_fraction` | 2.8270 | 2.6803 | 3.2550 | 2.8477 | **Q2** [0.5773, 0.6504] |
+
+#### E. Slice plot
+
+![cpu_act@s42/naive-lightgbm](slice_cpu_act@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.30423** (winner retrained in 1.23s, cv score of winner: 2.4848)
+- cv best RMSE: 2.4848, median: 2.5813, p10: 2.5252
+- train: median 1.170s/fold, mean 1.406s, p90 2.142s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.307 |
+| `feature_fraction` | 0.279 |
+| `bagging_fraction` | 0.151 |
+| `bagging_freq` | 0.054 |
+| `min_data_in_leaf` | 0.052 |
+| `mixture_hard_m_step` | 0.035 |
+| `mixture_init` | 0.030 |
+| `mixture_diversity_lambda` | 0.020 |
+| `extra_trees` | 0.018 |
+| `lambda_l1` | 0.015 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 138 | 3.7097 | 4.3838 | 2.5208 |
+| none | 128 | 3.9698 | 4.6263 | 2.4848 |
+| leaf_reuse | 34 | 5.7558 | 8.8337 | 2.6692 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 265 | 3.6859 | 3.9992 | 2.4848 |
+| expert_choice | 35 | 6.8290 | 10.1654 | 2.5357 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 226 | 3.7664 | 5.2810 | 2.4848 |
+| gate_only | 37 | 4.7635 | 5.2386 | 2.5686 |
+| em | 37 | 5.0901 | 4.5471 | 2.5125 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 226 | 3.1780 | 3.3835 | 2.4848 |
+| random | 32 | 4.0602 | 2.5049 | 2.6692 |
+| tree_hierarchical | 14 | 8.2573 | 4.9157 | 2.6038 |
+| gmm | 28 | 9.0005 | 11.8446 | 3.3571 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 136 | 3.7432 | 4.3392 | 2.5208 |
+| ema | 127 | 4.0293 | 4.7817 | 2.4848 |
+| markov | 37 | 5.2699 | 8.4279 | 2.5686 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 3.7100 | 4.9416 | 2.4848 |
+| True | 20 | 8.8494 | 6.4416 | 2.7503 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 264 | 3.6769 | 4.6736 | 2.4848 |
+| True | 36 | 6.8078 | 7.6078 | 3.1139 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 6.3463 | — | — | 3.7787 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 4.7956 | 3.9424 | 4.0038 | 3.4685 | **Q4** [0.3923, ∞) |
+| `mixture_warmup_iters` | 3.4996 | 3.6237 | 4.4049 | 4.6587 | **Q1** [None, 8.0] |
+| `mixture_balance_factor` | 3.4063 | — | 3.4891 | 4.9469 | **Q1** [None, 3.0] |
+| `learning_rate` | 5.3836 | 3.2309 | 3.4370 | 4.1589 | **Q2** [0.0954, 0.1241] |
+| `num_leaves` | 5.0468 | 3.0635 | 3.5512 | 4.6115 | **Q2** [67.0, 81.0] |
+| `max_depth` | 6.8295 | — | 3.2250 | 4.0527 | **Q3** [7.0, 9.0] |
+| `min_data_in_leaf` | 3.1161 | 3.3995 | 3.6909 | 5.8981 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![cpu_act@s42/moe](slice_cpu_act@s42_moe.png)
+
+
+---
+
+## cpu_act@s43  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.96263** (winner retrained in 0.33s, cv score of winner: 2.3606)
+- cv best RMSE: 2.3606, median: 2.4179, p10: 2.3767
+- train: median 0.209s/fold, mean 0.211s, p90 0.286s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.534 |
+| `learning_rate` | 0.347 |
+| `bagging_fraction` | 0.025 |
+| `feature_fraction` | 0.023 |
+| `num_leaves` | 0.019 |
+| `extra_trees` | 0.019 |
+| `bagging_freq` | 0.018 |
+| `max_depth` | 0.009 |
+| `lambda_l1` | 0.006 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.6156 | 0.7424 | 2.3606 |
+| True | 21 | 3.9526 | 1.4165 | 2.8650 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.0578 | 2.5427 | 2.6238 | 2.6125 | **Q2** [0.0635, 0.0793] |
+| `num_leaves` | 2.6429 | 2.5224 | 2.5676 | 3.0855 | **Q2** [20.0, 26.0] |
+| `max_depth` | 3.0309 | 2.5906 | 2.5758 | 2.6500 | **Q3** [10.0, 11.0] |
+| `min_data_in_leaf` | 2.4133 | 2.5333 | 2.4333 | 3.4038 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.5531 | 2.6273 | 2.9238 | 2.7327 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.7548 | 2.5349 | 2.6795 | 2.8676 | **Q2** [0.0001, 0.009] |
+| `feature_fraction` | 2.8955 | 2.6856 | 2.7271 | 2.5286 | **Q4** [0.9543, ∞) |
+| `bagging_fraction` | 2.7772 | 2.7105 | 2.6495 | 2.6996 | **Q3** [0.7722, 0.8744] |
+
+#### E. Slice plot
+
+![cpu_act@s43/naive-lightgbm](slice_cpu_act@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.90845** (winner retrained in 4.47s, cv score of winner: 2.3174)
+- cv best RMSE: 2.3174, median: 2.3739, p10: 2.3370
+- train: median 0.899s/fold, mean 1.733s, p90 4.026s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.662 |
+| `num_leaves` | 0.159 |
+| `mixture_warmup_iters` | 0.046 |
+| `mixture_diversity_lambda` | 0.044 |
+| `mixture_init` | 0.031 |
+| `mixture_gate_type` | 0.013 |
+| `mixture_refit_leaves` | 0.009 |
+| `bagging_fraction` | 0.007 |
+| `extra_trees` | 0.006 |
+| `mixture_routing_mode` | 0.006 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 106 | 3.0408 | 3.4764 | 2.3174 |
+| gbdt | 79 | 3.9102 | 4.6244 | 2.3930 |
+| none | 115 | 4.4517 | 8.5199 | 2.3286 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 266 | 3.4790 | 4.9914 | 2.3174 |
+| expert_choice | 34 | 6.4044 | 11.5607 | 2.3432 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 191 | 3.5155 | 6.2933 | 2.3174 |
+| loss_only | 79 | 3.8125 | 4.6376 | 2.3930 |
+| em | 30 | 5.6839 | 8.2533 | 2.3247 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 46 | 3.3079 | 4.2808 | 2.3930 |
+| uniform | 195 | 3.3327 | 5.7025 | 2.3174 |
+| gmm | 27 | 4.9996 | 8.7521 | 2.5003 |
+| tree_hierarchical | 32 | 6.4422 | 7.6258 | 2.4584 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 228 | 3.0068 | 4.0365 | 2.3174 |
+| ema | 34 | 5.7331 | 11.1313 | 2.3386 |
+| none | 38 | 6.9131 | 8.6797 | 2.3978 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 277 | 3.3452 | 5.5157 | 2.3174 |
+| True | 23 | 9.4155 | 9.8231 | 2.8489 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 3.6563 | 6.1640 | 2.3174 |
+| True | 20 | 5.9698 | 5.8773 | 2.7662 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 4.1578 | — | — | 3.7477 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 4.2317 | 2.6267 | 4.2741 | 4.1097 | **Q2** [0.0941, 0.1669] |
+| `mixture_warmup_iters` | 5.8469 | 3.1617 | 2.7876 | 3.5569 | **Q3** [43.0, 46.0] |
+| `mixture_balance_factor` | 4.9209 | 4.1736 | — | 3.4015 | **Q4** [9.0, ∞) |
+| `learning_rate` | 7.5818 | 2.5667 | 2.4806 | 2.6132 | **Q3** [0.1729, 0.2024] |
+| `num_leaves` | 3.1524 | 3.6501 | 2.8125 | 5.4270 | **Q3** [33.0, 43.0] |
+| `max_depth` | 4.6517 | 4.1283 | 3.0262 | 4.0161 | **Q3** [8.0, 10.0] |
+| `min_data_in_leaf` | 2.5337 | 2.9152 | 3.9003 | 5.5045 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![cpu_act@s43/moe](slice_cpu_act@s43_moe.png)
+
+
+---
+
+## cpu_act@s44  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.27606** (winner retrained in 0.19s, cv score of winner: 2.4780)
+- cv best RMSE: 2.4780, median: 2.5416, p10: 2.5063
+- train: median 0.167s/fold, mean 0.168s, p90 0.220s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.556 |
+| `learning_rate` | 0.242 |
+| `extra_trees` | 0.080 |
+| `feature_fraction` | 0.053 |
+| `bagging_fraction` | 0.026 |
+| `num_leaves` | 0.016 |
+| `bagging_freq` | 0.012 |
+| `max_depth` | 0.011 |
+| `lambda_l2` | 0.004 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7136 | 0.6089 | 2.4780 |
+| True | 20 | 3.8921 | 1.1427 | 2.8796 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.1451 | 2.5864 | 2.6362 | 2.8009 | **Q2** [0.0864, 0.0971] |
+| `num_leaves` | 2.6861 | 2.6349 | 2.6778 | 3.1672 | **Q2** [19.0, 23.0] |
+| `max_depth` | 2.9955 | 2.8130 | — | 2.7386 | **Q4** [7.0, ∞) |
+| `min_data_in_leaf` | 2.5623 | 2.5740 | 2.5874 | 3.4190 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.6384 | 3.0447 | 2.6391 | 2.8463 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.6267 | 2.8511 | 2.6385 | 3.0522 | **Q1** [None, 0.0] |
+| `feature_fraction` | 3.2942 | 2.6950 | 2.5976 | 2.5817 | **Q4** [0.9903, ∞) |
+| `bagging_fraction` | 3.1352 | 2.7428 | 2.6153 | 2.6753 | **Q3** [0.9574, 0.9762] |
+
+#### E. Slice plot
+
+![cpu_act@s44/naive-lightgbm](slice_cpu_act@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.27571** (winner retrained in 0.89s, cv score of winner: 2.4770)
+- cv best RMSE: 2.4770, median: 2.6136, p10: 2.4974
+- train: median 1.005s/fold, mean 2.207s, p90 8.382s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.353 |
+| `min_data_in_leaf` | 0.211 |
+| `feature_fraction` | 0.191 |
+| `mixture_diversity_lambda` | 0.107 |
+| `bagging_fraction` | 0.025 |
+| `bagging_freq` | 0.020 |
+| `mixture_num_experts` | 0.019 |
+| `extra_trees` | 0.017 |
+| `max_depth` | 0.011 |
+| `mixture_r_smoothing` | 0.011 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_r_smoothing` | **ema** | 3.1926 (n=238) | markov | Δ +3.1306 | p=3.61e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 136 | 2.9738 | 1.8523 | 2.4770 |
+| none | 109 | 3.9460 | 5.6487 | 2.5051 |
+| gbdt | 55 | 6.4395 | 7.3464 | 2.6392 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 270 | 3.6630 | 4.2893 | 2.4770 |
+| expert_choice | 30 | 6.6567 | 8.5122 | 2.5943 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 162 | 3.1389 | 2.2196 | 2.4770 |
+| loss_only | 72 | 4.0072 | 6.2746 | 2.4780 |
+| gate_only | 66 | 5.9350 | 7.1602 | 2.6392 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 147 | 2.8227 | 1.2897 | 2.4770 |
+| random | 88 | 4.0831 | 5.2335 | 2.5051 |
+| tree_hierarchical | 24 | 4.5702 | 4.3545 | 2.5943 |
+| gmm | 41 | 7.4340 | 9.3421 | 2.7447 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 238 | 3.1926 | 3.3147 | 2.4770 |
+| markov | 46 | 6.3232 | 6.7175 | 2.7447 |
+| none | 16 | 8.6263 | 11.0315 | 2.5797 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 243 | 3.3320 | 4.0673 | 2.4770 |
+| True | 57 | 6.6497 | 7.0774 | 2.6722 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 3.8079 | 5.0394 | 2.4770 |
+| True | 21 | 6.0155 | 3.1062 | 3.1574 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 7.2549 | — | — | 3.0695 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 6.2211 | 3.8125 | 2.7086 | 3.1074 | **Q3** [0.2894, 0.3216] |
+| `mixture_warmup_iters` | 3.0516 | 3.4447 | 3.1039 | 5.9921 | **Q1** [None, 12.0] |
+| `mixture_balance_factor` | 3.0644 | 4.3002 | 6.9343 | 3.1454 | **Q1** [None, 3.0] |
+| `learning_rate` | 6.6621 | 3.1236 | 3.1326 | 2.9313 | **Q4** [0.2025, ∞) |
+| `num_leaves` | 2.7317 | 3.1752 | 4.3924 | 5.5503 | **Q1** [None, 27.75] |
+| `max_depth` | 3.6869 | 4.2288 | 4.0847 | 3.8812 | **Q1** [None, 7.0] |
+| `min_data_in_leaf` | 2.6033 | 3.4869 | 3.0687 | 6.4697 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![cpu_act@s44/moe](slice_cpu_act@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| cpu_act@s44 | `mixture_r_smoothing` | **ema** | +3.1306 | 3.61e-03 |

--- a/bench_results/meth2_v080/ds_cpu_act_summary.json
+++ b/bench_results/meth2_v080/ds_cpu_act_summary.json
@@ -1,0 +1,2776 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "cpu_act"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "cpu_act": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.300955382422753,
+      "cv_best": 2.5167682181190614,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1394
+     },
+     "43": {
+      "holdout_rmse": 2.9626315579993556,
+      "cv_best": 2.3605952907213994,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3349
+     },
+     "44": {
+      "holdout_rmse": 2.276056326993748,
+      "cv_best": 2.478020653643999,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1879
+     }
+    },
+    "holdout_mean": 2.513214,
+    "holdout_std": 0.317948,
+    "cv_best_mean": 2.451795
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.3042277375955096,
+      "cv_best": 2.484824829974224,
+      "crash_rate": 0.0,
+      "retrain_s": 1.2276
+     },
+     "43": {
+      "holdout_rmse": 2.9084506082261097,
+      "cv_best": 2.317409489797144,
+      "crash_rate": 0.0,
+      "retrain_s": 4.4684
+     },
+     "44": {
+      "holdout_rmse": 2.2757066641793826,
+      "cv_best": 2.4769960029494182,
+      "crash_rate": 0.0,
+      "retrain_s": 0.8923
+     }
+    },
+    "holdout_mean": 2.496128,
+    "holdout_std": 0.291788,
+    "cv_best_mean": 2.42641
+   }
+  }
+ },
+ "runs": {
+  "cpu_act@s42": {
+   "dataset": "cpu_act",
+   "seed": 42,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 83.92462618248398,
+    "std": 18.493954695764945
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.5167682181190614,
+    "rmse_p10": 2.5382797920027733,
+    "rmse_median": 2.5886531381388105,
+    "train_s_median": 0.16016588024795056,
+    "train_s_mean": 0.1704200814614693,
+    "train_s_p90": 0.22663825202733281,
+    "best_params": {
+     "learning_rate": 0.09264509243568801,
+     "num_leaves": 16,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.03330432130542346,
+     "lambda_l2": 4.271764835509462e-08,
+     "feature_fraction": 0.8683160857189651,
+     "bagging_fraction": 0.5918727988243391,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5962,
+     "min_data_in_leaf": 0.1969,
+     "extra_trees": 0.1246,
+     "feature_fraction": 0.0308,
+     "num_leaves": 0.0252,
+     "max_depth": 0.0149,
+     "bagging_fraction": 0.0053,
+     "bagging_freq": 0.0036,
+     "lambda_l1": 0.0022,
+     "lambda_l2": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 5.162,
+        "std": 2.8843,
+        "min": 2.9974
+       },
+       "False": {
+        "n": 278,
+        "mean": 2.7237,
+        "std": 0.5702,
+        "min": 2.5168
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.4383,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0878
+       ],
+       "n": 75,
+       "mean_rmse": 3.5242
+      },
+      "Q2": {
+       "range": [
+        0.0878,
+        0.1015
+       ],
+       "n": 75,
+       "mean_rmse": 2.5987
+      },
+      "Q3": {
+       "range": [
+        0.1015,
+        0.1365
+       ],
+       "n": 75,
+       "mean_rmse": 2.6638
+      },
+      "Q4": {
+       "range": [
+        0.1365,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8232
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.7932
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        22.0
+       ],
+       "n": 81,
+       "mean_rmse": 2.6426
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        27.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7366
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.4317
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 67,
+       "mean_rmse": 3.5982
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 36,
+       "mean_rmse": 2.7181
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 197,
+       "mean_rmse": 2.6996
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 56,
+       "mean_rmse": 2.8011
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.5874
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.6193
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.6265
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0022
+       ],
+       "n": 75,
+       "mean_rmse": 3.1783
+      },
+      "Q2": {
+       "range": [
+        0.0022,
+        0.101
+       ],
+       "n": 75,
+       "mean_rmse": 3.0481
+      },
+      "Q3": {
+       "range": [
+        0.101,
+        0.2619
+       ],
+       "n": 75,
+       "mean_rmse": 2.599
+      },
+      "Q4": {
+       "range": [
+        0.2619,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7845
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7125
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6434
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.9249
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.3292
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8159
+       ],
+       "n": 75,
+       "mean_rmse": 3.3781
+      },
+      "Q2": {
+       "range": [
+        0.8159,
+        0.86
+       ],
+       "n": 75,
+       "mean_rmse": 2.763
+      },
+      "Q3": {
+       "range": [
+        0.86,
+        0.8808
+       ],
+       "n": 75,
+       "mean_rmse": 2.6453
+      },
+      "Q4": {
+       "range": [
+        0.8808,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8235
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5773
+       ],
+       "n": 75,
+       "mean_rmse": 2.827
+      },
+      "Q2": {
+       "range": [
+        0.5773,
+        0.6504
+       ],
+       "n": 75,
+       "mean_rmse": 2.6803
+      },
+      "Q3": {
+       "range": [
+        0.6504,
+        0.9249
+       ],
+       "n": 75,
+       "mean_rmse": 3.255
+      },
+      "Q4": {
+       "range": [
+        0.9249,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8477
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 263.1,
+    "holdout": {
+     "holdout_rmse": 2.300955382422753,
+     "retrain_s": 0.1394,
+     "predict_s": 0.0014,
+     "cv_rmse_of_winner": 2.5167682181190614
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.484824829974224,
+    "rmse_p10": 2.5252066917351916,
+    "rmse_median": 2.5813177328330106,
+    "train_s_median": 1.1701965289190412,
+    "train_s_mean": 1.4060881859784324,
+    "train_s_p90": 2.1423694979399444,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.1453900217916002,
+     "num_leaves": 85,
+     "max_depth": 7,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 9.699275350385382e-08,
+     "lambda_l2": 0.16624910551473676,
+     "feature_fraction": 0.7908360150587098,
+     "bagging_fraction": 0.5841083076620247,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 37,
+     "mixture_balance_factor": 3,
+     "mixture_smoothing_lambda": 0.07404119786813851,
+     "mixture_diversity_lambda": 0.3755497259871458,
+     "mixture_hard_m_step": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.37963796983985615,
+     "mixture_elbo_drop_threshold": 0.029226089426047958,
+     "mixture_elbo_plateau_threshold": 0.0014078468485720812,
+     "mixture_elbo_window": 15,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.3072,
+     "feature_fraction": 0.2788,
+     "bagging_fraction": 0.1508,
+     "bagging_freq": 0.054,
+     "min_data_in_leaf": 0.052,
+     "mixture_hard_m_step": 0.035,
+     "mixture_init": 0.0301,
+     "mixture_diversity_lambda": 0.0203,
+     "extra_trees": 0.0182,
+     "lambda_l1": 0.0145,
+     "num_leaves": 0.0121,
+     "mixture_refit_leaves": 0.0097,
+     "lambda_l2": 0.0027,
+     "mixture_routing_mode": 0.0026,
+     "mixture_e_step_mode": 0.0024,
+     "max_depth": 0.0023,
+     "mixture_r_smoothing": 0.0021,
+     "mixture_warmup_iters": 0.0021,
+     "mixture_balance_factor": 0.0015,
+     "mixture_gate_type": 0.0012,
+     "mixture_num_experts": 0.0005
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 34,
+        "mean": 5.7558,
+        "std": 8.8337,
+        "min": 2.6692
+       },
+       "none": {
+        "n": 128,
+        "mean": 3.9698,
+        "std": 4.6263,
+        "min": 2.4848
+       },
+       "gbdt": {
+        "n": 138,
+        "mean": 3.7097,
+        "std": 4.3838,
+        "min": 2.5208
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.2601,
+       "p_value": 0.640119,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 265,
+        "mean": 3.6859,
+        "std": 3.9992,
+        "min": 2.4848
+       },
+       "expert_choice": {
+        "n": 35,
+        "mean": 6.829,
+        "std": 10.1654,
+        "min": 2.5357
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 3.1431,
+       "p_value": 0.082803,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 226,
+        "mean": 3.7664,
+        "std": 5.281,
+        "min": 2.4848
+       },
+       "gate_only": {
+        "n": 37,
+        "mean": 4.7635,
+        "std": 5.2386,
+        "min": 2.5686
+       },
+       "em": {
+        "n": 37,
+        "mean": 5.0901,
+        "std": 4.5471,
+        "min": 2.5125
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.9971,
+       "p_value": 0.294762,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 32,
+        "mean": 4.0602,
+        "std": 2.5049,
+        "min": 2.6692
+       },
+       "gmm": {
+        "n": 28,
+        "mean": 9.0005,
+        "std": 11.8446,
+        "min": 3.3571
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 8.2573,
+        "std": 4.9157,
+        "min": 2.6038
+       },
+       "uniform": {
+        "n": 226,
+        "mean": 3.178,
+        "std": 3.3835,
+        "min": 2.4848
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.8822,
+       "p_value": 0.085981,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 127,
+        "mean": 4.0293,
+        "std": 4.7817,
+        "min": 2.4848
+       },
+       "markov": {
+        "n": 37,
+        "mean": 5.2699,
+        "std": 8.4279,
+        "min": 2.5686
+       },
+       "none": {
+        "n": 136,
+        "mean": 3.7432,
+        "std": 4.3392,
+        "min": 2.5208
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.2861,
+       "p_value": 0.614069,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 8.8494,
+        "std": 6.4416,
+        "min": 2.7503
+       },
+       "False": {
+        "n": 280,
+        "mean": 3.71,
+        "std": 4.9416,
+        "min": 2.4848
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 5.1394,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 36,
+        "mean": 6.8078,
+        "std": 7.6078,
+        "min": 3.1139
+       },
+       "False": {
+        "n": 264,
+        "mean": 3.6769,
+        "std": 4.6736,
+        "min": 2.4848
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 3.1309,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 32,
+       "mean_rmse": 6.3463
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 268,
+       "mean_rmse": 3.7787
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2868
+       ],
+       "n": 75,
+       "mean_rmse": 4.7956
+      },
+      "Q2": {
+       "range": [
+        0.2868,
+        0.3485
+       ],
+       "n": 75,
+       "mean_rmse": 3.9424
+      },
+      "Q3": {
+       "range": [
+        0.3485,
+        0.3923
+       ],
+       "n": 75,
+       "mean_rmse": 4.0038
+      },
+      "Q4": {
+       "range": [
+        0.3923,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.4685
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 3.4996
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        19.5
+       ],
+       "n": 79,
+       "mean_rmse": 3.6237
+      },
+      "Q3": {
+       "range": [
+        19.5,
+        33.0
+       ],
+       "n": 70,
+       "mean_rmse": 4.4049
+      },
+      "Q4": {
+       "range": [
+        33.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 4.6587
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 36,
+       "mean_rmse": 3.4063
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 146,
+       "mean_rmse": 3.4891
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 118,
+       "mean_rmse": 4.9469
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0954
+       ],
+       "n": 75,
+       "mean_rmse": 5.3836
+      },
+      "Q2": {
+       "range": [
+        0.0954,
+        0.1241
+       ],
+       "n": 75,
+       "mean_rmse": 3.2309
+      },
+      "Q3": {
+       "range": [
+        0.1241,
+        0.1616
+       ],
+       "n": 75,
+       "mean_rmse": 3.437
+      },
+      "Q4": {
+       "range": [
+        0.1616,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 4.1589
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        67.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.0468
+      },
+      "Q2": {
+       "range": [
+        67.0,
+        81.0
+       ],
+       "n": 78,
+       "mean_rmse": 3.0635
+      },
+      "Q3": {
+       "range": [
+        81.0,
+        89.0
+       ],
+       "n": 73,
+       "mean_rmse": 3.5512
+      },
+      "Q4": {
+       "range": [
+        89.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 4.6115
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 45,
+       "mean_rmse": 6.8295
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 151,
+       "mean_rmse": 3.225
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 104,
+       "mean_rmse": 4.0527
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 47,
+       "mean_rmse": 3.1161
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.5
+       ],
+       "n": 103,
+       "mean_rmse": 3.3995
+      },
+      "Q3": {
+       "range": [
+        9.5,
+        17.25
+       ],
+       "n": 75,
+       "mean_rmse": 3.6909
+      },
+      "Q4": {
+       "range": [
+        17.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.8981
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 2131.5,
+    "holdout": {
+     "holdout_rmse": 2.3042277375955096,
+     "retrain_s": 1.2276,
+     "predict_s": 0.0064,
+     "cv_rmse_of_winner": 2.484824829974224
+    }
+   }
+  },
+  "cpu_act@s43": {
+   "dataset": "cpu_act",
+   "seed": 43,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.04531583765639,
+    "std": 18.208031997815638
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.3605952907213994,
+    "rmse_p10": 2.3766976806914064,
+    "rmse_median": 2.4179002246630907,
+    "train_s_median": 0.20860016494989397,
+    "train_s_mean": 0.21062025212372346,
+    "train_s_p90": 0.28568218089640146,
+    "best_params": {
+     "learning_rate": 0.061448868291719326,
+     "num_leaves": 29,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 3.556881073599275e-07,
+     "lambda_l2": 0.016652932385200474,
+     "feature_fraction": 0.9571427521547401,
+     "bagging_fraction": 0.7709482037567025,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5339,
+     "learning_rate": 0.3473,
+     "bagging_fraction": 0.0249,
+     "feature_fraction": 0.0232,
+     "num_leaves": 0.0192,
+     "extra_trees": 0.0189,
+     "bagging_freq": 0.0176,
+     "max_depth": 0.0086,
+     "lambda_l1": 0.0063,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 3.9526,
+        "std": 1.4165,
+        "min": 2.865
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.6156,
+        "std": 0.7424,
+        "min": 2.3606
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.337,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0635
+       ],
+       "n": 75,
+       "mean_rmse": 3.0578
+      },
+      "Q2": {
+       "range": [
+        0.0635,
+        0.0793
+       ],
+       "n": 75,
+       "mean_rmse": 2.5427
+      },
+      "Q3": {
+       "range": [
+        0.0793,
+        0.1074
+       ],
+       "n": 75,
+       "mean_rmse": 2.6238
+      },
+      "Q4": {
+       "range": [
+        0.1074,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6125
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.6429
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        26.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.5224
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        32.0
+       ],
+       "n": 85,
+       "mean_rmse": 2.5676
+      },
+      "Q4": {
+       "range": [
+        32.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 3.0855
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 3.0309
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 51,
+       "mean_rmse": 2.5906
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 38,
+       "mean_rmse": 2.5758
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 149,
+       "mean_rmse": 2.65
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.4133
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.5333
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.4333
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 3.4038
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.5531
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6273
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.3735
+       ],
+       "n": 75,
+       "mean_rmse": 2.9238
+      },
+      "Q4": {
+       "range": [
+        0.3735,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7327
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 2.7548
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.009
+       ],
+       "n": 75,
+       "mean_rmse": 2.5349
+      },
+      "Q3": {
+       "range": [
+        0.009,
+        0.0305
+       ],
+       "n": 75,
+       "mean_rmse": 2.6795
+      },
+      "Q4": {
+       "range": [
+        0.0305,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8676
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8157
+       ],
+       "n": 75,
+       "mean_rmse": 2.8955
+      },
+      "Q2": {
+       "range": [
+        0.8157,
+        0.9004
+       ],
+       "n": 75,
+       "mean_rmse": 2.6856
+      },
+      "Q3": {
+       "range": [
+        0.9004,
+        0.9543
+       ],
+       "n": 75,
+       "mean_rmse": 2.7271
+      },
+      "Q4": {
+       "range": [
+        0.9543,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.5286
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7364
+       ],
+       "n": 75,
+       "mean_rmse": 2.7772
+      },
+      "Q2": {
+       "range": [
+        0.7364,
+        0.7722
+       ],
+       "n": 75,
+       "mean_rmse": 2.7105
+      },
+      "Q3": {
+       "range": [
+        0.7722,
+        0.8744
+       ],
+       "n": 75,
+       "mean_rmse": 2.6495
+      },
+      "Q4": {
+       "range": [
+        0.8744,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6996
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 324.0,
+    "holdout": {
+     "holdout_rmse": 2.9626315579993556,
+     "retrain_s": 0.3349,
+     "predict_s": 0.0018,
+     "cv_rmse_of_winner": 2.3605952907213994
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.317409489797144,
+    "rmse_p10": 2.3370094063597704,
+    "rmse_median": 2.373934301376826,
+    "train_s_median": 0.8992756111547351,
+    "train_s_mean": 1.7325322526221472,
+    "train_s_p90": 4.025554809942841,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.1782704607009615,
+     "num_leaves": 26,
+     "max_depth": 10,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 7.770880903480778e-08,
+     "lambda_l2": 6.208173118189182e-07,
+     "feature_fraction": 0.9066251852865962,
+     "bagging_fraction": 0.5446659404372609,
+     "bagging_freq": 0,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 42,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.39848511102075174,
+     "mixture_diversity_lambda": 0.17280479377808397,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 47,
+     "mixture_gate_learning_rate": 0.012016249107228889,
+     "mixture_gate_lambda_l2": 0.0021469494837299567,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 12,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.3294337809020754,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6621,
+     "num_leaves": 0.1589,
+     "mixture_warmup_iters": 0.0457,
+     "mixture_diversity_lambda": 0.0436,
+     "mixture_init": 0.0307,
+     "mixture_gate_type": 0.013,
+     "mixture_refit_leaves": 0.0093,
+     "bagging_fraction": 0.0072,
+     "extra_trees": 0.006,
+     "mixture_routing_mode": 0.0056,
+     "min_data_in_leaf": 0.0038,
+     "feature_fraction": 0.0034,
+     "bagging_freq": 0.0029,
+     "mixture_balance_factor": 0.0027,
+     "max_depth": 0.0022,
+     "lambda_l2": 0.0017,
+     "mixture_hard_m_step": 0.0005,
+     "mixture_e_step_mode": 0.0004,
+     "mixture_r_smoothing": 0.0001,
+     "mixture_num_experts": 0.0001,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 79,
+        "mean": 3.9102,
+        "std": 4.6244,
+        "min": 2.393
+       },
+       "none": {
+        "n": 115,
+        "mean": 4.4517,
+        "std": 8.5199,
+        "min": 2.3286
+       },
+       "leaf_reuse": {
+        "n": 106,
+        "mean": 3.0408,
+        "std": 3.4764,
+        "min": 2.3174
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.8694,
+       "p_value": 0.165685,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 34,
+        "mean": 6.4044,
+        "std": 11.5607,
+        "min": 2.3432
+       },
+       "token_choice": {
+        "n": 266,
+        "mean": 3.479,
+        "std": 4.9914,
+        "min": 2.3174
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 2.9254,
+       "p_value": 0.159702,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 79,
+        "mean": 3.8125,
+        "std": 4.6376,
+        "min": 2.393
+       },
+       "em": {
+        "n": 30,
+        "mean": 5.6839,
+        "std": 8.2533,
+        "min": 2.3247
+       },
+       "gate_only": {
+        "n": 191,
+        "mean": 3.5155,
+        "std": 6.2933,
+        "min": 2.3174
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.297,
+       "p_value": 0.669971,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 27,
+        "mean": 4.9996,
+        "std": 8.7521,
+        "min": 2.5003
+       },
+       "tree_hierarchical": {
+        "n": 32,
+        "mean": 6.4422,
+        "std": 7.6258,
+        "min": 2.4584
+       },
+       "random": {
+        "n": 46,
+        "mean": 3.3079,
+        "std": 4.2808,
+        "min": 2.393
+       },
+       "uniform": {
+        "n": 195,
+        "mean": 3.3327,
+        "std": 5.7025,
+        "min": 2.3174
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.0248,
+       "p_value": 0.97405,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 34,
+        "mean": 5.7331,
+        "std": 11.1313,
+        "min": 2.3386
+       },
+       "none": {
+        "n": 38,
+        "mean": 6.9131,
+        "std": 8.6797,
+        "min": 2.3978
+       },
+       "markov": {
+        "n": 228,
+        "mean": 3.0068,
+        "std": 4.0365,
+        "min": 2.3174
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 2.7263,
+       "p_value": 0.172379,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 23,
+        "mean": 9.4155,
+        "std": 9.8231,
+        "min": 2.8489
+       },
+       "False": {
+        "n": 277,
+        "mean": 3.3452,
+        "std": 5.5157,
+        "min": 2.3174
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 6.0703,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 3.6563,
+        "std": 6.164,
+        "min": 2.3174
+       },
+       "True": {
+        "n": 20,
+        "mean": 5.9698,
+        "std": 5.8773,
+        "min": 2.7662
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.3135,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 46,
+       "mean_rmse": 4.1578
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 254,
+       "mean_rmse": 3.7477
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0941
+       ],
+       "n": 75,
+       "mean_rmse": 4.2317
+      },
+      "Q2": {
+       "range": [
+        0.0941,
+        0.1669
+       ],
+       "n": 75,
+       "mean_rmse": 2.6267
+      },
+      "Q3": {
+       "range": [
+        0.1669,
+        0.2293
+       ],
+       "n": 75,
+       "mean_rmse": 4.2741
+      },
+      "Q4": {
+       "range": [
+        0.2293,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 4.1097
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.8469
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        43.0
+       ],
+       "n": 67,
+       "mean_rmse": 3.1617
+      },
+      "Q3": {
+       "range": [
+        43.0,
+        46.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.7876
+      },
+      "Q4": {
+       "range": [
+        46.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 3.5569
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 64,
+       "mean_rmse": 4.9209
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 33,
+       "mean_rmse": 4.1736
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 203,
+       "mean_rmse": 3.4015
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1383
+       ],
+       "n": 75,
+       "mean_rmse": 7.5818
+      },
+      "Q2": {
+       "range": [
+        0.1383,
+        0.1729
+       ],
+       "n": 75,
+       "mean_rmse": 2.5667
+      },
+      "Q3": {
+       "range": [
+        0.1729,
+        0.2024
+       ],
+       "n": 75,
+       "mean_rmse": 2.4806
+      },
+      "Q4": {
+       "range": [
+        0.2024,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6132
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        25.0
+       ],
+       "n": 70,
+       "mean_rmse": 3.1524
+      },
+      "Q2": {
+       "range": [
+        25.0,
+        33.0
+       ],
+       "n": 70,
+       "mean_rmse": 3.6501
+      },
+      "Q3": {
+       "range": [
+        33.0,
+        43.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.8125
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 5.427
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 58,
+       "mean_rmse": 4.6517
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 57,
+       "mean_rmse": 4.1283
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 106,
+       "mean_rmse": 3.0262
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 4.0161
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 58,
+       "mean_rmse": 2.5337
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.9152
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        17.25
+       ],
+       "n": 98,
+       "mean_rmse": 3.9003
+      },
+      "Q4": {
+       "range": [
+        17.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.5045
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 2619.8,
+    "holdout": {
+     "holdout_rmse": 2.9084506082261097,
+     "retrain_s": 4.4684,
+     "predict_s": 0.0166,
+     "cv_rmse_of_winner": 2.317409489797144
+    }
+   }
+  },
+  "cpu_act@s44": {
+   "dataset": "cpu_act",
+   "seed": 44,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.05965822398535,
+    "std": 18.44113958458848
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.478020653643999,
+    "rmse_p10": 2.5062736680386064,
+    "rmse_median": 2.541616785532076,
+    "train_s_median": 0.16742631290107968,
+    "train_s_mean": 0.16766300991301736,
+    "train_s_p90": 0.21983964979648593,
+    "best_params": {
+     "learning_rate": 0.09794167184693416,
+     "num_leaves": 20,
+     "max_depth": 7,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.009843483454644992,
+     "lambda_l2": 0.0014078509805729065,
+     "feature_fraction": 0.9992950848593232,
+     "bagging_fraction": 0.9641084492758434,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5565,
+     "learning_rate": 0.2424,
+     "extra_trees": 0.0799,
+     "feature_fraction": 0.0526,
+     "bagging_fraction": 0.0263,
+     "num_leaves": 0.0157,
+     "bagging_freq": 0.0116,
+     "max_depth": 0.0108,
+     "lambda_l2": 0.0039,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7136,
+        "std": 0.6089,
+        "min": 2.478
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.8921,
+        "std": 1.1427,
+        "min": 2.8796
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.1785,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0864
+       ],
+       "n": 75,
+       "mean_rmse": 3.1451
+      },
+      "Q2": {
+       "range": [
+        0.0864,
+        0.0971
+       ],
+       "n": 75,
+       "mean_rmse": 2.5864
+      },
+      "Q3": {
+       "range": [
+        0.0971,
+        0.1132
+       ],
+       "n": 75,
+       "mean_rmse": 2.6362
+      },
+      "Q4": {
+       "range": [
+        0.1132,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8009
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.6861
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        23.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.6349
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        37.25
+       ],
+       "n": 82,
+       "mean_rmse": 2.6778
+      },
+      "Q4": {
+       "range": [
+        37.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.1672
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 53,
+       "mean_rmse": 2.9955
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 33,
+       "mean_rmse": 2.813
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 214,
+       "mean_rmse": 2.7386
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.5623
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 2.574
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 90,
+       "mean_rmse": 2.5874
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.419
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6384
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0022
+       ],
+       "n": 75,
+       "mean_rmse": 3.0447
+      },
+      "Q3": {
+       "range": [
+        0.0022,
+        0.0123
+       ],
+       "n": 75,
+       "mean_rmse": 2.6391
+      },
+      "Q4": {
+       "range": [
+        0.0123,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8463
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6267
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0005
+       ],
+       "n": 75,
+       "mean_rmse": 2.8511
+      },
+      "Q3": {
+       "range": [
+        0.0005,
+        0.0035
+       ],
+       "n": 75,
+       "mean_rmse": 2.6385
+      },
+      "Q4": {
+       "range": [
+        0.0035,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.0522
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9465
+       ],
+       "n": 75,
+       "mean_rmse": 3.2942
+      },
+      "Q2": {
+       "range": [
+        0.9465,
+        0.9787
+       ],
+       "n": 75,
+       "mean_rmse": 2.695
+      },
+      "Q3": {
+       "range": [
+        0.9787,
+        0.9903
+       ],
+       "n": 75,
+       "mean_rmse": 2.5976
+      },
+      "Q4": {
+       "range": [
+        0.9903,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.5817
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9328
+       ],
+       "n": 75,
+       "mean_rmse": 3.1352
+      },
+      "Q2": {
+       "range": [
+        0.9328,
+        0.9574
+       ],
+       "n": 75,
+       "mean_rmse": 2.7428
+      },
+      "Q3": {
+       "range": [
+        0.9574,
+        0.9762
+       ],
+       "n": 75,
+       "mean_rmse": 2.6153
+      },
+      "Q4": {
+       "range": [
+        0.9762,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6753
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 259.5,
+    "holdout": {
+     "holdout_rmse": 2.276056326993748,
+     "retrain_s": 0.1879,
+     "predict_s": 0.0016,
+     "cv_rmse_of_winner": 2.478020653643999
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4769960029494182,
+    "rmse_p10": 2.497449208914516,
+    "rmse_median": 2.613617203523,
+    "train_s_median": 1.0052551800385117,
+    "train_s_mean": 2.206859457936138,
+    "train_s_p90": 8.382487836964431,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.17270510500656738,
+     "num_leaves": 21,
+     "max_depth": 7,
+     "min_data_in_leaf": 8,
+     "lambda_l1": 0.002386208830816849,
+     "lambda_l2": 1.6322193213962908e-06,
+     "feature_fraction": 0.7305226341871558,
+     "bagging_fraction": 0.9905098868031205,
+     "bagging_freq": 2,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 19,
+     "mixture_balance_factor": 8,
+     "mixture_smoothing_lambda": 0.8418819836531914,
+     "mixture_diversity_lambda": 0.31926696743694477,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 5,
+     "mixture_gate_num_leaves": 55,
+     "mixture_gate_learning_rate": 0.014143788008586948,
+     "mixture_gate_lambda_l2": 0.8352509062418293,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 23,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.09425879081069964,
+     "mixture_elbo_drop_threshold": 0.002017470119671719,
+     "mixture_elbo_plateau_threshold": 0.0033205792190226105,
+     "mixture_elbo_window": 6,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 2,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "learning_rate": 0.3526,
+     "min_data_in_leaf": 0.2106,
+     "feature_fraction": 0.1909,
+     "mixture_diversity_lambda": 0.1066,
+     "bagging_fraction": 0.0246,
+     "bagging_freq": 0.0197,
+     "mixture_num_experts": 0.019,
+     "extra_trees": 0.0174,
+     "max_depth": 0.0106,
+     "mixture_r_smoothing": 0.0106,
+     "mixture_balance_factor": 0.0086,
+     "mixture_init": 0.0064,
+     "mixture_warmup_iters": 0.0053,
+     "mixture_gate_type": 0.0049,
+     "mixture_hard_m_step": 0.0045,
+     "lambda_l1": 0.0026,
+     "mixture_e_step_mode": 0.0023,
+     "mixture_routing_mode": 0.0013,
+     "num_leaves": 0.0011,
+     "mixture_refit_leaves": 0.0003,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 55,
+        "mean": 6.4395,
+        "std": 7.3464,
+        "min": 2.6392
+       },
+       "none": {
+        "n": 109,
+        "mean": 3.946,
+        "std": 5.6487,
+        "min": 2.5051
+       },
+       "leaf_reuse": {
+        "n": 136,
+        "mean": 2.9738,
+        "std": 1.8523,
+        "min": 2.477
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.9722,
+       "p_value": 0.088551,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 270,
+        "mean": 3.663,
+        "std": 4.2893,
+        "min": 2.477
+       },
+       "expert_choice": {
+        "n": 30,
+        "mean": 6.6567,
+        "std": 8.5122,
+        "min": 2.5943
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 2.9937,
+       "p_value": 0.071293,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 66,
+        "mean": 5.935,
+        "std": 7.1602,
+        "min": 2.6392
+       },
+       "em": {
+        "n": 162,
+        "mean": 3.1389,
+        "std": 2.2196,
+        "min": 2.477
+       },
+       "loss_only": {
+        "n": 72,
+        "mean": 4.0072,
+        "std": 6.2746,
+        "min": 2.478
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.8683,
+       "p_value": 0.25975,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 147,
+        "mean": 2.8227,
+        "std": 1.2897,
+        "min": 2.477
+       },
+       "tree_hierarchical": {
+        "n": 24,
+        "mean": 4.5702,
+        "std": 4.3545,
+        "min": 2.5943
+       },
+       "random": {
+        "n": 88,
+        "mean": 4.0831,
+        "std": 5.2335,
+        "min": 2.5051
+       },
+       "gmm": {
+        "n": 41,
+        "mean": 7.434,
+        "std": 9.3421,
+        "min": 2.7447
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 1.2604,
+       "p_value": 0.029782,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 16,
+        "mean": 8.6263,
+        "std": 11.0315,
+        "min": 2.5797
+       },
+       "ema": {
+        "n": 238,
+        "mean": 3.1926,
+        "std": 3.3147,
+        "min": 2.477
+       },
+       "markov": {
+        "n": 46,
+        "mean": 6.3232,
+        "std": 6.7175,
+        "min": 2.7447
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 3.1306,
+       "p_value": 0.003613,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 57,
+        "mean": 6.6497,
+        "std": 7.0774,
+        "min": 2.6722
+       },
+       "False": {
+        "n": 243,
+        "mean": 3.332,
+        "std": 4.0673,
+        "min": 2.477
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 3.3177,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 6.0155,
+        "std": 3.1062,
+        "min": 3.1574
+       },
+       "False": {
+        "n": 279,
+        "mean": 3.8079,
+        "std": 5.0394,
+        "min": 2.477
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.2076,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 64,
+       "mean_rmse": 7.2549
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 236,
+       "mean_rmse": 3.0695
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2345
+       ],
+       "n": 75,
+       "mean_rmse": 6.2211
+      },
+      "Q2": {
+       "range": [
+        0.2345,
+        0.2894
+       ],
+       "n": 75,
+       "mean_rmse": 3.8125
+      },
+      "Q3": {
+       "range": [
+        0.2894,
+        0.3216
+       ],
+       "n": 75,
+       "mean_rmse": 2.7086
+      },
+      "Q4": {
+       "range": [
+        0.3216,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.1074
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 70,
+       "mean_rmse": 3.0516
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        19.5
+       ],
+       "n": 80,
+       "mean_rmse": 3.4447
+      },
+      "Q3": {
+       "range": [
+        19.5,
+        26.0
+       ],
+       "n": 69,
+       "mean_rmse": 3.1039
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 5.9921
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 49,
+       "mean_rmse": 3.0644
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 91,
+       "mean_rmse": 4.3002
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 38,
+       "mean_rmse": 6.9343
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 122,
+       "mean_rmse": 3.1454
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1361
+       ],
+       "n": 75,
+       "mean_rmse": 6.6621
+      },
+      "Q2": {
+       "range": [
+        0.1361,
+        0.1739
+       ],
+       "n": 75,
+       "mean_rmse": 3.1236
+      },
+      "Q3": {
+       "range": [
+        0.1739,
+        0.2025
+       ],
+       "n": 75,
+       "mean_rmse": 3.1326
+      },
+      "Q4": {
+       "range": [
+        0.2025,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9313
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        27.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.7317
+      },
+      "Q2": {
+       "range": [
+        27.75,
+        53.5
+       ],
+       "n": 75,
+       "mean_rmse": 3.1752
+      },
+      "Q3": {
+       "range": [
+        53.5,
+        89.25
+       ],
+       "n": 75,
+       "mean_rmse": 4.3924
+      },
+      "Q4": {
+       "range": [
+        89.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.5503
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 67,
+       "mean_rmse": 3.6869
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 80,
+       "mean_rmse": 4.2288
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 47,
+       "mean_rmse": 4.0847
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 106,
+       "mean_rmse": 3.8812
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.6033
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        14.0
+       ],
+       "n": 85,
+       "mean_rmse": 3.4869
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        25.0
+       ],
+       "n": 75,
+       "mean_rmse": 3.0687
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 6.4697
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 3330.7,
+    "holdout": {
+     "holdout_rmse": 2.2757066641793826,
+     "retrain_s": 0.8923,
+     "predict_s": 0.0112,
+     "cv_rmse_of_winner": 2.4769960029494182
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_elevators_report.md
+++ b/bench_results/meth2_v080/ds_elevators_report.md
@@ -1,0 +1,508 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['elevators'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| elevators | naive-lightgbm | **0.00238** ± 0.00005 | 0.00264 | 0.0% | 0.19 |
+| elevators | moe | **0.00229** ± 0.00005 | 0.00256 | 0.0% | 2.07 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| elevators@s42 | naive-lightgbm | 0.0026 | 0.0027 | 0.125 | 208 |
+| elevators@s42 | moe | 0.0026 | 0.0027 | 2.033 | 3347 |
+| elevators@s43 | naive-lightgbm | 0.0027 | 0.0027 | 0.151 | 245 |
+| elevators@s43 | moe | 0.0026 | 0.0027 | 2.691 | 3860 |
+| elevators@s44 | naive-lightgbm | 0.0026 | 0.0027 | 0.150 | 228 |
+| elevators@s44 | moe | 0.0026 | 0.0027 | 1.982 | 2647 |
+
+
+
+---
+
+## elevators@s42  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00245** (winner retrained in 0.14s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0027
+- train: median 0.125s/fold, mean 0.133s, p90 0.185s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.705 |
+| `learning_rate` | 0.177 |
+| `num_leaves` | 0.033 |
+| `bagging_freq` | 0.030 |
+| `feature_fraction` | 0.022 |
+| `bagging_fraction` | 0.013 |
+| `extra_trees` | 0.009 |
+| `max_depth` | 0.007 |
+| `min_data_in_leaf` | 0.005 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.0028 | 0.0004 | 0.0026 |
+| True | 22 | 0.0036 | 0.0009 | 0.0028 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0033 | 0.0027 | 0.0027 | 0.0028 | **Q2** [0.1755, 0.2043] |
+| `num_leaves` | 0.0029 | 0.0027 | 0.0028 | 0.0031 | **Q2** [14.0, 18.0] |
+| `max_depth` | 0.0031 | — | — | 0.0028 | **Q4** [6.0, ∞) |
+| `min_data_in_leaf` | 0.0028 | 0.0028 | 0.0029 | 0.0031 | **Q1** [None, 11.0] |
+| `lambda_l1` | 0.0029 | 0.0029 | 0.0028 | 0.0030 | **Q3** [0.0003, 0.0015] |
+| `lambda_l2` | 0.0031 | 0.0028 | 0.0028 | 0.0029 | **Q2** [0.0001, 0.0003] |
+| `feature_fraction` | 0.0031 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.9043, 0.9313] |
+| `bagging_fraction` | 0.0031 | 0.0028 | 0.0028 | 0.0029 | **Q2** [0.9313, 0.9559] |
+
+#### E. Slice plot
+
+![elevators@s42/naive-lightgbm](slice_elevators@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00236** (winner retrained in 2.03s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0026
+- train: median 2.033s/fold, mean 2.208s, p90 3.592s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.405 |
+| `mixture_init` | 0.344 |
+| `mixture_diversity_lambda` | 0.039 |
+| `mixture_r_smoothing` | 0.022 |
+| `mixture_warmup_iters` | 0.022 |
+| `max_depth` | 0.022 |
+| `mixture_num_experts` | 0.021 |
+| `extra_trees` | 0.018 |
+| `mixture_refit_leaves` | 0.015 |
+| `min_data_in_leaf` | 0.014 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 0.0036 (n=179) | expert_choice | Δ +0.0015 | p=8.29e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 243 | 0.0041 | 0.0043 | 0.0026 |
+| gbdt | 30 | 0.0045 | 0.0031 | 0.0026 |
+| none | 27 | 0.0050 | 0.0046 | 0.0026 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 179 | 0.0036 | 0.0033 | 0.0026 |
+| expert_choice | 121 | 0.0051 | 0.0052 | 0.0026 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 172 | 0.0036 | 0.0035 | 0.0026 |
+| loss_only | 104 | 0.0046 | 0.0047 | 0.0026 |
+| em | 24 | 0.0066 | 0.0058 | 0.0027 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 236 | 0.0032 | 0.0022 | 0.0026 |
+| random | 33 | 0.0035 | 0.0011 | 0.0026 |
+| tree_hierarchical | 15 | 0.0112 | 0.0073 | 0.0026 |
+| gmm | 16 | 0.0141 | 0.0069 | 0.0026 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 129 | 0.0040 | 0.0040 | 0.0026 |
+| none | 90 | 0.0041 | 0.0041 | 0.0026 |
+| markov | 81 | 0.0047 | 0.0046 | 0.0027 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.0041 | 0.0043 | 0.0026 |
+| True | 20 | 0.0054 | 0.0028 | 0.0033 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 265 | 0.0041 | 0.0042 | 0.0026 |
+| True | 35 | 0.0051 | 0.0043 | 0.0028 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0052 | — | — | 0.0039 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0034 | 0.0036 | 0.0042 | 0.0056 | **Q1** [None, 0.0667] |
+| `mixture_warmup_iters` | 0.0051 | 0.0044 | 0.0035 | 0.0038 | **Q3** [39.5, 46.0] |
+| `mixture_balance_factor` | — | 0.0036 | 0.0051 | 0.0045 | **Q2** [2.0, 5.0] |
+| `learning_rate` | 0.0054 | 0.0036 | 0.0039 | 0.0039 | **Q2** [0.1944, 0.2472] |
+| `num_leaves` | 0.0043 | 0.0033 | 0.0042 | 0.0051 | **Q2** [14.0, 18.5] |
+| `max_depth` | 0.0051 | 0.0042 | 0.0038 | 0.0041 | **Q3** [11.0, 12.0] |
+| `min_data_in_leaf` | 0.0042 | 0.0034 | 0.0036 | 0.0056 | **Q2** [16.75, 21.0] |
+
+#### E. Slice plot
+
+![elevators@s42/moe](slice_elevators@s42_moe.png)
+
+
+---
+
+## elevators@s43  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00236** (winner retrained in 0.14s, cv score of winner: 0.0027)
+- cv best RMSE: 0.0027, median: 0.0027, p10: 0.0027
+- train: median 0.151s/fold, mean 0.158s, p90 0.234s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.552 |
+| `learning_rate` | 0.246 |
+| `num_leaves` | 0.055 |
+| `feature_fraction` | 0.046 |
+| `min_data_in_leaf` | 0.026 |
+| `bagging_fraction` | 0.025 |
+| `max_depth` | 0.021 |
+| `extra_trees` | 0.018 |
+| `bagging_freq` | 0.007 |
+| `lambda_l2` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.0028 | 0.0005 | 0.0027 |
+| True | 21 | 0.0037 | 0.0007 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0033 | 0.0027 | 0.0028 | 0.0027 | **Q2** [0.1548, 0.1835] |
+| `num_leaves` | 0.0028 | 0.0028 | 0.0029 | 0.0031 | **Q1** [None, 17.0] |
+| `max_depth` | 0.0034 | 0.0029 | — | 0.0029 | **Q2** [5.0, 8.0] |
+| `min_data_in_leaf` | 0.0028 | 0.0028 | 0.0027 | 0.0032 | **Q3** [20.5, 24.0] |
+| `lambda_l1` | 0.0029 | 0.0028 | 0.0028 | 0.0031 | **Q2** [0.0, 0.0004] |
+| `lambda_l2` | 0.0029 | 0.0029 | 0.0029 | 0.0030 | **Q1** [None, 0.0001] |
+| `feature_fraction` | 0.0032 | 0.0029 | 0.0028 | 0.0027 | **Q4** [0.9712, ∞) |
+| `bagging_fraction` | 0.0031 | 0.0029 | 0.0029 | 0.0028 | **Q4** [0.9656, ∞) |
+
+#### E. Slice plot
+
+![elevators@s43/naive-lightgbm](slice_elevators@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00225** (winner retrained in 2.56s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0026
+- train: median 2.691s/fold, mean 2.551s, p90 4.247s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.341 |
+| `mixture_r_smoothing` | 0.130 |
+| `mixture_init` | 0.119 |
+| `mixture_diversity_lambda` | 0.081 |
+| `mixture_refit_leaves` | 0.063 |
+| `mixture_warmup_iters` | 0.050 |
+| `min_data_in_leaf` | 0.042 |
+| `mixture_gate_type` | 0.034 |
+| `learning_rate` | 0.029 |
+| `bagging_freq` | 0.024 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 262 | 0.0034 | 0.0028 | 0.0026 |
+| gbdt | 22 | 0.0047 | 0.0029 | 0.0028 |
+| none | 16 | 0.0061 | 0.0053 | 0.0026 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 279 | 0.0034 | 0.0023 | 0.0026 |
+| token_choice | 21 | 0.0075 | 0.0067 | 0.0034 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 219 | 0.0034 | 0.0026 | 0.0026 |
+| gate_only | 52 | 0.0041 | 0.0040 | 0.0027 |
+| em | 29 | 0.0047 | 0.0041 | 0.0026 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 209 | 0.0033 | 0.0028 | 0.0026 |
+| uniform | 59 | 0.0036 | 0.0020 | 0.0027 |
+| tree_hierarchical | 14 | 0.0062 | 0.0052 | 0.0028 |
+| gmm | 18 | 0.0064 | 0.0044 | 0.0027 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 240 | 0.0035 | 0.0029 | 0.0026 |
+| ema | 42 | 0.0041 | 0.0028 | 0.0027 |
+| none | 18 | 0.0056 | 0.0043 | 0.0027 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 276 | 0.0034 | 0.0025 | 0.0026 |
+| True | 24 | 0.0069 | 0.0061 | 0.0031 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.0036 | 0.0029 | 0.0026 |
+| True | 22 | 0.0051 | 0.0045 | 0.0028 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0051 | — | — | 0.0034 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0031 | 0.0037 | 0.0032 | 0.0048 | **Q1** [None, 0.0534] |
+| `mixture_warmup_iters` | 0.0031 | 0.0033 | 0.0033 | 0.0047 | **Q1** [None, 7.0] |
+| `mixture_balance_factor` | 0.0051 | — | 0.0032 | 0.0036 | **Q3** [5.0, 7.0] |
+| `learning_rate` | 0.0046 | 0.0032 | 0.0030 | 0.0039 | **Q3** [0.1921, 0.2184] |
+| `num_leaves` | 0.0044 | 0.0037 | 0.0031 | 0.0035 | **Q3** [107.0, 116.0] |
+| `max_depth` | 0.0041 | — | 0.0035 | 0.0038 | **Q3** [6.0, 8.0] |
+| `min_data_in_leaf` | 0.0040 | 0.0034 | 0.0034 | 0.0040 | **Q2** [19.0, 24.0] |
+
+#### E. Slice plot
+
+![elevators@s43/moe](slice_elevators@s43_moe.png)
+
+
+---
+
+## elevators@s44  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00234** (winner retrained in 0.30s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0027
+- train: median 0.150s/fold, mean 0.147s, p90 0.211s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.604 |
+| `learning_rate` | 0.098 |
+| `feature_fraction` | 0.079 |
+| `num_leaves` | 0.058 |
+| `bagging_fraction` | 0.052 |
+| `bagging_freq` | 0.046 |
+| `max_depth` | 0.030 |
+| `min_data_in_leaf` | 0.019 |
+| `extra_trees` | 0.013 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.0028 | 0.0005 | 0.0026 |
+| True | 21 | 0.0035 | 0.0008 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0032 | 0.0027 | 0.0027 | 0.0029 | **Q2** [0.1153, 0.1319] |
+| `num_leaves` | 0.0031 | 0.0029 | 0.0028 | 0.0027 | **Q4** [124.0, ∞) |
+| `max_depth` | 0.0031 | 0.0028 | 0.0028 | 0.0028 | **Q2** [6.0, 7.0] |
+| `min_data_in_leaf` | 0.0029 | 0.0027 | 0.0028 | 0.0031 | **Q2** [15.0, 19.0] |
+| `lambda_l1` | 0.0030 | 0.0027 | 0.0028 | 0.0031 | **Q2** [0.0, 0.0002] |
+| `lambda_l2` | 0.0028 | 0.0028 | 0.0028 | 0.0030 | **Q1** [None, 0.0003] |
+| `feature_fraction` | 0.0032 | 0.0028 | 0.0028 | 0.0027 | **Q4** [0.9776, ∞) |
+| `bagging_fraction` | 0.0031 | 0.0029 | 0.0027 | 0.0027 | **Q3** [0.9628, 0.9815] |
+
+#### E. Slice plot
+
+![elevators@s44/naive-lightgbm](slice_elevators@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00225** (winner retrained in 1.62s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0026
+- train: median 1.982s/fold, mean 1.747s, p90 2.838s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.420 |
+| `mixture_r_smoothing` | 0.070 |
+| `bagging_freq` | 0.069 |
+| `mixture_hard_m_step` | 0.066 |
+| `mixture_init` | 0.059 |
+| `mixture_refit_leaves` | 0.050 |
+| `mixture_warmup_iters` | 0.049 |
+| `mixture_num_experts` | 0.048 |
+| `feature_fraction` | 0.040 |
+| `bagging_fraction` | 0.036 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 0.0034 (n=250) | token_choice | Δ +0.0018 | p=9.37e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 247 | 0.0033 | 0.0025 | 0.0026 |
+| none | 16 | 0.0054 | 0.0044 | 0.0027 |
+| leaf_reuse | 37 | 0.0058 | 0.0057 | 0.0026 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 250 | 0.0034 | 0.0029 | 0.0026 |
+| token_choice | 50 | 0.0052 | 0.0046 | 0.0027 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 217 | 0.0034 | 0.0028 | 0.0026 |
+| loss_only | 47 | 0.0038 | 0.0027 | 0.0026 |
+| em | 36 | 0.0056 | 0.0055 | 0.0026 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 55 | 0.0032 | 0.0011 | 0.0026 |
+| gmm | 195 | 0.0034 | 0.0028 | 0.0026 |
+| random | 35 | 0.0046 | 0.0039 | 0.0026 |
+| tree_hierarchical | 15 | 0.0076 | 0.0076 | 0.0026 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 249 | 0.0031 | 0.0015 | 0.0026 |
+| markov | 35 | 0.0060 | 0.0063 | 0.0027 |
+| none | 16 | 0.0090 | 0.0064 | 0.0030 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 258 | 0.0033 | 0.0025 | 0.0026 |
+| True | 42 | 0.0061 | 0.0057 | 0.0029 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.0037 | 0.0034 | 0.0026 |
+| True | 21 | 0.0044 | 0.0017 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0042 | 0.0066 | — | 0.0033 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0028 | 0.0029 | 0.0035 | 0.0056 | **Q1** [None, 0.0104] |
+| `mixture_warmup_iters` | 0.0030 | 0.0029 | 0.0035 | 0.0053 | **Q2** [6.0, 8.0] |
+| `mixture_balance_factor` | — | 0.0033 | 0.0036 | 0.0044 | **Q2** [2.0, 3.0] |
+| `learning_rate` | 0.0052 | 0.0029 | 0.0035 | 0.0033 | **Q2** [0.1798, 0.232] |
+| `num_leaves` | 0.0056 | 0.0029 | 0.0030 | 0.0033 | **Q2** [101.75, 115.0] |
+| `max_depth` | 0.0054 | 0.0031 | — | 0.0033 | **Q2** [10.0, 11.0] |
+| `min_data_in_leaf` | 0.0046 | 0.0031 | 0.0032 | 0.0039 | **Q2** [35.0, 41.0] |
+
+#### E. Slice plot
+
+![elevators@s44/moe](slice_elevators@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| elevators@s42 | `mixture_routing_mode` | **token_choice** | +0.0015 | 8.29e-03 |
+| elevators@s44 | `mixture_routing_mode` | **expert_choice** | +0.0018 | 9.37e-03 |

--- a/bench_results/meth2_v080/ds_elevators_summary.json
+++ b/bench_results/meth2_v080/ds_elevators_summary.json
@@ -1,0 +1,2759 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "elevators"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "elevators": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.0024475993016704815,
+      "cv_best": 0.0026330350603668623,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1406
+     },
+     "43": {
+      "holdout_rmse": 0.002364735983277477,
+      "cv_best": 0.0026565633378986203,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1378
+     },
+     "44": {
+      "holdout_rmse": 0.002340609908281478,
+      "cv_best": 0.0026358550583388644,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2997
+     }
+    },
+    "holdout_mean": 0.002384,
+    "holdout_std": 4.6e-05,
+    "cv_best_mean": 0.002642
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.00236242854472564,
+      "cv_best": 0.0025729913613148523,
+      "crash_rate": 0.0,
+      "retrain_s": 2.0288
+     },
+     "43": {
+      "holdout_rmse": 0.0022484661471989915,
+      "cv_best": 0.0025558869266825964,
+      "crash_rate": 0.0,
+      "retrain_s": 2.5569
+     },
+     "44": {
+      "holdout_rmse": 0.002249339046022266,
+      "cv_best": 0.002564369145363277,
+      "crash_rate": 0.0,
+      "retrain_s": 1.6199
+     }
+    },
+    "holdout_mean": 0.002287,
+    "holdout_std": 5.4e-05,
+    "cv_best_mean": 0.002564
+   }
+  }
+ },
+ "runs": {
+  "elevators@s42": {
+   "dataset": "elevators",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021624375,
+    "std": 0.006717125937435966
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0026330350603668623,
+    "rmse_p10": 0.0026671229525594723,
+    "rmse_median": 0.0027124111761814007,
+    "train_s_median": 0.12450971510261297,
+    "train_s_mean": 0.13337895847856998,
+    "train_s_p90": 0.18536675952374945,
+    "best_params": {
+     "learning_rate": 0.23778434791157024,
+     "num_leaves": 15,
+     "max_depth": 6,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 0.00034200225716518373,
+     "lambda_l2": 0.00011876407186465006,
+     "feature_fraction": 0.9097243991797953,
+     "bagging_fraction": 0.9406735868207391,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.7053,
+     "learning_rate": 0.1767,
+     "num_leaves": 0.0325,
+     "bagging_freq": 0.0298,
+     "feature_fraction": 0.0221,
+     "bagging_fraction": 0.0127,
+     "extra_trees": 0.0088,
+     "max_depth": 0.0071,
+     "min_data_in_leaf": 0.005,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.0036,
+        "std": 0.0009,
+        "min": 0.0028
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.0028,
+        "std": 0.0004,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0008,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1755
+       ],
+       "n": 75,
+       "mean_rmse": 0.0033
+      },
+      "Q2": {
+       "range": [
+        0.1755,
+        0.2043
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2043,
+        0.2322
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.2322,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        41.25
+       ],
+       "n": 85,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        41.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0031
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 235,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        14.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        18.25
+       ],
+       "n": 86,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        18.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0015
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0015,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0011
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0011,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9043
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9043,
+        0.9313
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9313,
+        0.9528
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9528,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9313
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9313,
+        0.9559
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9559,
+        0.9726
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9726,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 207.9,
+    "holdout": {
+     "holdout_rmse": 0.0024475993016704815,
+     "retrain_s": 0.1406,
+     "predict_s": 0.0016,
+     "cv_rmse_of_winner": 0.0026330350603668623
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0025729913613148523,
+    "rmse_p10": 0.002596750970663779,
+    "rmse_median": 0.00269191744064352,
+    "train_s_median": 2.033215265162289,
+    "train_s_mean": 2.207939158361405,
+    "train_s_p90": 3.5917619701847436,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.29868571049940207,
+     "num_leaves": 19,
+     "max_depth": 9,
+     "min_data_in_leaf": 21,
+     "lambda_l1": 5.812268035712692e-06,
+     "lambda_l2": 0.007537288470915052,
+     "feature_fraction": 0.8985197053051862,
+     "bagging_fraction": 0.9848096155985847,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 50,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.0018868210892752958,
+     "mixture_diversity_lambda": 0.03704792885855443,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 60,
+     "mixture_gate_learning_rate": 0.08116074239961334,
+     "mixture_gate_lambda_l2": 0.04794264970464937,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 16,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.3153330975584464,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 5,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "lambda_l1": 0.4051,
+     "mixture_init": 0.3441,
+     "mixture_diversity_lambda": 0.0386,
+     "mixture_r_smoothing": 0.0224,
+     "mixture_warmup_iters": 0.0223,
+     "max_depth": 0.022,
+     "mixture_num_experts": 0.0214,
+     "extra_trees": 0.018,
+     "mixture_refit_leaves": 0.015,
+     "min_data_in_leaf": 0.0141,
+     "feature_fraction": 0.0139,
+     "num_leaves": 0.0119,
+     "mixture_gate_type": 0.0097,
+     "bagging_freq": 0.0092,
+     "mixture_balance_factor": 0.0091,
+     "bagging_fraction": 0.0072,
+     "mixture_e_step_mode": 0.0071,
+     "mixture_routing_mode": 0.0049,
+     "learning_rate": 0.0031,
+     "lambda_l2": 0.0008,
+     "mixture_hard_m_step": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 243,
+        "mean": 0.0041,
+        "std": 0.0043,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 27,
+        "mean": 0.005,
+        "std": 0.0046,
+        "min": 0.0026
+       },
+       "gbdt": {
+        "n": 30,
+        "mean": 0.0045,
+        "std": 0.0031,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0004,
+       "p_value": 0.516867,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 179,
+        "mean": 0.0036,
+        "std": 0.0033,
+        "min": 0.0026
+       },
+       "expert_choice": {
+        "n": 121,
+        "mean": 0.0051,
+        "std": 0.0052,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0015,
+       "p_value": 0.008285,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 104,
+        "mean": 0.0046,
+        "std": 0.0047,
+        "min": 0.0026
+       },
+       "gate_only": {
+        "n": 172,
+        "mean": 0.0036,
+        "std": 0.0035,
+        "min": 0.0026
+       },
+       "em": {
+        "n": 24,
+        "mean": 0.0066,
+        "std": 0.0058,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.001,
+       "p_value": 0.067748,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 33,
+        "mean": 0.0035,
+        "std": 0.0011,
+        "min": 0.0026
+       },
+       "gmm": {
+        "n": 16,
+        "mean": 0.0141,
+        "std": 0.0069,
+        "min": 0.0026
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 0.0112,
+        "std": 0.0073,
+        "min": 0.0026
+       },
+       "uniform": {
+        "n": 236,
+        "mean": 0.0032,
+        "std": 0.0022,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0003,
+       "p_value": 0.203743,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 129,
+        "mean": 0.004,
+        "std": 0.004,
+        "min": 0.0026
+       },
+       "markov": {
+        "n": 81,
+        "mean": 0.0047,
+        "std": 0.0046,
+        "min": 0.0027
+       },
+       "none": {
+        "n": 90,
+        "mean": 0.0041,
+        "std": 0.0041,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.0001,
+       "p_value": 0.75591,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 0.0054,
+        "std": 0.0028,
+        "min": 0.0033
+       },
+       "False": {
+        "n": 280,
+        "mean": 0.0041,
+        "std": 0.0043,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0013,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 35,
+        "mean": 0.0051,
+        "std": 0.0043,
+        "min": 0.0028
+       },
+       "False": {
+        "n": 265,
+        "mean": 0.0041,
+        "std": 0.0042,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0052
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 227,
+       "mean_rmse": 0.0039
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0667
+       ],
+       "n": 75,
+       "mean_rmse": 0.0034
+      },
+      "Q2": {
+       "range": [
+        0.0667,
+        0.1505
+       ],
+       "n": 75,
+       "mean_rmse": 0.0036
+      },
+      "Q3": {
+       "range": [
+        0.1505,
+        0.2716
+       ],
+       "n": 75,
+       "mean_rmse": 0.0042
+      },
+      "Q4": {
+       "range": [
+        0.2716,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0056
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        32.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0051
+      },
+      "Q2": {
+       "range": [
+        32.0,
+        39.5
+       ],
+       "n": 77,
+       "mean_rmse": 0.0044
+      },
+      "Q3": {
+       "range": [
+        39.5,
+        46.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0035
+      },
+      "Q4": {
+       "range": [
+        46.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.0038
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        5.0
+       ],
+       "n": 143,
+       "mean_rmse": 0.0036
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        10.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.0051
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0045
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1944
+       ],
+       "n": 75,
+       "mean_rmse": 0.0054
+      },
+      "Q2": {
+       "range": [
+        0.1944,
+        0.2472
+       ],
+       "n": 75,
+       "mean_rmse": 0.0036
+      },
+      "Q3": {
+       "range": [
+        0.2472,
+        0.2782
+       ],
+       "n": 75,
+       "mean_rmse": 0.0039
+      },
+      "Q4": {
+       "range": [
+        0.2782,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0039
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0043
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.5
+       ],
+       "n": 80,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        18.5,
+        29.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0042
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.0051
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0051
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 36,
+       "mean_rmse": 0.0042
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.0038
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0041
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        16.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0042
+      },
+      "Q2": {
+       "range": [
+        16.75,
+        21.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0034
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        35.25
+       ],
+       "n": 78,
+       "mean_rmse": 0.0036
+      },
+      "Q4": {
+       "range": [
+        35.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0056
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 3346.9,
+    "holdout": {
+     "holdout_rmse": 0.00236242854472564,
+     "retrain_s": 2.0288,
+     "predict_s": 0.0278,
+     "cv_rmse_of_winner": 0.0025729913613148523
+    }
+   }
+  },
+  "elevators@s43": {
+   "dataset": "elevators",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021558875,
+    "std": 0.0066420654720030425
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0026565633378986203,
+    "rmse_p10": 0.002680527752898886,
+    "rmse_median": 0.002715646736400354,
+    "train_s_median": 0.1505495473742485,
+    "train_s_mean": 0.15772248706469932,
+    "train_s_p90": 0.2340463417023421,
+    "best_params": {
+     "learning_rate": 0.22904905338999487,
+     "num_leaves": 13,
+     "max_depth": 9,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 0.0006508740691517306,
+     "lambda_l2": 2.9956687016156434e-07,
+     "feature_fraction": 0.9381780782007021,
+     "bagging_fraction": 0.913244587365999,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.5518,
+     "learning_rate": 0.2458,
+     "num_leaves": 0.0554,
+     "feature_fraction": 0.0462,
+     "min_data_in_leaf": 0.026,
+     "bagging_fraction": 0.0251,
+     "max_depth": 0.0207,
+     "extra_trees": 0.0182,
+     "bagging_freq": 0.0073,
+     "lambda_l2": 0.0035
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.0037,
+        "std": 0.0007,
+        "min": 0.0029
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.0028,
+        "std": 0.0005,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0009,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1548
+       ],
+       "n": 75,
+       "mean_rmse": 0.0033
+      },
+      "Q2": {
+       "range": [
+        0.1548,
+        0.1835
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.1835,
+        0.2143
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.2143,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        30.0
+       ],
+       "n": 82,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        49.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 22,
+       "mean_rmse": 0.0034
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 159,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        20.5
+       ],
+       "n": 82,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        20.5,
+        24.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 0.0032
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0015
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0015,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0911
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.0911,
+        0.4249
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        0.4249,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8619
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.8619,
+        0.9452
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.9452,
+        0.9712
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9712,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9085
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9085,
+        0.9387
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.9387,
+        0.9656
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        0.9656,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 244.9,
+    "holdout": {
+     "holdout_rmse": 0.002364735983277477,
+     "retrain_s": 0.1378,
+     "predict_s": 0.0025,
+     "cv_rmse_of_winner": 0.0026565633378986203
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0025558869266825964,
+    "rmse_p10": 0.002589709020553369,
+    "rmse_median": 0.002727453199263029,
+    "train_s_median": 2.6913707265630364,
+    "train_s_mean": 2.551096038270742,
+    "train_s_p90": 4.24650471650064,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.2071281473321863,
+     "num_leaves": 113,
+     "max_depth": 5,
+     "min_data_in_leaf": 22,
+     "lambda_l1": 1.4527619063074635e-07,
+     "lambda_l2": 2.876780287708679e-08,
+     "feature_fraction": 0.9707174860604778,
+     "bagging_fraction": 0.6748835760248554,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 8,
+     "mixture_balance_factor": 5,
+     "mixture_smoothing_lambda": 0.862438781475381,
+     "mixture_diversity_lambda": 0.0747498500200924,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 34,
+     "mixture_gate_learning_rate": 0.016698264405221944,
+     "mixture_gate_lambda_l2": 0.6219382408886488,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 22,
+     "mixture_expert_capacity_factor": 1.229544000797619,
+     "mixture_expert_choice_boost": 23.709448289740752,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "lambda_l1": 0.341,
+     "mixture_r_smoothing": 0.1297,
+     "mixture_init": 0.1194,
+     "mixture_diversity_lambda": 0.0812,
+     "mixture_refit_leaves": 0.0629,
+     "mixture_warmup_iters": 0.0496,
+     "min_data_in_leaf": 0.0423,
+     "mixture_gate_type": 0.0337,
+     "learning_rate": 0.0293,
+     "bagging_freq": 0.0244,
+     "mixture_balance_factor": 0.0155,
+     "feature_fraction": 0.0155,
+     "bagging_fraction": 0.0152,
+     "mixture_e_step_mode": 0.012,
+     "mixture_routing_mode": 0.0119,
+     "lambda_l2": 0.0075,
+     "num_leaves": 0.0057,
+     "mixture_num_experts": 0.0021,
+     "max_depth": 0.0008,
+     "mixture_hard_m_step": 0.0,
+     "extra_trees": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 22,
+        "mean": 0.0047,
+        "std": 0.0029,
+        "min": 0.0028
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0061,
+        "std": 0.0053,
+        "min": 0.0026
+       },
+       "leaf_reuse": {
+        "n": 262,
+        "mean": 0.0034,
+        "std": 0.0028,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0013,
+       "p_value": 0.062732,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 279,
+        "mean": 0.0034,
+        "std": 0.0023,
+        "min": 0.0026
+       },
+       "token_choice": {
+        "n": 21,
+        "mean": 0.0075,
+        "std": 0.0067,
+        "min": 0.0034
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0041,
+       "p_value": 0.013005,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 219,
+        "mean": 0.0034,
+        "std": 0.0026,
+        "min": 0.0026
+       },
+       "em": {
+        "n": 29,
+        "mean": 0.0047,
+        "std": 0.0041,
+        "min": 0.0026
+       },
+       "gate_only": {
+        "n": 52,
+        "mean": 0.0041,
+        "std": 0.004,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0007,
+       "p_value": 0.243948,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 18,
+        "mean": 0.0064,
+        "std": 0.0044,
+        "min": 0.0027
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 0.0062,
+        "std": 0.0052,
+        "min": 0.0028
+       },
+       "random": {
+        "n": 209,
+        "mean": 0.0033,
+        "std": 0.0028,
+        "min": 0.0026
+       },
+       "uniform": {
+        "n": 59,
+        "mean": 0.0036,
+        "std": 0.002,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.0003,
+       "p_value": 0.455912,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 42,
+        "mean": 0.0041,
+        "std": 0.0028,
+        "min": 0.0027
+       },
+       "none": {
+        "n": 18,
+        "mean": 0.0056,
+        "std": 0.0043,
+        "min": 0.0027
+       },
+       "markov": {
+        "n": 240,
+        "mean": 0.0035,
+        "std": 0.0029,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.0006,
+       "p_value": 0.162517,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 24,
+        "mean": 0.0069,
+        "std": 0.0061,
+        "min": 0.0031
+       },
+       "False": {
+        "n": 276,
+        "mean": 0.0034,
+        "std": 0.0025,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0035,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 0.0036,
+        "std": 0.0029,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 22,
+        "mean": 0.0051,
+        "std": 0.0045,
+        "min": 0.0028
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0015,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 46,
+       "mean_rmse": 0.0051
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 254,
+       "mean_rmse": 0.0034
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0534
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.0534,
+        0.0813
+       ],
+       "n": 75,
+       "mean_rmse": 0.0037
+      },
+      "Q3": {
+       "range": [
+        0.0813,
+        0.108
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        0.108,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0048
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0033
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.0047
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 56,
+       "mean_rmse": 0.0051
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 159,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 0.0036
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1384
+       ],
+       "n": 75,
+       "mean_rmse": 0.0046
+      },
+      "Q2": {
+       "range": [
+        0.1384,
+        0.1921
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q3": {
+       "range": [
+        0.1921,
+        0.2184
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        0.2184,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0039
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        80.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0044
+      },
+      "Q2": {
+       "range": [
+        80.75,
+        107.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0037
+      },
+      "Q3": {
+       "range": [
+        107.0,
+        116.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0031
+      },
+      "Q4": {
+       "range": [
+        116.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0035
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 46,
+       "mean_rmse": 0.0041
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 163,
+       "mean_rmse": 0.0035
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 91,
+       "mean_rmse": 0.0038
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.004
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        24.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0034
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        36.0
+       ],
+       "n": 86,
+       "mean_rmse": 0.0034
+      },
+      "Q4": {
+       "range": [
+        36.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.004
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 3859.9,
+    "holdout": {
+     "holdout_rmse": 0.0022484661471989915,
+     "retrain_s": 2.5569,
+     "predict_s": 0.0239,
+     "cv_rmse_of_winner": 0.0025558869266825964
+    }
+   }
+  },
+  "elevators@s44": {
+   "dataset": "elevators",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021623500000000004,
+    "std": 0.006704326793198554
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0026358550583388644,
+    "rmse_p10": 0.002654763558637113,
+    "rmse_median": 0.002696921483605334,
+    "train_s_median": 0.14967386964708568,
+    "train_s_mean": 0.14700892777492602,
+    "train_s_p90": 0.21082471027970315,
+    "best_params": {
+     "learning_rate": 0.11710211476394085,
+     "num_leaves": 123,
+     "max_depth": 8,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 2.7563434176324515e-05,
+     "lambda_l2": 0.00028475448024112987,
+     "feature_fraction": 0.9924300268336325,
+     "bagging_fraction": 0.9732175073815882,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6035,
+     "learning_rate": 0.0978,
+     "feature_fraction": 0.0785,
+     "num_leaves": 0.0582,
+     "bagging_fraction": 0.0524,
+     "bagging_freq": 0.0456,
+     "max_depth": 0.0298,
+     "min_data_in_leaf": 0.019,
+     "extra_trees": 0.0133,
+     "lambda_l2": 0.002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 279,
+        "mean": 0.0028,
+        "std": 0.0005,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 21,
+        "mean": 0.0035,
+        "std": 0.0008,
+        "min": 0.0029
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0007,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1153
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.1153,
+        0.1319
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.1319,
+        0.1556
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.1556,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        103.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        103.0,
+        119.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        119.0,
+        124.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 52,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 50,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 123,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        19.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        24.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0002,
+        0.0019
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0019,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0023
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0023,
+        0.0397
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0397,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8263
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.8263,
+        0.9341
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9341,
+        0.9776
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9776,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9027
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9027,
+        0.9628
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.9628,
+        0.9815
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9815,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 228.3,
+    "holdout": {
+     "holdout_rmse": 0.002340609908281478,
+     "retrain_s": 0.2997,
+     "predict_s": 0.0031,
+     "cv_rmse_of_winner": 0.0026358550583388644
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.002564369145363277,
+    "rmse_p10": 0.0025870105805729715,
+    "rmse_median": 0.0026768539416582287,
+    "train_s_median": 1.9816543169319631,
+    "train_s_mean": 1.7468035727615159,
+    "train_s_p90": 2.8382321193069218,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.259853089481647,
+     "num_leaves": 124,
+     "max_depth": 11,
+     "min_data_in_leaf": 39,
+     "lambda_l1": 1.7330319291748143e-07,
+     "lambda_l2": 0.005461006671361944,
+     "feature_fraction": 0.9815057442910936,
+     "bagging_fraction": 0.8919889566724256,
+     "bagging_freq": 7,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 8,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.8839474701489677,
+     "mixture_diversity_lambda": 0.010069228363052985,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 38,
+     "mixture_gate_learning_rate": 0.01465476166866551,
+     "mixture_gate_lambda_l2": 1.4579079182831856,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_expert_capacity_factor": 0.9291610155151707,
+     "mixture_expert_choice_boost": 8.651997081003376,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "lambda_l1": 0.4198,
+     "mixture_r_smoothing": 0.0702,
+     "bagging_freq": 0.0694,
+     "mixture_hard_m_step": 0.0658,
+     "mixture_init": 0.0588,
+     "mixture_refit_leaves": 0.0495,
+     "mixture_warmup_iters": 0.049,
+     "mixture_num_experts": 0.0478,
+     "feature_fraction": 0.0404,
+     "bagging_fraction": 0.0363,
+     "max_depth": 0.0248,
+     "num_leaves": 0.02,
+     "min_data_in_leaf": 0.018,
+     "mixture_diversity_lambda": 0.0175,
+     "mixture_gate_type": 0.0053,
+     "mixture_routing_mode": 0.0051,
+     "extra_trees": 0.0007,
+     "mixture_balance_factor": 0.0007,
+     "lambda_l2": 0.0004,
+     "learning_rate": 0.0002,
+     "mixture_e_step_mode": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 247,
+        "mean": 0.0033,
+        "std": 0.0025,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0054,
+        "std": 0.0044,
+        "min": 0.0027
+       },
+       "leaf_reuse": {
+        "n": 37,
+        "mean": 0.0058,
+        "std": 0.0057,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0021,
+       "p_value": 0.080923,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 50,
+        "mean": 0.0052,
+        "std": 0.0046,
+        "min": 0.0027
+       },
+       "expert_choice": {
+        "n": 250,
+        "mean": 0.0034,
+        "std": 0.0029,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0018,
+       "p_value": 0.009374,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 217,
+        "mean": 0.0034,
+        "std": 0.0028,
+        "min": 0.0026
+       },
+       "em": {
+        "n": 36,
+        "mean": 0.0056,
+        "std": 0.0055,
+        "min": 0.0026
+       },
+       "loss_only": {
+        "n": 47,
+        "mean": 0.0038,
+        "std": 0.0027,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0004,
+       "p_value": 0.334078,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 55,
+        "mean": 0.0032,
+        "std": 0.0011,
+        "min": 0.0026
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 0.0076,
+        "std": 0.0076,
+        "min": 0.0026
+       },
+       "random": {
+        "n": 35,
+        "mean": 0.0046,
+        "std": 0.0039,
+        "min": 0.0026
+       },
+       "gmm": {
+        "n": 195,
+        "mean": 0.0034,
+        "std": 0.0028,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "gmm",
+       "delta_mean": 0.0002,
+       "p_value": 0.485423,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 16,
+        "mean": 0.009,
+        "std": 0.0064,
+        "min": 0.003
+       },
+       "ema": {
+        "n": 249,
+        "mean": 0.0031,
+        "std": 0.0015,
+        "min": 0.0026
+       },
+       "markov": {
+        "n": 35,
+        "mean": 0.006,
+        "std": 0.0063,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0029,
+       "p_value": 0.010923,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 42,
+        "mean": 0.0061,
+        "std": 0.0057,
+        "min": 0.0029
+       },
+       "False": {
+        "n": 258,
+        "mean": 0.0033,
+        "std": 0.0025,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0028,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.0044,
+        "std": 0.0017,
+        "min": 0.0029
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.0037,
+        "std": 0.0034,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0007,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0042
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 19,
+       "mean_rmse": 0.0066
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 216,
+       "mean_rmse": 0.0033
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0104
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0104,
+        0.0247
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.0247,
+        0.07
+       ],
+       "n": 75,
+       "mean_rmse": 0.0035
+      },
+      "Q4": {
+       "range": [
+        0.07,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0056
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 31,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 93,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        14.0
+       ],
+       "n": 98,
+       "mean_rmse": 0.0035
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0053
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 85,
+       "mean_rmse": 0.0036
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 0.0044
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1798
+       ],
+       "n": 75,
+       "mean_rmse": 0.0052
+      },
+      "Q2": {
+       "range": [
+        0.1798,
+        0.232
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.232,
+        0.2626
+       ],
+       "n": 75,
+       "mean_rmse": 0.0035
+      },
+      "Q4": {
+       "range": [
+        0.2626,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0033
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        101.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0056
+      },
+      "Q2": {
+       "range": [
+        101.75,
+        115.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        115.0,
+        121.0
+       ],
+       "n": 84,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0033
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 57,
+       "mean_rmse": 0.0054
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 25,
+       "mean_rmse": 0.0031
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 218,
+       "mean_rmse": 0.0033
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0046
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        41.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0031
+      },
+      "Q3": {
+       "range": [
+        41.0,
+        45.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        45.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0039
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2647.4,
+    "holdout": {
+     "holdout_rmse": 0.002249339046022266,
+     "retrain_s": 1.6199,
+     "predict_s": 0.02,
+     "cv_rmse_of_winner": 0.002564369145363277
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_fred_gdp_report.md
+++ b/bench_results/meth2_v080/ds_fred_gdp_report.md
@@ -1,0 +1,531 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['fred_gdp'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `0cf3634c544c`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| fred_gdp | naive-lightgbm | **1.52767** ± 0.01959 | 0.80518 | 0.0% | 0.02 |
+| fred_gdp | moe | **1.49375** ± 0.00592 | 0.82530 | 0.0% | 1.30 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| fred_gdp@s42 | naive-lightgbm | 0.8046 | 0.8281 | 0.013 | 25 |
+| fred_gdp@s42 | moe | 0.8384 | 0.9038 | 0.136 | 240 |
+| fred_gdp@s43 | naive-lightgbm | 0.7992 | 0.8220 | 0.017 | 31 |
+| fred_gdp@s43 | moe | 0.8231 | 0.9203 | 0.150 | 663 |
+| fred_gdp@s44 | naive-lightgbm | 0.8117 | 0.8302 | 0.010 | 22 |
+| fred_gdp@s44 | moe | 0.8144 | 0.8788 | 0.233 | 1157 |
+
+
+
+---
+
+## fred_gdp@s42  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.50612** (winner retrained in 0.02s, cv score of winner: 0.8046)
+- cv best RMSE: 0.8046, median: 0.8281, p10: 0.8113
+- train: median 0.013s/fold, mean 0.013s, p90 0.016s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.877 |
+| `max_depth` | 0.031 |
+| `learning_rate` | 0.027 |
+| `bagging_fraction` | 0.017 |
+| `num_leaves` | 0.015 |
+| `feature_fraction` | 0.012 |
+| `bagging_freq` | 0.012 |
+| `extra_trees` | 0.007 |
+| `lambda_l2` | 0.002 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.8276 | 0.0146 | 0.8046 |
+| True | 22 | 0.8417 | 0.0101 | 0.8252 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8370 | 0.8285 | 0.8227 | 0.8264 | **Q3** [0.2513, 0.2747] |
+| `num_leaves` | 0.8229 | 0.8247 | 0.8300 | 0.8367 | **Q1** [None, 12.0] |
+| `max_depth` | 0.8320 | 0.8270 | 0.8239 | 0.8327 | **Q3** [7.0, 8.0] |
+| `min_data_in_leaf` | 0.8392 | 0.8207 | 0.8220 | 0.8337 | **Q2** [20.0, 23.0] |
+| `lambda_l1` | 0.8320 | 0.8254 | 0.8293 | 0.8279 | **Q2** [0.0, 0.0001] |
+| `lambda_l2` | 0.8262 | 0.8260 | 0.8294 | 0.8330 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.8354 | 0.8243 | 0.8249 | 0.8301 | **Q2** [0.8639, 0.892] |
+| `bagging_fraction` | 0.8319 | 0.8226 | 0.8258 | 0.8343 | **Q2** [0.7971, 0.8357] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/naive-lightgbm](slice_fred_gdp@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.49863** (winner retrained in 0.22s, cv score of winner: 0.8384)
+- cv best RMSE: 0.8384, median: 0.9038, p10: 0.8586
+- train: median 0.136s/fold, mean 0.150s, p90 0.261s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.918 |
+| `mixture_warmup_iters` | 0.018 |
+| `lambda_l1` | 0.015 |
+| `mixture_init` | 0.006 |
+| `num_leaves` | 0.006 |
+| `mixture_diversity_lambda` | 0.006 |
+| `learning_rate` | 0.005 |
+| `feature_fraction` | 0.004 |
+| `mixture_balance_factor` | 0.004 |
+| `mixture_num_experts` | 0.003 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 0.9125 (n=211) | none | Δ +0.0277 | p=9.06e-03 |
+| `mixture_routing_mode` | **expert_choice** | 0.9102 (n=246) | token_choice | Δ +0.0643 | p=1.00e-06 |
+| `mixture_init` | **uniform** | 0.9071 (n=239) | random | Δ +0.0610 | p=3.14e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 211 | 0.9125 | 0.0680 | 0.8384 |
+| none | 62 | 0.9402 | 0.0725 | 0.8452 |
+| gbdt | 27 | 0.9521 | 0.0783 | 0.8611 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 246 | 0.9102 | 0.0630 | 0.8384 |
+| token_choice | 54 | 0.9745 | 0.0829 | 0.8437 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 213 | 0.9145 | 0.0691 | 0.8437 |
+| em | 60 | 0.9281 | 0.0722 | 0.8384 |
+| loss_only | 27 | 0.9659 | 0.0707 | 0.8699 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 239 | 0.9071 | 0.0586 | 0.8384 |
+| random | 26 | 0.9681 | 0.0921 | 0.8453 |
+| gmm | 15 | 0.9740 | 0.0671 | 0.8748 |
+| tree_hierarchical | 20 | 0.9980 | 0.0887 | 0.8612 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 115 | 0.9113 | 0.0714 | 0.8475 |
+| none | 152 | 0.9229 | 0.0679 | 0.8384 |
+| ema | 33 | 0.9538 | 0.0772 | 0.8453 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.9167 | 0.0669 | 0.8384 |
+| True | 21 | 0.9895 | 0.0919 | 0.8786 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 250 | 0.9121 | 0.0667 | 0.8384 |
+| False | 50 | 0.9702 | 0.0742 | 0.8453 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9656 | — | — | 0.9116 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.9442 | 0.9180 | 0.9010 | 0.9241 | **Q3** [0.355, 0.3799] |
+| `mixture_warmup_iters` | 0.9243 | 0.9160 | 0.9040 | 0.9446 | **Q3** [18.0, 25.0] |
+| `mixture_balance_factor` | 0.9519 | 0.9111 | 0.9286 | 0.9014 | **Q4** [10.0, ∞) |
+| `learning_rate` | 0.9681 | 0.9063 | 0.8944 | 0.9185 | **Q3** [0.1419, 0.1652] |
+| `num_leaves` | 0.9424 | 0.9026 | 0.9229 | 0.9196 | **Q2** [65.75, 75.5] |
+| `max_depth` | 0.9116 | 0.9580 | 0.9039 | 0.9156 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 0.8947 | 0.8900 | 0.9038 | 0.9925 | **Q2** [7.0, 9.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/moe](slice_fred_gdp@s42_moe.png)
+
+
+---
+
+## fred_gdp@s43  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.55352** (winner retrained in 0.03s, cv score of winner: 0.7992)
+- cv best RMSE: 0.7992, median: 0.8220, p10: 0.8085
+- train: median 0.017s/fold, mean 0.017s, p90 0.022s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.897 |
+| `bagging_fraction` | 0.060 |
+| `feature_fraction` | 0.012 |
+| `bagging_freq` | 0.008 |
+| `lambda_l1` | 0.006 |
+| `learning_rate` | 0.006 |
+| `num_leaves` | 0.006 |
+| `max_depth` | 0.002 |
+| `lambda_l2` | 0.002 |
+| `extra_trees` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.8294 | 0.0263 | 0.7992 |
+| True | 22 | 0.8461 | 0.0275 | 0.8170 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8367 | 0.8283 | 0.8300 | 0.8273 | **Q4** [0.2758, ∞) |
+| `num_leaves` | 0.8261 | 0.8267 | 0.8299 | 0.8396 | **Q1** [None, 15.0] |
+| `max_depth` | 0.8351 | 0.8372 | 0.8280 | 0.8230 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.8565 | 0.8175 | 0.8182 | 0.8338 | **Q2** [14.0, 17.0] |
+| `lambda_l1` | 0.8285 | 0.8235 | 0.8346 | 0.8358 | **Q2** [0.0001, 0.0004] |
+| `lambda_l2` | 0.8363 | 0.8285 | 0.8232 | 0.8343 | **Q3** [0.0001, 0.0003] |
+| `feature_fraction` | 0.8343 | 0.8259 | 0.8245 | 0.8376 | **Q3** [0.6627, 0.6925] |
+| `bagging_fraction` | 0.8400 | 0.8243 | 0.8248 | 0.8332 | **Q2** [0.8401, 0.8623] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/naive-lightgbm](slice_fred_gdp@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.48542** (winner retrained in 0.23s, cv score of winner: 0.8231)
+- cv best RMSE: 0.8231, median: 0.9203, p10: 0.8351
+- train: median 0.150s/fold, mean 0.434s, p90 0.250s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.988 |
+| `mixture_init` | 0.003 |
+| `learning_rate` | 0.002 |
+| `mixture_warmup_iters` | 0.001 |
+| `max_depth` | 0.001 |
+| `mixture_r_smoothing` | 0.001 |
+| `bagging_fraction` | 0.001 |
+| `feature_fraction` | 0.001 |
+| `mixture_diversity_lambda` | 0.001 |
+| `num_leaves` | 0.001 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 0.9004 (n=195) | token_choice | Δ +0.0361 | p=1.40e-05 |
+| `mixture_init` | **uniform** | 0.8972 (n=170) | random | Δ +0.0284 | p=2.15e-03 |
+| `mixture_r_smoothing` | **none** | 0.9040 (n=241) | ema | Δ +0.0316 | p=1.11e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 171 | 0.9020 | 0.0622 | 0.8231 |
+| none | 66 | 0.9231 | 0.0704 | 0.8274 |
+| gbdt | 63 | 0.9326 | 0.0554 | 0.8472 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 195 | 0.9004 | 0.0561 | 0.8231 |
+| token_choice | 105 | 0.9365 | 0.0710 | 0.8274 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 190 | 0.9051 | 0.0623 | 0.8231 |
+| gate_only | 90 | 0.9211 | 0.0645 | 0.8274 |
+| loss_only | 20 | 0.9526 | 0.0595 | 0.8662 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 170 | 0.8972 | 0.0573 | 0.8231 |
+| random | 75 | 0.9256 | 0.0683 | 0.8274 |
+| tree_hierarchical | 33 | 0.9432 | 0.0747 | 0.8410 |
+| gmm | 22 | 0.9477 | 0.0363 | 0.8537 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 241 | 0.9040 | 0.0613 | 0.8231 |
+| ema | 30 | 0.9356 | 0.0439 | 0.8472 |
+| markov | 29 | 0.9653 | 0.0730 | 0.8662 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 230 | 0.9053 | 0.0632 | 0.8231 |
+| True | 70 | 0.9384 | 0.0604 | 0.8472 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 231 | 0.9053 | 0.0629 | 0.8231 |
+| False | 69 | 0.9391 | 0.0610 | 0.8472 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9630 | — | — | 0.9058 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.9208 | 0.9261 | 0.8939 | 0.9114 | **Q3** [0.32, 0.355] |
+| `mixture_warmup_iters` | 0.9329 | 0.9199 | 0.9014 | 0.9012 | **Q4** [43.0, ∞) |
+| `mixture_balance_factor` | 0.9375 | 0.9300 | — | 0.8960 | **Q4** [10.0, ∞) |
+| `learning_rate` | 0.9387 | 0.9102 | 0.9004 | 0.9030 | **Q3** [0.1488, 0.1936] |
+| `num_leaves` | 0.8924 | 0.8962 | 0.9360 | 0.9275 | **Q1** [None, 17.0] |
+| `max_depth` | 0.9414 | 0.9283 | — | 0.9047 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | 0.8867 | 0.8740 | 0.8912 | 0.9757 | **Q2** [10.0, 11.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/moe](slice_fred_gdp@s43_moe.png)
+
+
+---
+
+## fred_gdp@s44  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.52337** (winner retrained in 0.02s, cv score of winner: 0.8117)
+- cv best RMSE: 0.8117, median: 0.8302, p10: 0.8197
+- train: median 0.010s/fold, mean 0.011s, p90 0.016s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.755 |
+| `learning_rate` | 0.159 |
+| `bagging_fraction` | 0.029 |
+| `extra_trees` | 0.021 |
+| `bagging_freq` | 0.011 |
+| `max_depth` | 0.011 |
+| `num_leaves` | 0.009 |
+| `feature_fraction` | 0.004 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 273 | 0.8323 | 0.0129 | 0.8117 |
+| True | 27 | 0.8364 | 0.0097 | 0.8218 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8337 | 0.8346 | 0.8311 | 0.8314 | **Q3** [0.0474, 0.0804] |
+| `num_leaves` | 0.8316 | 0.8286 | 0.8311 | 0.8390 | **Q2** [20.0, 29.0] |
+| `max_depth` | 0.8363 | 0.8330 | 0.8297 | 0.8354 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 0.8391 | 0.8294 | 0.8254 | 0.8376 | **Q3** [16.0, 20.0] |
+| `lambda_l1` | 0.8321 | 0.8339 | 0.8289 | 0.8359 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.8372 | 0.8316 | 0.8311 | 0.8309 | **Q4** [0.2105, ∞) |
+| `feature_fraction` | 0.8376 | 0.8345 | 0.8291 | 0.8297 | **Q3** [0.748, 0.8971] |
+| `bagging_fraction` | 0.8316 | 0.8278 | 0.8316 | 0.8398 | **Q2** [0.5409, 0.5594] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/naive-lightgbm](slice_fred_gdp@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.49721** (winner retrained in 3.45s, cv score of winner: 0.8144)
+- cv best RMSE: 0.8144, median: 0.8788, p10: 0.8301
+- train: median 0.233s/fold, mean 0.763s, p90 2.278s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.984 |
+| `learning_rate` | 0.003 |
+| `mixture_r_smoothing` | 0.002 |
+| `bagging_freq` | 0.002 |
+| `mixture_diversity_lambda` | 0.001 |
+| `num_leaves` | 0.001 |
+| `mixture_gate_type` | 0.001 |
+| `mixture_init` | 0.001 |
+| `bagging_fraction` | 0.001 |
+| `lambda_l1` | 0.001 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 0.8950 (n=256) | leaf_reuse | Δ +0.0607 | p=1.59e-04 |
+| `mixture_routing_mode` | **expert_choice** | 0.8972 (n=238) | token_choice | Δ +0.0330 | p=2.91e-04 |
+| `mixture_e_step_mode` | **loss_only** | 0.8786 (n=155) | gate_only | Δ +0.0480 | p=0.00e+00 |
+| `mixture_init` | **gmm** | 0.8759 (n=146) | tree_hierarchical | Δ +0.0431 | p=1.28e-04 |
+| `mixture_r_smoothing` | **markov** | 0.8786 (n=153) | ema | Δ +0.0489 | p=3.90e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 256 | 0.8950 | 0.0747 | 0.8144 |
+| leaf_reuse | 23 | 0.9557 | 0.0614 | 0.8615 |
+| none | 21 | 0.9569 | 0.0697 | 0.8692 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 238 | 0.8972 | 0.0796 | 0.8144 |
+| token_choice | 62 | 0.9302 | 0.0564 | 0.8425 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 155 | 0.8786 | 0.0720 | 0.8144 |
+| gate_only | 126 | 0.9266 | 0.0702 | 0.8388 |
+| em | 19 | 0.9615 | 0.0752 | 0.8394 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 146 | 0.8759 | 0.0714 | 0.8144 |
+| tree_hierarchical | 68 | 0.9190 | 0.0748 | 0.8340 |
+| uniform | 74 | 0.9341 | 0.0648 | 0.8433 |
+| random | 12 | 0.9750 | 0.0734 | 0.8536 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 153 | 0.8786 | 0.0686 | 0.8144 |
+| ema | 70 | 0.9275 | 0.0827 | 0.8269 |
+| none | 77 | 0.9331 | 0.0681 | 0.8425 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 269 | 0.8979 | 0.0744 | 0.8144 |
+| False | 31 | 0.9571 | 0.0742 | 0.8444 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 248 | 0.8952 | 0.0752 | 0.8144 |
+| False | 52 | 0.9460 | 0.0687 | 0.8606 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9679 | — | 0.8788 | 0.9276 | **Q3** [3.0, 4.0] |
+| `mixture_diversity_lambda` | 0.9051 | 0.8831 | 0.8936 | 0.9342 | **Q2** [0.1988, 0.2331] |
+| `mixture_warmup_iters` | 0.8954 | 0.8817 | 0.9349 | 0.9073 | **Q2** [25.0, 37.0] |
+| `mixture_balance_factor` | 0.8828 | 0.9149 | 0.9377 | 0.8828 | **Q1** [None, 4.0] |
+| `learning_rate` | 0.9237 | 0.8754 | 0.8773 | 0.9397 | **Q2** [0.0397, 0.0748] |
+| `num_leaves` | 0.9581 | 0.8969 | 0.8887 | 0.8768 | **Q4** [125.0, ∞) |
+| `max_depth` | 0.9267 | 0.8957 | 0.8711 | 0.9446 | **Q3** [5.0, 6.0] |
+| `min_data_in_leaf` | 0.8628 | 0.8619 | 0.8948 | 0.9858 | **Q2** [7.0, 10.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/moe](slice_fred_gdp@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| fred_gdp@s42 | `mixture_gate_type` | **leaf_reuse** | +0.0277 | 9.06e-03 |
+| fred_gdp@s42 | `mixture_routing_mode` | **expert_choice** | +0.0643 | 1.00e-06 |
+| fred_gdp@s42 | `mixture_init` | **uniform** | +0.0610 | 3.14e-03 |
+| fred_gdp@s43 | `mixture_routing_mode` | **expert_choice** | +0.0361 | 1.40e-05 |
+| fred_gdp@s43 | `mixture_init` | **uniform** | +0.0284 | 2.15e-03 |
+| fred_gdp@s43 | `mixture_r_smoothing` | **none** | +0.0316 | 1.11e-03 |
+| fred_gdp@s44 | `mixture_gate_type` | **gbdt** | +0.0607 | 1.59e-04 |
+| fred_gdp@s44 | `mixture_routing_mode` | **expert_choice** | +0.0330 | 2.91e-04 |
+| fred_gdp@s44 | `mixture_e_step_mode` | **loss_only** | +0.0480 | 0.00e+00 |
+| fred_gdp@s44 | `mixture_init` | **gmm** | +0.0431 | 1.28e-04 |
+| fred_gdp@s44 | `mixture_r_smoothing` | **markov** | +0.0489 | 3.90e-05 |

--- a/bench_results/meth2_v080/ds_fred_gdp_summary.json
+++ b/bench_results/meth2_v080/ds_fred_gdp_summary.json
@@ -1,0 +1,2809 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "fred_gdp"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "0cf3634c544c8f91ada2261bdf448aad9bd4b491",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "fred_gdp": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.5061180109801906,
+      "cv_best": 0.8045707992835883,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0159
+     },
+     "43": {
+      "holdout_rmse": 1.5535232842937101,
+      "cv_best": 0.7992196638224648,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0331
+     },
+     "44": {
+      "holdout_rmse": 1.5233652372424795,
+      "cv_best": 0.8117366524936191,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0173
+     }
+    },
+    "holdout_mean": 1.527669,
+    "holdout_std": 0.019591,
+    "cv_best_mean": 0.805176
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.4986285435549231,
+      "cv_best": 0.8383538319825649,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2189
+     },
+     "43": {
+      "holdout_rmse": 1.4854197153360655,
+      "cv_best": 0.8231233397384525,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2287
+     },
+     "44": {
+      "holdout_rmse": 1.497214380621263,
+      "cv_best": 0.814431790665951,
+      "crash_rate": 0.0,
+      "retrain_s": 3.4522
+     }
+    },
+    "holdout_mean": 1.493754,
+    "holdout_std": 0.005922,
+    "cv_best_mean": 0.825303
+   }
+  }
+ },
+ "runs": {
+  "fred_gdp@s42": {
+   "dataset": "fred_gdp",
+   "seed": 42,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8045707992835883,
+    "rmse_p10": 0.8112900804650067,
+    "rmse_median": 0.8281294145677633,
+    "train_s_median": 0.012999155558645725,
+    "train_s_mean": 0.013313593500604232,
+    "train_s_p90": 0.01649274129420519,
+    "best_params": {
+     "learning_rate": 0.26813269780124827,
+     "num_leaves": 10,
+     "max_depth": 3,
+     "min_data_in_leaf": 22,
+     "lambda_l1": 0.12967856053900614,
+     "lambda_l2": 1.4845794718946206e-06,
+     "feature_fraction": 0.9131884423534623,
+     "bagging_fraction": 0.8419513249064565,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8767,
+     "max_depth": 0.0309,
+     "learning_rate": 0.0274,
+     "bagging_fraction": 0.0173,
+     "num_leaves": 0.0149,
+     "feature_fraction": 0.0121,
+     "bagging_freq": 0.0118,
+     "extra_trees": 0.0071,
+     "lambda_l2": 0.0018,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.8417,
+        "std": 0.0101,
+        "min": 0.8252
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.8276,
+        "std": 0.0146,
+        "min": 0.8046
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0141,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2113
+       ],
+       "n": 75,
+       "mean_rmse": 0.837
+      },
+      "Q2": {
+       "range": [
+        0.2113,
+        0.2513
+       ],
+       "n": 75,
+       "mean_rmse": 0.8285
+      },
+      "Q3": {
+       "range": [
+        0.2513,
+        0.2747
+       ],
+       "n": 75,
+       "mean_rmse": 0.8227
+      },
+      "Q4": {
+       "range": [
+        0.2747,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8264
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8229
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8247
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        24.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.83
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.8367
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.832
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 97,
+       "mean_rmse": 0.827
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.8239
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 92,
+       "mean_rmse": 0.8327
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.8392
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        23.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.8207
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        28.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.822
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.8337
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.832
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8254
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0005
+       ],
+       "n": 75,
+       "mean_rmse": 0.8293
+      },
+      "Q4": {
+       "range": [
+        0.0005,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8279
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8262
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.826
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8294
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.833
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8639
+       ],
+       "n": 75,
+       "mean_rmse": 0.8354
+      },
+      "Q2": {
+       "range": [
+        0.8639,
+        0.892
+       ],
+       "n": 75,
+       "mean_rmse": 0.8243
+      },
+      "Q3": {
+       "range": [
+        0.892,
+        0.9171
+       ],
+       "n": 75,
+       "mean_rmse": 0.8249
+      },
+      "Q4": {
+       "range": [
+        0.9171,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8301
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7971
+       ],
+       "n": 75,
+       "mean_rmse": 0.8319
+      },
+      "Q2": {
+       "range": [
+        0.7971,
+        0.8357
+       ],
+       "n": 75,
+       "mean_rmse": 0.8226
+      },
+      "Q3": {
+       "range": [
+        0.8357,
+        0.8839
+       ],
+       "n": 75,
+       "mean_rmse": 0.8258
+      },
+      "Q4": {
+       "range": [
+        0.8839,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8343
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 25.4,
+    "holdout": {
+     "holdout_rmse": 1.5061180109801906,
+     "retrain_s": 0.0159,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8045707992835883
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8383538319825649,
+    "rmse_p10": 0.858598821806509,
+    "rmse_median": 0.9038341097418232,
+    "train_s_median": 0.13641985431313514,
+    "train_s_mean": 0.15023914465556543,
+    "train_s_p90": 0.26146366640925406,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.2645491639006038,
+     "num_leaves": 67,
+     "max_depth": 3,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 8.698347263410621e-05,
+     "lambda_l2": 0.009021541958519732,
+     "feature_fraction": 0.5721907420013078,
+     "bagging_fraction": 0.6968054315716977,
+     "bagging_freq": 6,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 20,
+     "mixture_balance_factor": 9,
+     "mixture_diversity_lambda": 0.4176441866510586,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 2,
+     "mixture_gate_num_leaves": 15,
+     "mixture_gate_learning_rate": 0.04801883981219299,
+     "mixture_gate_lambda_l2": 0.42297555170151846,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 28,
+     "mixture_expert_capacity_factor": 1.2249224734887125,
+     "mixture_expert_choice_boost": 29.698655146366875,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.0921084913993158,
+     "mixture_refit_every_n": 13,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9177,
+     "mixture_warmup_iters": 0.0177,
+     "lambda_l1": 0.0152,
+     "mixture_init": 0.0065,
+     "num_leaves": 0.0064,
+     "mixture_diversity_lambda": 0.0056,
+     "learning_rate": 0.005,
+     "feature_fraction": 0.0044,
+     "mixture_balance_factor": 0.0039,
+     "mixture_num_experts": 0.0029,
+     "bagging_fraction": 0.0027,
+     "mixture_gate_type": 0.0023,
+     "mixture_r_smoothing": 0.0022,
+     "lambda_l2": 0.0021,
+     "max_depth": 0.0016,
+     "mixture_refit_leaves": 0.001,
+     "bagging_freq": 0.0008,
+     "extra_trees": 0.0007,
+     "mixture_e_step_mode": 0.0007,
+     "mixture_routing_mode": 0.0004,
+     "mixture_hard_m_step": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 211,
+        "mean": 0.9125,
+        "std": 0.068,
+        "min": 0.8384
+       },
+       "none": {
+        "n": 62,
+        "mean": 0.9402,
+        "std": 0.0725,
+        "min": 0.8452
+       },
+       "gbdt": {
+        "n": 27,
+        "mean": 0.9521,
+        "std": 0.0783,
+        "min": 0.8611
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0277,
+       "p_value": 0.009056,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 54,
+        "mean": 0.9745,
+        "std": 0.0829,
+        "min": 0.8437
+       },
+       "expert_choice": {
+        "n": 246,
+        "mean": 0.9102,
+        "std": 0.063,
+        "min": 0.8384
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0643,
+       "p_value": 1e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 27,
+        "mean": 0.9659,
+        "std": 0.0707,
+        "min": 0.8699
+       },
+       "gate_only": {
+        "n": 213,
+        "mean": 0.9145,
+        "std": 0.0691,
+        "min": 0.8437
+       },
+       "em": {
+        "n": 60,
+        "mean": 0.9281,
+        "std": 0.0722,
+        "min": 0.8384
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0136,
+       "p_value": 0.1983,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 26,
+        "mean": 0.9681,
+        "std": 0.0921,
+        "min": 0.8453
+       },
+       "gmm": {
+        "n": 15,
+        "mean": 0.974,
+        "std": 0.0671,
+        "min": 0.8748
+       },
+       "tree_hierarchical": {
+        "n": 20,
+        "mean": 0.998,
+        "std": 0.0887,
+        "min": 0.8612
+       },
+       "uniform": {
+        "n": 239,
+        "mean": 0.9071,
+        "std": 0.0586,
+        "min": 0.8384
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.061,
+       "p_value": 0.003142,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 33,
+        "mean": 0.9538,
+        "std": 0.0772,
+        "min": 0.8453
+       },
+       "markov": {
+        "n": 115,
+        "mean": 0.9113,
+        "std": 0.0714,
+        "min": 0.8475
+       },
+       "none": {
+        "n": 152,
+        "mean": 0.9229,
+        "std": 0.0679,
+        "min": 0.8384
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.0116,
+       "p_value": 0.182766,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.9895,
+        "std": 0.0919,
+        "min": 0.8786
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.9167,
+        "std": 0.0669,
+        "min": 0.8384
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0728,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 250,
+        "mean": 0.9121,
+        "std": 0.0667,
+        "min": 0.8384
+       },
+       "False": {
+        "n": 50,
+        "mean": 0.9702,
+        "std": 0.0742,
+        "min": 0.8453
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0581,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 57,
+       "mean_rmse": 0.9656
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 243,
+       "mean_rmse": 0.9116
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3015
+       ],
+       "n": 75,
+       "mean_rmse": 0.9442
+      },
+      "Q2": {
+       "range": [
+        0.3015,
+        0.355
+       ],
+       "n": 75,
+       "mean_rmse": 0.918
+      },
+      "Q3": {
+       "range": [
+        0.355,
+        0.3799
+       ],
+       "n": 75,
+       "mean_rmse": 0.901
+      },
+      "Q4": {
+       "range": [
+        0.3799,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9241
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.9243
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.916
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        25.0
+       ],
+       "n": 96,
+       "mean_rmse": 0.904
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.9446
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.9519
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.9111
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.9286
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 96,
+       "mean_rmse": 0.9014
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1193
+       ],
+       "n": 75,
+       "mean_rmse": 0.9681
+      },
+      "Q2": {
+       "range": [
+        0.1193,
+        0.1419
+       ],
+       "n": 75,
+       "mean_rmse": 0.9063
+      },
+      "Q3": {
+       "range": [
+        0.1419,
+        0.1652
+       ],
+       "n": 75,
+       "mean_rmse": 0.8944
+      },
+      "Q4": {
+       "range": [
+        0.1652,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9185
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        65.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.9424
+      },
+      "Q2": {
+       "range": [
+        65.75,
+        75.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.9026
+      },
+      "Q3": {
+       "range": [
+        75.5,
+        98.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.9229
+      },
+      "Q4": {
+       "range": [
+        98.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.9196
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 58,
+       "mean_rmse": 0.9116
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        8.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.958
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 53,
+       "mean_rmse": 0.9039
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.9156
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.8947
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.89
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.9038
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.9925
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 240.1,
+    "holdout": {
+     "holdout_rmse": 1.4986285435549231,
+     "retrain_s": 0.2189,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8383538319825649
+    }
+   }
+  },
+  "fred_gdp@s43": {
+   "dataset": "fred_gdp",
+   "seed": 43,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.7992196638224648,
+    "rmse_p10": 0.8085264679899674,
+    "rmse_median": 0.8220148953021857,
+    "train_s_median": 0.017017675563693047,
+    "train_s_mean": 0.01698026804253459,
+    "train_s_p90": 0.021809001676738268,
+    "best_params": {
+     "learning_rate": 0.28855427282259166,
+     "num_leaves": 25,
+     "max_depth": 10,
+     "min_data_in_leaf": 17,
+     "lambda_l1": 0.0001244718758928286,
+     "lambda_l2": 0.00010625701033692853,
+     "feature_fraction": 0.6507202557716241,
+     "bagging_fraction": 0.8604126994569147,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8969,
+     "bagging_fraction": 0.0605,
+     "feature_fraction": 0.0119,
+     "bagging_freq": 0.0082,
+     "lambda_l1": 0.0065,
+     "learning_rate": 0.0064,
+     "num_leaves": 0.0058,
+     "max_depth": 0.0016,
+     "lambda_l2": 0.0016,
+     "extra_trees": 0.0006
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.8461,
+        "std": 0.0275,
+        "min": 0.817
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.8294,
+        "std": 0.0263,
+        "min": 0.7992
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0167,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1777
+       ],
+       "n": 75,
+       "mean_rmse": 0.8367
+      },
+      "Q2": {
+       "range": [
+        0.1777,
+        0.2454
+       ],
+       "n": 75,
+       "mean_rmse": 0.8283
+      },
+      "Q3": {
+       "range": [
+        0.2454,
+        0.2758
+       ],
+       "n": 75,
+       "mean_rmse": 0.83
+      },
+      "Q4": {
+       "range": [
+        0.2758,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8273
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.8261
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        23.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.8267
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        32.25
+       ],
+       "n": 76,
+       "mean_rmse": 0.8299
+      },
+      "Q4": {
+       "range": [
+        32.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8396
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.8351
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        10.0
+       ],
+       "n": 94,
+       "mean_rmse": 0.8372
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.828
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 0.823
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.8565
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        17.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.8175
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        21.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.8182
+      },
+      "Q4": {
+       "range": [
+        21.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.8338
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8285
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.8235
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0614
+       ],
+       "n": 75,
+       "mean_rmse": 0.8346
+      },
+      "Q4": {
+       "range": [
+        0.0614,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8358
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8363
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8285
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.8232
+      },
+      "Q4": {
+       "range": [
+        0.0003,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8343
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6343
+       ],
+       "n": 75,
+       "mean_rmse": 0.8343
+      },
+      "Q2": {
+       "range": [
+        0.6343,
+        0.6627
+       ],
+       "n": 75,
+       "mean_rmse": 0.8259
+      },
+      "Q3": {
+       "range": [
+        0.6627,
+        0.6925
+       ],
+       "n": 75,
+       "mean_rmse": 0.8245
+      },
+      "Q4": {
+       "range": [
+        0.6925,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8376
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8401
+       ],
+       "n": 75,
+       "mean_rmse": 0.84
+      },
+      "Q2": {
+       "range": [
+        0.8401,
+        0.8623
+       ],
+       "n": 75,
+       "mean_rmse": 0.8243
+      },
+      "Q3": {
+       "range": [
+        0.8623,
+        0.8838
+       ],
+       "n": 75,
+       "mean_rmse": 0.8248
+      },
+      "Q4": {
+       "range": [
+        0.8838,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8332
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 31.0,
+    "holdout": {
+     "holdout_rmse": 1.5535232842937101,
+     "retrain_s": 0.0331,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.7992196638224648
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8231233397384525,
+    "rmse_p10": 0.8350999421106438,
+    "rmse_median": 0.9202922526443016,
+    "train_s_median": 0.14957623798400166,
+    "train_s_mean": 0.43415657499060034,
+    "train_s_p90": 0.2501781938970089,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.2485049092369969,
+     "num_leaves": 18,
+     "max_depth": 9,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 4.308803498028462e-07,
+     "lambda_l2": 0.00044358468977291924,
+     "feature_fraction": 0.6370701307737531,
+     "bagging_fraction": 0.7990242693724002,
+     "bagging_freq": 4,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 43,
+     "mixture_balance_factor": 10,
+     "mixture_diversity_lambda": 0.3786300857461635,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 10,
+     "mixture_gate_num_leaves": 21,
+     "mixture_gate_learning_rate": 0.21109697787075343,
+     "mixture_gate_lambda_l2": 0.0017208919423224985,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_retrain_interval": 21,
+     "mixture_expert_capacity_factor": 0.9383804214665884,
+     "mixture_expert_choice_boost": 9.896267858687517,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9883,
+     "mixture_init": 0.0029,
+     "learning_rate": 0.0023,
+     "mixture_warmup_iters": 0.0011,
+     "max_depth": 0.0008,
+     "mixture_r_smoothing": 0.0007,
+     "bagging_fraction": 0.0006,
+     "feature_fraction": 0.0006,
+     "mixture_diversity_lambda": 0.0005,
+     "num_leaves": 0.0005,
+     "extra_trees": 0.0003,
+     "mixture_hard_m_step": 0.0002,
+     "mixture_e_step_mode": 0.0002,
+     "mixture_num_experts": 0.0002,
+     "bagging_freq": 0.0002,
+     "lambda_l2": 0.0002,
+     "mixture_gate_type": 0.0002,
+     "mixture_balance_factor": 0.0001,
+     "lambda_l1": 0.0001,
+     "mixture_routing_mode": 0.0,
+     "mixture_refit_leaves": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 63,
+        "mean": 0.9326,
+        "std": 0.0554,
+        "min": 0.8472
+       },
+       "none": {
+        "n": 66,
+        "mean": 0.9231,
+        "std": 0.0704,
+        "min": 0.8274
+       },
+       "leaf_reuse": {
+        "n": 171,
+        "mean": 0.902,
+        "std": 0.0622,
+        "min": 0.8231
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0211,
+       "p_value": 0.036118,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 195,
+        "mean": 0.9004,
+        "std": 0.0561,
+        "min": 0.8231
+       },
+       "token_choice": {
+        "n": 105,
+        "mean": 0.9365,
+        "std": 0.071,
+        "min": 0.8274
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0361,
+       "p_value": 1.4e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 20,
+        "mean": 0.9526,
+        "std": 0.0595,
+        "min": 0.8662
+       },
+       "em": {
+        "n": 190,
+        "mean": 0.9051,
+        "std": 0.0623,
+        "min": 0.8231
+       },
+       "gate_only": {
+        "n": 90,
+        "mean": 0.9211,
+        "std": 0.0645,
+        "min": 0.8274
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.016,
+       "p_value": 0.052341,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 22,
+        "mean": 0.9477,
+        "std": 0.0363,
+        "min": 0.8537
+       },
+       "tree_hierarchical": {
+        "n": 33,
+        "mean": 0.9432,
+        "std": 0.0747,
+        "min": 0.841
+       },
+       "random": {
+        "n": 75,
+        "mean": 0.9256,
+        "std": 0.0683,
+        "min": 0.8274
+       },
+       "uniform": {
+        "n": 170,
+        "mean": 0.8972,
+        "std": 0.0573,
+        "min": 0.8231
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0284,
+       "p_value": 0.00215,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 30,
+        "mean": 0.9356,
+        "std": 0.0439,
+        "min": 0.8472
+       },
+       "none": {
+        "n": 241,
+        "mean": 0.904,
+        "std": 0.0613,
+        "min": 0.8231
+       },
+       "markov": {
+        "n": 29,
+        "mean": 0.9653,
+        "std": 0.073,
+        "min": 0.8662
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0316,
+       "p_value": 0.001113,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 70,
+        "mean": 0.9384,
+        "std": 0.0604,
+        "min": 0.8472
+       },
+       "False": {
+        "n": 230,
+        "mean": 0.9053,
+        "std": 0.0632,
+        "min": 0.8231
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0331,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 69,
+        "mean": 0.9391,
+        "std": 0.061,
+        "min": 0.8472
+       },
+       "True": {
+        "n": 231,
+        "mean": 0.9053,
+        "std": 0.0629,
+        "min": 0.8231
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0338,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 38,
+       "mean_rmse": 0.963
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 262,
+       "mean_rmse": 0.9058
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1196
+       ],
+       "n": 75,
+       "mean_rmse": 0.9208
+      },
+      "Q2": {
+       "range": [
+        0.1196,
+        0.32
+       ],
+       "n": 75,
+       "mean_rmse": 0.9261
+      },
+      "Q3": {
+       "range": [
+        0.32,
+        0.355
+       ],
+       "n": 75,
+       "mean_rmse": 0.8939
+      },
+      "Q4": {
+       "range": [
+        0.355,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9114
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        28.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.9329
+      },
+      "Q2": {
+       "range": [
+        28.0,
+        38.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.9199
+      },
+      "Q3": {
+       "range": [
+        38.0,
+        43.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.9014
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.9012
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.9375
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        10.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.93
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 166,
+       "mean_rmse": 0.896
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0542
+       ],
+       "n": 75,
+       "mean_rmse": 0.9387
+      },
+      "Q2": {
+       "range": [
+        0.0542,
+        0.1488
+       ],
+       "n": 75,
+       "mean_rmse": 0.9102
+      },
+      "Q3": {
+       "range": [
+        0.1488,
+        0.1936
+       ],
+       "n": 75,
+       "mean_rmse": 0.9004
+      },
+      "Q4": {
+       "range": [
+        0.1936,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.903
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.8924
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        24.5
+       ],
+       "n": 82,
+       "mean_rmse": 0.8962
+      },
+      "Q3": {
+       "range": [
+        24.5,
+        89.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.936
+      },
+      "Q4": {
+       "range": [
+        89.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.9275
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 48,
+       "mean_rmse": 0.9414
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 31,
+       "mean_rmse": 0.9283
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 221,
+       "mean_rmse": 0.9047
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8867
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 27,
+       "mean_rmse": 0.874
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        15.0
+       ],
+       "n": 112,
+       "mean_rmse": 0.8912
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 0.9757
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 662.9,
+    "holdout": {
+     "holdout_rmse": 1.4854197153360655,
+     "retrain_s": 0.2287,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.8231233397384525
+    }
+   }
+  },
+  "fred_gdp@s44": {
+   "dataset": "fred_gdp",
+   "seed": 44,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8117366524936191,
+    "rmse_p10": 0.8197061923511014,
+    "rmse_median": 0.830175229918682,
+    "train_s_median": 0.01021418794989586,
+    "train_s_mean": 0.011237621313581863,
+    "train_s_p90": 0.01646806620061398,
+    "best_params": {
+     "learning_rate": 0.10726070140919869,
+     "num_leaves": 28,
+     "max_depth": 8,
+     "min_data_in_leaf": 18,
+     "lambda_l1": 7.168951221560929e-07,
+     "lambda_l2": 2.311799168136852,
+     "feature_fraction": 0.9434770143567955,
+     "bagging_fraction": 0.5276087936299121,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.7551,
+     "learning_rate": 0.1592,
+     "bagging_fraction": 0.0289,
+     "extra_trees": 0.0214,
+     "bagging_freq": 0.0111,
+     "max_depth": 0.0109,
+     "num_leaves": 0.0087,
+     "feature_fraction": 0.0038,
+     "lambda_l2": 0.0009,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 273,
+        "mean": 0.8323,
+        "std": 0.0129,
+        "min": 0.8117
+       },
+       "True": {
+        "n": 27,
+        "mean": 0.8364,
+        "std": 0.0097,
+        "min": 0.8218
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0041,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0207
+       ],
+       "n": 75,
+       "mean_rmse": 0.8337
+      },
+      "Q2": {
+       "range": [
+        0.0207,
+        0.0474
+       ],
+       "n": 75,
+       "mean_rmse": 0.8346
+      },
+      "Q3": {
+       "range": [
+        0.0474,
+        0.0804
+       ],
+       "n": 75,
+       "mean_rmse": 0.8311
+      },
+      "Q4": {
+       "range": [
+        0.0804,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8314
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8316
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        29.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.8286
+      },
+      "Q3": {
+       "range": [
+        29.0,
+        40.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.8311
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.839
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.8363
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 37,
+       "mean_rmse": 0.833
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 134,
+       "mean_rmse": 0.8297
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 89,
+       "mean_rmse": 0.8354
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.8391
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        16.0
+       ],
+       "n": 55,
+       "mean_rmse": 0.8294
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        20.0
+       ],
+       "n": 92,
+       "mean_rmse": 0.8254
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.8376
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8321
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8339
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8289
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8359
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0047
+       ],
+       "n": 75,
+       "mean_rmse": 0.8372
+      },
+      "Q2": {
+       "range": [
+        0.0047,
+        0.0359
+       ],
+       "n": 75,
+       "mean_rmse": 0.8316
+      },
+      "Q3": {
+       "range": [
+        0.0359,
+        0.2105
+       ],
+       "n": 75,
+       "mean_rmse": 0.8311
+      },
+      "Q4": {
+       "range": [
+        0.2105,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5828
+       ],
+       "n": 75,
+       "mean_rmse": 0.8376
+      },
+      "Q2": {
+       "range": [
+        0.5828,
+        0.748
+       ],
+       "n": 75,
+       "mean_rmse": 0.8345
+      },
+      "Q3": {
+       "range": [
+        0.748,
+        0.8971
+       ],
+       "n": 75,
+       "mean_rmse": 0.8291
+      },
+      "Q4": {
+       "range": [
+        0.8971,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8297
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5409
+       ],
+       "n": 75,
+       "mean_rmse": 0.8316
+      },
+      "Q2": {
+       "range": [
+        0.5409,
+        0.5594
+       ],
+       "n": 75,
+       "mean_rmse": 0.8278
+      },
+      "Q3": {
+       "range": [
+        0.5594,
+        0.5923
+       ],
+       "n": 75,
+       "mean_rmse": 0.8316
+      },
+      "Q4": {
+       "range": [
+        0.5923,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8398
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 21.6,
+    "holdout": {
+     "holdout_rmse": 1.5233652372424795,
+     "retrain_s": 0.0173,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8117366524936191
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.814431790665951,
+    "rmse_p10": 0.8301082713477267,
+    "rmse_median": 0.8788477894201454,
+    "train_s_median": 0.23262652941048145,
+    "train_s_mean": 0.7631303512454032,
+    "train_s_p90": 2.2778629154711965,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.07365783158501756,
+     "num_leaves": 128,
+     "max_depth": 4,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 0.021819637653576182,
+     "lambda_l2": 2.675603561468721e-07,
+     "feature_fraction": 0.9997436338087304,
+     "bagging_fraction": 0.527471263998565,
+     "bagging_freq": 3,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 25,
+     "mixture_balance_factor": 10,
+     "mixture_smoothing_lambda": 0.16622237074855795,
+     "mixture_diversity_lambda": 0.20214324700334368,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 5,
+     "mixture_gate_num_leaves": 26,
+     "mixture_gate_learning_rate": 0.060298447130986955,
+     "mixture_gate_lambda_l2": 9.474619218529064,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_expert_capacity_factor": 1.4803224283206835,
+     "mixture_expert_choice_boost": 29.26726575938947,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.03679816775882351,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9839,
+     "learning_rate": 0.0032,
+     "mixture_r_smoothing": 0.0021,
+     "bagging_freq": 0.0018,
+     "mixture_diversity_lambda": 0.0013,
+     "num_leaves": 0.0011,
+     "mixture_gate_type": 0.001,
+     "mixture_init": 0.001,
+     "bagging_fraction": 0.0009,
+     "lambda_l1": 0.0008,
+     "mixture_e_step_mode": 0.0006,
+     "mixture_warmup_iters": 0.0006,
+     "lambda_l2": 0.0005,
+     "mixture_num_experts": 0.0004,
+     "extra_trees": 0.0003,
+     "feature_fraction": 0.0003,
+     "max_depth": 0.0001,
+     "mixture_refit_leaves": 0.0001,
+     "mixture_routing_mode": 0.0,
+     "mixture_balance_factor": 0.0,
+     "mixture_hard_m_step": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 256,
+        "mean": 0.895,
+        "std": 0.0747,
+        "min": 0.8144
+       },
+       "none": {
+        "n": 21,
+        "mean": 0.9569,
+        "std": 0.0697,
+        "min": 0.8692
+       },
+       "leaf_reuse": {
+        "n": 23,
+        "mean": 0.9557,
+        "std": 0.0614,
+        "min": 0.8615
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0607,
+       "p_value": 0.000159,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 62,
+        "mean": 0.9302,
+        "std": 0.0564,
+        "min": 0.8425
+       },
+       "expert_choice": {
+        "n": 238,
+        "mean": 0.8972,
+        "std": 0.0796,
+        "min": 0.8144
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.033,
+       "p_value": 0.000291,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 126,
+        "mean": 0.9266,
+        "std": 0.0702,
+        "min": 0.8388
+       },
+       "em": {
+        "n": 19,
+        "mean": 0.9615,
+        "std": 0.0752,
+        "min": 0.8394
+       },
+       "loss_only": {
+        "n": 155,
+        "mean": 0.8786,
+        "std": 0.072,
+        "min": 0.8144
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.048,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 74,
+        "mean": 0.9341,
+        "std": 0.0648,
+        "min": 0.8433
+       },
+       "tree_hierarchical": {
+        "n": 68,
+        "mean": 0.919,
+        "std": 0.0748,
+        "min": 0.834
+       },
+       "random": {
+        "n": 12,
+        "mean": 0.975,
+        "std": 0.0734,
+        "min": 0.8536
+       },
+       "gmm": {
+        "n": 146,
+        "mean": 0.8759,
+        "std": 0.0714,
+        "min": 0.8144
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0431,
+       "p_value": 0.000128,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 77,
+        "mean": 0.9331,
+        "std": 0.0681,
+        "min": 0.8425
+       },
+       "ema": {
+        "n": 70,
+        "mean": 0.9275,
+        "std": 0.0827,
+        "min": 0.8269
+       },
+       "markov": {
+        "n": 153,
+        "mean": 0.8786,
+        "std": 0.0686,
+        "min": 0.8144
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.0489,
+       "p_value": 3.9e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 269,
+        "mean": 0.8979,
+        "std": 0.0744,
+        "min": 0.8144
+       },
+       "False": {
+        "n": 31,
+        "mean": 0.9571,
+        "std": 0.0742,
+        "min": 0.8444
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0592,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 248,
+        "mean": 0.8952,
+        "std": 0.0752,
+        "min": 0.8144
+       },
+       "False": {
+        "n": 52,
+        "mean": 0.946,
+        "std": 0.0687,
+        "min": 0.8606
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0508,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 12,
+       "mean_rmse": 0.9679
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 155,
+       "mean_rmse": 0.8788
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 0.9276
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1988
+       ],
+       "n": 75,
+       "mean_rmse": 0.9051
+      },
+      "Q2": {
+       "range": [
+        0.1988,
+        0.2331
+       ],
+       "n": 75,
+       "mean_rmse": 0.8831
+      },
+      "Q3": {
+       "range": [
+        0.2331,
+        0.2866
+       ],
+       "n": 75,
+       "mean_rmse": 0.8936
+      },
+      "Q4": {
+       "range": [
+        0.2866,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9342
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        25.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.8954
+      },
+      "Q2": {
+       "range": [
+        25.0,
+        37.0
+       ],
+       "n": 86,
+       "mean_rmse": 0.8817
+      },
+      "Q3": {
+       "range": [
+        37.0,
+        48.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.9349
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.9073
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.8828
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.9149
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        10.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.9377
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 0.8828
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0397
+       ],
+       "n": 75,
+       "mean_rmse": 0.9237
+      },
+      "Q2": {
+       "range": [
+        0.0397,
+        0.0748
+       ],
+       "n": 75,
+       "mean_rmse": 0.8754
+      },
+      "Q3": {
+       "range": [
+        0.0748,
+        0.1031
+       ],
+       "n": 75,
+       "mean_rmse": 0.8773
+      },
+      "Q4": {
+       "range": [
+        0.1031,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9397
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        112.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.9581
+      },
+      "Q2": {
+       "range": [
+        112.0,
+        121.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.8969
+      },
+      "Q3": {
+       "range": [
+        121.0,
+        125.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.8887
+      },
+      "Q4": {
+       "range": [
+        125.0,
+        null
+       ],
+       "n": 92,
+       "mean_rmse": 0.8768
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 28,
+       "mean_rmse": 0.9267
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 102,
+       "mean_rmse": 0.8957
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 91,
+       "mean_rmse": 0.8711
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.9446
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.8628
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 101,
+       "mean_rmse": 0.8619
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        14.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.8948
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.9858
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1156.7,
+    "holdout": {
+     "holdout_rmse": 1.497214380621263,
+     "retrain_s": 3.4522,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.814431790665951
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_hmm_report.md
+++ b/bench_results/meth2_v080/ds_hmm_report.md
@@ -1,0 +1,521 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['hmm'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `0cf3634c544c`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| hmm | naive-lightgbm | **2.21802** ± 0.24377 | 2.27009 | 0.0% | 0.04 |
+| hmm | moe | **2.23422** ± 0.25317 | 2.25054 | 0.0% | 0.19 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| hmm@s42 | naive-lightgbm | 2.2992 | 2.3152 | 0.033 | 57 |
+| hmm@s42 | moe | 2.2931 | 2.3208 | 1.989 | 2541 |
+| hmm@s43 | naive-lightgbm | 2.3800 | 2.3935 | 0.031 | 52 |
+| hmm@s43 | moe | 2.3351 | 2.3692 | 0.076 | 249 |
+| hmm@s44 | naive-lightgbm | 2.1311 | 2.1423 | 0.027 | 50 |
+| hmm@s44 | moe | 2.1234 | 2.1395 | 0.125 | 196 |
+
+
+
+---
+
+## hmm@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.88834** (winner retrained in 0.05s, cv score of winner: 2.2992)
+- cv best RMSE: 2.2992, median: 2.3152, p10: 2.3078
+- train: median 0.033s/fold, mean 0.034s, p90 0.041s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.401 |
+| `learning_rate` | 0.293 |
+| `min_data_in_leaf` | 0.112 |
+| `bagging_fraction` | 0.089 |
+| `num_leaves` | 0.028 |
+| `max_depth` | 0.026 |
+| `feature_fraction` | 0.024 |
+| `bagging_freq` | 0.014 |
+| `lambda_l2` | 0.010 |
+| `lambda_l1` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 2.3177 | 0.0143 | 2.2992 |
+| False | 20 | 2.3549 | 0.0208 | 2.3261 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.3258 | 2.3142 | 2.3149 | 2.3260 | **Q2** [0.0611, 0.0714] |
+| `num_leaves` | 2.3210 | 2.3206 | 2.3198 | 2.3196 | **Q4** [120.0, ∞) |
+| `max_depth` | — | — | 2.3163 | 2.3274 | **Q3** [3.0, 5.0] |
+| `min_data_in_leaf` | 2.3232 | 2.3162 | 2.3158 | 2.3262 | **Q3** [31.0, 36.0] |
+| `lambda_l1` | 2.3321 | 2.3174 | 2.3162 | 2.3152 | **Q4** [2.9866, ∞) |
+| `lambda_l2` | 2.3254 | 2.3201 | 2.3165 | 2.3189 | **Q3** [0.0494, 0.2783] |
+| `feature_fraction` | 2.3295 | 2.3164 | 2.3155 | 2.3195 | **Q3** [0.8977, 0.9296] |
+| `bagging_fraction` | 2.3310 | 2.3194 | 2.3147 | 2.3158 | **Q3** [0.934, 0.9603] |
+
+#### E. Slice plot
+
+![hmm@s42/naive-lightgbm](slice_hmm@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.89585** (winner retrained in 0.31s, cv score of winner: 2.2931)
+- cv best RMSE: 2.2931, median: 2.3208, p10: 2.3021
+- train: median 1.989s/fold, mean 1.686s, p90 2.913s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.249 |
+| `learning_rate` | 0.194 |
+| `num_leaves` | 0.153 |
+| `min_data_in_leaf` | 0.106 |
+| `mixture_refit_leaves` | 0.076 |
+| `extra_trees` | 0.042 |
+| `mixture_init` | 0.042 |
+| `mixture_balance_factor` | 0.032 |
+| `bagging_freq` | 0.020 |
+| `mixture_num_experts` | 0.017 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 2.3288 (n=231) | none | Δ +0.0324 | p=2.87e-04 |
+| `mixture_routing_mode` | **expert_choice** | 2.3360 (n=277) | token_choice | Δ +0.0619 | p=4.81e-03 |
+| `mixture_init` | **gmm** | 2.3333 (n=254) | uniform | Δ +0.0340 | p=5.36e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 231 | 2.3288 | 0.0353 | 2.2931 |
+| none | 51 | 2.3612 | 0.0571 | 2.3047 |
+| leaf_reuse | 18 | 2.4350 | 0.0932 | 2.3765 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 277 | 2.3360 | 0.0445 | 2.2931 |
+| token_choice | 23 | 2.3979 | 0.0922 | 2.3056 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 103 | 2.3321 | 0.0423 | 2.2957 |
+| em | 135 | 2.3443 | 0.0573 | 2.2931 |
+| loss_only | 62 | 2.3472 | 0.0546 | 2.2968 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 254 | 2.3333 | 0.0443 | 2.2931 |
+| uniform | 14 | 2.3673 | 0.0270 | 2.3280 |
+| random | 16 | 2.3704 | 0.0238 | 2.3304 |
+| tree_hierarchical | 16 | 2.4060 | 0.1120 | 2.3188 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 263 | 2.3371 | 0.0517 | 2.2931 |
+| markov | 17 | 2.3613 | 0.0475 | 2.3022 |
+| none | 20 | 2.3713 | 0.0525 | 2.3067 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.3368 | 0.0500 | 2.2931 |
+| True | 21 | 2.3923 | 0.0569 | 2.3068 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.3350 | 0.0486 | 2.2931 |
+| False | 21 | 2.4173 | 0.0403 | 2.3534 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 2.3407 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 2.3405 | 2.3307 | 2.3446 | 2.3471 | **Q2** [0.2422, 0.2802] |
+| `mixture_warmup_iters` | 2.3678 | 2.3338 | 2.3315 | 2.3334 | **Q3** [47.0, 49.0] |
+| `mixture_balance_factor` | 2.3550 | — | 2.3300 | 2.3562 | **Q3** [3.0, 4.0] |
+| `learning_rate` | 2.3696 | 2.3267 | 2.3270 | 2.3396 | **Q2** [0.1568, 0.1899] |
+| `num_leaves` | 2.3649 | 2.3374 | 2.3276 | 2.3336 | **Q3** [116.0, 120.0] |
+| `max_depth` | — | — | 2.3314 | 2.3553 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.3493 | 2.3320 | 2.3341 | 2.3477 | **Q2** [27.0, 33.0] |
+
+#### E. Slice plot
+
+![hmm@s42/moe](slice_hmm@s42_moe.png)
+
+
+---
+
+## hmm@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.47018** (winner retrained in 0.05s, cv score of winner: 2.3800)
+- cv best RMSE: 2.3800, median: 2.3935, p10: 2.3844
+- train: median 0.031s/fold, mean 0.032s, p90 0.042s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.526 |
+| `extra_trees` | 0.249 |
+| `learning_rate` | 0.079 |
+| `bagging_fraction` | 0.051 |
+| `lambda_l1` | 0.038 |
+| `feature_fraction` | 0.023 |
+| `max_depth` | 0.015 |
+| `num_leaves` | 0.009 |
+| `lambda_l2` | 0.006 |
+| `bagging_freq` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.3973 | 0.0165 | 2.3800 |
+| False | 21 | 2.4486 | 0.0327 | 2.4035 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.4073 | 2.3941 | 2.3955 | 2.4069 | **Q2** [0.0531, 0.0605] |
+| `num_leaves` | 2.3941 | 2.4000 | 2.4058 | 2.4035 | **Q1** [None, 15.75] |
+| `max_depth` | 2.4084 | 2.3978 | 2.3967 | 2.4019 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | 2.3942 | 2.3915 | 2.3982 | 2.4191 | **Q2** [7.0, 10.0] |
+| `lambda_l1` | 2.4157 | 2.3956 | 2.3973 | 2.3950 | **Q4** [4.0999, ∞) |
+| `lambda_l2` | 2.4147 | 2.3962 | 2.3976 | 2.3951 | **Q4** [1.2586, ∞) |
+| `feature_fraction` | 2.4142 | 2.4004 | 2.3950 | 2.3941 | **Q4** [0.9768, ∞) |
+| `bagging_fraction` | 2.4139 | 2.3994 | 2.3933 | 2.3972 | **Q3** [0.892, 0.921] |
+
+#### E. Slice plot
+
+![hmm@s43/naive-lightgbm](slice_hmm@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.50475** (winner retrained in 0.07s, cv score of winner: 2.3351)
+- cv best RMSE: 2.3351, median: 2.3692, p10: 2.3499
+- train: median 0.076s/fold, mean 0.160s, p90 0.269s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.247 |
+| `mixture_gate_type` | 0.145 |
+| `num_leaves` | 0.104 |
+| `bagging_fraction` | 0.101 |
+| `feature_fraction` | 0.092 |
+| `bagging_freq` | 0.069 |
+| `mixture_hard_m_step` | 0.061 |
+| `max_depth` | 0.043 |
+| `min_data_in_leaf` | 0.042 |
+| `mixture_diversity_lambda` | 0.022 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 2.3747 (n=248) | expert_choice | Δ +0.0400 | p=1.03e-04 |
+| `mixture_init` | **uniform** | 2.3667 (n=185) | tree_hierarchical | Δ +0.0241 | p=1.39e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 216 | 2.3752 | 0.0383 | 2.3351 |
+| gbdt | 59 | 2.3841 | 0.0311 | 2.3375 |
+| leaf_reuse | 25 | 2.4314 | 0.0551 | 2.3571 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 248 | 2.3747 | 0.0298 | 2.3351 |
+| expert_choice | 52 | 2.4147 | 0.0668 | 2.3375 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 201 | 2.3769 | 0.0404 | 2.3351 |
+| gate_only | 71 | 2.3861 | 0.0427 | 2.3519 |
+| em | 28 | 2.4042 | 0.0396 | 2.3610 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 185 | 2.3667 | 0.0203 | 2.3351 |
+| tree_hierarchical | 55 | 2.3908 | 0.0422 | 2.3480 |
+| random | 42 | 2.3997 | 0.0378 | 2.3610 |
+| gmm | 18 | 2.4654 | 0.0749 | 2.3654 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 178 | 2.3738 | 0.0369 | 2.3376 |
+| markov | 45 | 2.3815 | 0.0437 | 2.3351 |
+| ema | 77 | 2.3998 | 0.0450 | 2.3584 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 267 | 2.3749 | 0.0342 | 2.3351 |
+| True | 33 | 2.4363 | 0.0544 | 2.3654 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.3784 | 0.0384 | 2.3351 |
+| True | 20 | 2.4273 | 0.0567 | 2.3759 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 2.3816 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 2.3806 | 2.3744 | 2.3967 | 2.3748 | **Q2** [0.0464, 0.0939] |
+| `mixture_warmup_iters` | 2.3863 | 2.3793 | 2.3706 | 2.3904 | **Q3** [35.0, 41.0] |
+| `mixture_balance_factor` | — | 2.3838 | 2.3873 | 2.3729 | **Q4** [8.0, ∞) |
+| `learning_rate` | 2.3933 | 2.3825 | 2.3635 | 2.3872 | **Q3** [0.0688, 0.0795] |
+| `num_leaves` | 2.3754 | 2.3700 | 2.3685 | 2.4102 | **Q3** [26.0, 35.0] |
+| `max_depth` | — | — | 2.3721 | 2.4074 | **Q3** [3.0, 5.0] |
+| `min_data_in_leaf` | 2.3990 | 2.3666 | 2.3693 | 2.3954 | **Q2** [38.0, 42.0] |
+
+#### E. Slice plot
+
+![hmm@s43/moe](slice_hmm@s43_moe.png)
+
+
+---
+
+## hmm@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.29553** (winner retrained in 0.03s, cv score of winner: 2.1311)
+- cv best RMSE: 2.1311, median: 2.1423, p10: 2.1347
+- train: median 0.027s/fold, mean 0.030s, p90 0.039s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.481 |
+| `max_depth` | 0.155 |
+| `bagging_fraction` | 0.123 |
+| `learning_rate` | 0.090 |
+| `min_data_in_leaf` | 0.083 |
+| `feature_fraction` | 0.041 |
+| `num_leaves` | 0.019 |
+| `bagging_freq` | 0.005 |
+| `lambda_l2` | 0.002 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 278 | 2.1441 | 0.0129 | 2.1311 |
+| False | 22 | 2.1867 | 0.0243 | 2.1570 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.1514 | 2.1411 | 2.1454 | 2.1511 | **Q2** [0.0406, 0.0468] |
+| `num_leaves` | 2.1552 | 2.1441 | 2.1438 | 2.1462 | **Q3** [102.0, 112.0] |
+| `max_depth` | — | — | 2.1430 | 2.1581 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.1393 | 2.1438 | 2.1472 | 2.1582 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.1468 | 2.1476 | 2.1447 | 2.1498 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 2.1443 | 2.1449 | 2.1449 | 2.1548 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.1508 | 2.1424 | 2.1434 | 2.1522 | **Q2** [0.7138, 0.7421] |
+| `bagging_fraction` | 2.1590 | 2.1422 | 2.1434 | 2.1443 | **Q2** [0.8818, 0.9284] |
+
+#### E. Slice plot
+
+![hmm@s44/naive-lightgbm](slice_hmm@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.30206** (winner retrained in 0.18s, cv score of winner: 2.1234)
+- cv best RMSE: 2.1234, median: 2.1395, p10: 2.1295
+- train: median 0.125s/fold, mean 0.124s, p90 0.155s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.709 |
+| `feature_fraction` | 0.088 |
+| `learning_rate` | 0.061 |
+| `mixture_gate_type` | 0.021 |
+| `mixture_warmup_iters` | 0.021 |
+| `min_data_in_leaf` | 0.017 |
+| `mixture_num_experts` | 0.015 |
+| `extra_trees` | 0.013 |
+| `mixture_diversity_lambda` | 0.012 |
+| `num_leaves` | 0.008 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 2.1591 (n=258) | token_choice | Δ +0.0262 | p=9.36e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 244 | 2.1575 | 0.0543 | 2.1234 |
+| gbdt | 16 | 2.1736 | 0.0436 | 2.1316 |
+| none | 40 | 2.1904 | 0.0611 | 2.1349 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 258 | 2.1591 | 0.0547 | 2.1234 |
+| token_choice | 42 | 2.1853 | 0.0582 | 2.1349 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 250 | 2.1586 | 0.0536 | 2.1234 |
+| em | 27 | 2.1775 | 0.0487 | 2.1348 |
+| loss_only | 23 | 2.1908 | 0.0744 | 2.1335 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 253 | 2.1474 | 0.0291 | 2.1234 |
+| random | 18 | 2.1668 | 0.0279 | 2.1440 |
+| tree_hierarchical | 15 | 2.2893 | 0.0679 | 2.1589 |
+| gmm | 14 | 2.2986 | 0.0767 | 2.1679 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 205 | 2.1603 | 0.0556 | 2.1234 |
+| markov | 69 | 2.1651 | 0.0584 | 2.1297 |
+| ema | 26 | 2.1760 | 0.0492 | 2.1303 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 262 | 2.1600 | 0.0544 | 2.1234 |
+| False | 38 | 2.1820 | 0.0621 | 2.1382 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.1589 | 0.0537 | 2.1234 |
+| False | 21 | 2.2146 | 0.0591 | 2.1570 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 2.1628 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 2.1668 | 2.1581 | 2.1608 | 2.1653 | **Q2** [0.201, 0.2876] |
+| `mixture_warmup_iters` | 2.1738 | 2.1631 | 2.1596 | 2.1561 | **Q4** [48.0, ∞) |
+| `mixture_balance_factor` | 2.1896 | 2.1671 | — | 2.1554 | **Q4** [8.0, ∞) |
+| `learning_rate` | 2.1913 | 2.1463 | 2.1476 | 2.1658 | **Q2** [0.1338, 0.1582] |
+| `num_leaves` | 2.1604 | 2.1579 | 2.1514 | 2.1812 | **Q3** [36.0, 50.0] |
+| `max_depth` | 2.1745 | 2.1558 | 2.1910 | 2.1584 | **Q2** [7.0, 11.0] |
+| `min_data_in_leaf` | 2.1776 | 2.1494 | 2.1571 | 2.1668 | **Q2** [31.75, 39.0] |
+
+#### E. Slice plot
+
+![hmm@s44/moe](slice_hmm@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| hmm@s42 | `mixture_gate_type` | **gbdt** | +0.0324 | 2.87e-04 |
+| hmm@s42 | `mixture_routing_mode` | **expert_choice** | +0.0619 | 4.81e-03 |
+| hmm@s42 | `mixture_init` | **gmm** | +0.0340 | 5.36e-04 |
+| hmm@s43 | `mixture_routing_mode` | **token_choice** | +0.0400 | 1.03e-04 |
+| hmm@s43 | `mixture_init` | **uniform** | +0.0241 | 1.39e-04 |
+| hmm@s44 | `mixture_routing_mode` | **expert_choice** | +0.0262 | 9.36e-03 |

--- a/bench_results/meth2_v080/ds_hmm_summary.json
+++ b/bench_results/meth2_v080/ds_hmm_summary.json
@@ -1,0 +1,2696 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "hmm"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "0cf3634c544c8f91ada2261bdf448aad9bd4b491",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "hmm": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.888342906785671,
+      "cv_best": 2.2991586479654282,
+      "crash_rate": 0.0,
+      "retrain_s": 0.051
+     },
+     "43": {
+      "holdout_rmse": 2.4701788835392824,
+      "cv_best": 2.379979557922336,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0457
+     },
+     "44": {
+      "holdout_rmse": 2.29552544390291,
+      "cv_best": 2.1311368317391413,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0283
+     }
+    },
+    "holdout_mean": 2.218016,
+    "holdout_std": 0.243775,
+    "cv_best_mean": 2.270092
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.8958482329695783,
+      "cv_best": 2.2930583099385538,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3064
+     },
+     "43": {
+      "holdout_rmse": 2.5047535243482475,
+      "cv_best": 2.335125271030672,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0686
+     },
+     "44": {
+      "holdout_rmse": 2.3020555586645948,
+      "cv_best": 2.1234260835489907,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1847
+     }
+    },
+    "holdout_mean": 2.234219,
+    "holdout_std": 0.25317,
+    "cv_best_mean": 2.250537
+   }
+  }
+ },
+ "runs": {
+  "hmm@s42": {
+   "dataset": "hmm",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.045793656680186444,
+    "std": 2.4137364484700643
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.2991586479654282,
+    "rmse_p10": 2.3078319097059055,
+    "rmse_median": 2.315209081827666,
+    "train_s_median": 0.03319062292575836,
+    "train_s_mean": 0.03432164289926489,
+    "train_s_p90": 0.04054625120013952,
+    "best_params": {
+     "learning_rate": 0.09493440081364529,
+     "num_leaves": 125,
+     "max_depth": 5,
+     "min_data_in_leaf": 41,
+     "lambda_l1": 0.7722375890086123,
+     "lambda_l2": 1.9149345992899975,
+     "feature_fraction": 0.8426373035251148,
+     "bagging_fraction": 0.9850867005699576,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4009,
+     "learning_rate": 0.2935,
+     "min_data_in_leaf": 0.1123,
+     "bagging_fraction": 0.089,
+     "num_leaves": 0.0284,
+     "max_depth": 0.0256,
+     "feature_fraction": 0.0243,
+     "bagging_freq": 0.0144,
+     "lambda_l2": 0.01,
+     "lambda_l1": 0.0015
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 280,
+        "mean": 2.3177,
+        "std": 0.0143,
+        "min": 2.2992
+       },
+       "False": {
+        "n": 20,
+        "mean": 2.3549,
+        "std": 0.0208,
+        "min": 2.3261
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0372,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0611
+       ],
+       "n": 75,
+       "mean_rmse": 2.3258
+      },
+      "Q2": {
+       "range": [
+        0.0611,
+        0.0714
+       ],
+       "n": 75,
+       "mean_rmse": 2.3142
+      },
+      "Q3": {
+       "range": [
+        0.0714,
+        0.0859
+       ],
+       "n": 75,
+       "mean_rmse": 2.3149
+      },
+      "Q4": {
+       "range": [
+        0.0859,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.326
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        64.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.321
+      },
+      "Q2": {
+       "range": [
+        64.0,
+        108.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.3206
+      },
+      "Q3": {
+       "range": [
+        108.0,
+        120.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3198
+      },
+      "Q4": {
+       "range": [
+        120.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.3196
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 195,
+       "mean_rmse": 2.3163
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 105,
+       "mean_rmse": 2.3274
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 62,
+       "mean_rmse": 2.3232
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        31.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.3162
+      },
+      "Q3": {
+       "range": [
+        31.0,
+        36.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.3158
+      },
+      "Q4": {
+       "range": [
+        36.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.3262
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.3513
+       ],
+       "n": 75,
+       "mean_rmse": 2.3321
+      },
+      "Q2": {
+       "range": [
+        0.3513,
+        1.2675
+       ],
+       "n": 75,
+       "mean_rmse": 2.3174
+      },
+      "Q3": {
+       "range": [
+        1.2675,
+        2.9866
+       ],
+       "n": 75,
+       "mean_rmse": 2.3162
+      },
+      "Q4": {
+       "range": [
+        2.9866,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3152
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0009
+       ],
+       "n": 75,
+       "mean_rmse": 2.3254
+      },
+      "Q2": {
+       "range": [
+        0.0009,
+        0.0494
+       ],
+       "n": 75,
+       "mean_rmse": 2.3201
+      },
+      "Q3": {
+       "range": [
+        0.0494,
+        0.2783
+       ],
+       "n": 75,
+       "mean_rmse": 2.3165
+      },
+      "Q4": {
+       "range": [
+        0.2783,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3189
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8461
+       ],
+       "n": 75,
+       "mean_rmse": 2.3295
+      },
+      "Q2": {
+       "range": [
+        0.8461,
+        0.8977
+       ],
+       "n": 75,
+       "mean_rmse": 2.3164
+      },
+      "Q3": {
+       "range": [
+        0.8977,
+        0.9296
+       ],
+       "n": 75,
+       "mean_rmse": 2.3155
+      },
+      "Q4": {
+       "range": [
+        0.9296,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3195
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.902
+       ],
+       "n": 75,
+       "mean_rmse": 2.331
+      },
+      "Q2": {
+       "range": [
+        0.902,
+        0.934
+       ],
+       "n": 75,
+       "mean_rmse": 2.3194
+      },
+      "Q3": {
+       "range": [
+        0.934,
+        0.9603
+       ],
+       "n": 75,
+       "mean_rmse": 2.3147
+      },
+      "Q4": {
+       "range": [
+        0.9603,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3158
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 57.3,
+    "holdout": {
+     "holdout_rmse": 1.888342906785671,
+     "retrain_s": 0.051,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.2991586479654282
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.2930583099385538,
+    "rmse_p10": 2.3021362113242136,
+    "rmse_median": 2.3207737568782876,
+    "train_s_median": 1.9888945341110231,
+    "train_s_mean": 1.6856536026336253,
+    "train_s_p90": 2.9130776054039598,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.23090090141544115,
+     "num_leaves": 116,
+     "max_depth": 3,
+     "min_data_in_leaf": 36,
+     "lambda_l1": 0.0007425218227857262,
+     "lambda_l2": 0.5190415573854932,
+     "feature_fraction": 0.5162107065072907,
+     "bagging_fraction": 0.9279467012990062,
+     "bagging_freq": 3,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 48,
+     "mixture_balance_factor": 3,
+     "mixture_smoothing_lambda": 0.8293529559227637,
+     "mixture_diversity_lambda": 0.36229246108505286,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 26,
+     "mixture_gate_learning_rate": 0.01027893772978103,
+     "mixture_gate_lambda_l2": 0.0019273514988441523,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_expert_capacity_factor": 1.261126385770018,
+     "mixture_expert_choice_boost": 7.217713554344677,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.22027004638006709,
+     "mixture_refit_every_n": 24,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 3,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "mixture_gate_type": 0.2488,
+     "learning_rate": 0.1935,
+     "num_leaves": 0.1534,
+     "min_data_in_leaf": 0.1059,
+     "mixture_refit_leaves": 0.0756,
+     "extra_trees": 0.0424,
+     "mixture_init": 0.0415,
+     "mixture_balance_factor": 0.0317,
+     "bagging_freq": 0.0204,
+     "mixture_num_experts": 0.0174,
+     "feature_fraction": 0.0172,
+     "mixture_diversity_lambda": 0.0106,
+     "bagging_fraction": 0.0095,
+     "mixture_routing_mode": 0.0066,
+     "lambda_l2": 0.0062,
+     "mixture_warmup_iters": 0.005,
+     "max_depth": 0.0049,
+     "mixture_e_step_mode": 0.0045,
+     "mixture_hard_m_step": 0.0037,
+     "lambda_l1": 0.0006,
+     "mixture_r_smoothing": 0.0006
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 18,
+        "mean": 2.435,
+        "std": 0.0932,
+        "min": 2.3765
+       },
+       "none": {
+        "n": 51,
+        "mean": 2.3612,
+        "std": 0.0571,
+        "min": 2.3047
+       },
+       "gbdt": {
+        "n": 231,
+        "mean": 2.3288,
+        "std": 0.0353,
+        "min": 2.2931
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0324,
+       "p_value": 0.000287,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 23,
+        "mean": 2.3979,
+        "std": 0.0922,
+        "min": 2.3056
+       },
+       "expert_choice": {
+        "n": 277,
+        "mean": 2.336,
+        "std": 0.0445,
+        "min": 2.2931
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0619,
+       "p_value": 0.004813,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 62,
+        "mean": 2.3472,
+        "std": 0.0546,
+        "min": 2.2968
+       },
+       "gate_only": {
+        "n": 103,
+        "mean": 2.3321,
+        "std": 0.0423,
+        "min": 2.2957
+       },
+       "em": {
+        "n": 135,
+        "mean": 2.3443,
+        "std": 0.0573,
+        "min": 2.2931
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0122,
+       "p_value": 0.060011,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 16,
+        "mean": 2.3704,
+        "std": 0.0238,
+        "min": 2.3304
+       },
+       "gmm": {
+        "n": 254,
+        "mean": 2.3333,
+        "std": 0.0443,
+        "min": 2.2931
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 2.406,
+        "std": 0.112,
+        "min": 2.3188
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 2.3673,
+        "std": 0.027,
+        "min": 2.328
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "uniform",
+       "delta_mean": 0.034,
+       "p_value": 0.000536,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 263,
+        "mean": 2.3371,
+        "std": 0.0517,
+        "min": 2.2931
+       },
+       "markov": {
+        "n": 17,
+        "mean": 2.3613,
+        "std": 0.0475,
+        "min": 2.3022
+       },
+       "none": {
+        "n": 20,
+        "mean": 2.3713,
+        "std": 0.0525,
+        "min": 2.3067
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0242,
+       "p_value": 0.064106,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 2.3923,
+        "std": 0.0569,
+        "min": 2.3068
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.3368,
+        "std": 0.05,
+        "min": 2.2931
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0555,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.335,
+        "std": 0.0486,
+        "min": 2.2931
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.4173,
+        "std": 0.0403,
+        "min": 2.3534
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0823,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 2.3407
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2422
+       ],
+       "n": 75,
+       "mean_rmse": 2.3405
+      },
+      "Q2": {
+       "range": [
+        0.2422,
+        0.2802
+       ],
+       "n": 75,
+       "mean_rmse": 2.3307
+      },
+      "Q3": {
+       "range": [
+        0.2802,
+        0.3837
+       ],
+       "n": 75,
+       "mean_rmse": 2.3446
+      },
+      "Q4": {
+       "range": [
+        0.3837,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3471
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        44.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.3678
+      },
+      "Q2": {
+       "range": [
+        44.0,
+        47.0
+       ],
+       "n": 66,
+       "mean_rmse": 2.3338
+      },
+      "Q3": {
+       "range": [
+        47.0,
+        49.0
+       ],
+       "n": 85,
+       "mean_rmse": 2.3315
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.3334
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 25,
+       "mean_rmse": 2.355
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 176,
+       "mean_rmse": 2.33
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 99,
+       "mean_rmse": 2.3562
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1568
+       ],
+       "n": 75,
+       "mean_rmse": 2.3696
+      },
+      "Q2": {
+       "range": [
+        0.1568,
+        0.1899
+       ],
+       "n": 75,
+       "mean_rmse": 2.3267
+      },
+      "Q3": {
+       "range": [
+        0.1899,
+        0.2198
+       ],
+       "n": 75,
+       "mean_rmse": 2.327
+      },
+      "Q4": {
+       "range": [
+        0.2198,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3396
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        108.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.3649
+      },
+      "Q2": {
+       "range": [
+        108.0,
+        116.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.3374
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        120.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.3276
+      },
+      "Q4": {
+       "range": [
+        120.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.3336
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 183,
+       "mean_rmse": 2.3314
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 117,
+       "mean_rmse": 2.3553
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        27.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3493
+      },
+      "Q2": {
+       "range": [
+        27.0,
+        33.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.332
+      },
+      "Q3": {
+       "range": [
+        33.0,
+        39.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.3341
+      },
+      "Q4": {
+       "range": [
+        39.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.3477
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2541.4,
+    "holdout": {
+     "holdout_rmse": 1.8958482329695783,
+     "retrain_s": 0.3064,
+     "predict_s": 0.0007,
+     "cv_rmse_of_winner": 2.2930583099385538
+    }
+   }
+  },
+  "hmm@s43": {
+   "dataset": "hmm",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.4217584667381496,
+    "std": 2.6151502465431355
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.379979557922336,
+    "rmse_p10": 2.3844018557755606,
+    "rmse_median": 2.3935301279425514,
+    "train_s_median": 0.030508671700954434,
+    "train_s_mean": 0.031658621519804,
+    "train_s_p90": 0.042423082329332826,
+    "best_params": {
+     "learning_rate": 0.05661476441827138,
+     "num_leaves": 20,
+     "max_depth": 8,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 2.899525875709731,
+     "lambda_l2": 1.4537344690996084,
+     "feature_fraction": 0.9559564891707837,
+     "bagging_fraction": 0.8605286620730526,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5259,
+     "extra_trees": 0.249,
+     "learning_rate": 0.0793,
+     "bagging_fraction": 0.0506,
+     "lambda_l1": 0.0385,
+     "feature_fraction": 0.0234,
+     "max_depth": 0.0153,
+     "num_leaves": 0.009,
+     "lambda_l2": 0.0065,
+     "bagging_freq": 0.0024
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.3973,
+        "std": 0.0165,
+        "min": 2.38
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.4486,
+        "std": 0.0327,
+        "min": 2.4035
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0513,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0531
+       ],
+       "n": 75,
+       "mean_rmse": 2.4073
+      },
+      "Q2": {
+       "range": [
+        0.0531,
+        0.0605
+       ],
+       "n": 75,
+       "mean_rmse": 2.3941
+      },
+      "Q3": {
+       "range": [
+        0.0605,
+        0.0725
+       ],
+       "n": 75,
+       "mean_rmse": 2.3955
+      },
+      "Q4": {
+       "range": [
+        0.0725,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.4069
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        15.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3941
+      },
+      "Q2": {
+       "range": [
+        15.75,
+        26.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.4
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        73.5
+       ],
+       "n": 79,
+       "mean_rmse": 2.4058
+      },
+      "Q4": {
+       "range": [
+        73.5,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.4035
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 52,
+       "mean_rmse": 2.4084
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 50,
+       "mean_rmse": 2.3978
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 83,
+       "mean_rmse": 2.3967
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 115,
+       "mean_rmse": 2.4019
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 49,
+       "mean_rmse": 2.3942
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.3915
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        18.0
+       ],
+       "n": 88,
+       "mean_rmse": 2.3982
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.4191
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.8358
+       ],
+       "n": 75,
+       "mean_rmse": 2.4157
+      },
+      "Q2": {
+       "range": [
+        0.8358,
+        2.2098
+       ],
+       "n": 75,
+       "mean_rmse": 2.3956
+      },
+      "Q3": {
+       "range": [
+        2.2098,
+        4.0999
+       ],
+       "n": 75,
+       "mean_rmse": 2.3973
+      },
+      "Q4": {
+       "range": [
+        4.0999,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.395
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0696
+       ],
+       "n": 75,
+       "mean_rmse": 2.4147
+      },
+      "Q2": {
+       "range": [
+        0.0696,
+        0.4908
+       ],
+       "n": 75,
+       "mean_rmse": 2.3962
+      },
+      "Q3": {
+       "range": [
+        0.4908,
+        1.2586
+       ],
+       "n": 75,
+       "mean_rmse": 2.3976
+      },
+      "Q4": {
+       "range": [
+        1.2586,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3951
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.907
+       ],
+       "n": 75,
+       "mean_rmse": 2.4142
+      },
+      "Q2": {
+       "range": [
+        0.907,
+        0.9594
+       ],
+       "n": 75,
+       "mean_rmse": 2.4004
+      },
+      "Q3": {
+       "range": [
+        0.9594,
+        0.9768
+       ],
+       "n": 75,
+       "mean_rmse": 2.395
+      },
+      "Q4": {
+       "range": [
+        0.9768,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3941
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8543
+       ],
+       "n": 75,
+       "mean_rmse": 2.4139
+      },
+      "Q2": {
+       "range": [
+        0.8543,
+        0.892
+       ],
+       "n": 75,
+       "mean_rmse": 2.3994
+      },
+      "Q3": {
+       "range": [
+        0.892,
+        0.921
+       ],
+       "n": 75,
+       "mean_rmse": 2.3933
+      },
+      "Q4": {
+       "range": [
+        0.921,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3972
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 51.7,
+    "holdout": {
+     "holdout_rmse": 2.4701788835392824,
+     "retrain_s": 0.0457,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.379979557922336
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.335125271030672,
+    "rmse_p10": 2.349933460428081,
+    "rmse_median": 2.36917051193059,
+    "train_s_median": 0.07550235856324433,
+    "train_s_mean": 0.16048098441089192,
+    "train_s_p90": 0.2690114834904671,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.0720105971248139,
+     "num_leaves": 13,
+     "max_depth": 3,
+     "min_data_in_leaf": 43,
+     "lambda_l1": 0.022278667199188033,
+     "lambda_l2": 0.00011348944840847406,
+     "feature_fraction": 0.9836013286570752,
+     "bagging_fraction": 0.9776109639081721,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 45,
+     "mixture_balance_factor": 7,
+     "mixture_smoothing_lambda": 0.755121412717406,
+     "mixture_diversity_lambda": 0.46354952466087296,
+     "mixture_hard_m_step": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.2471,
+     "mixture_gate_type": 0.145,
+     "num_leaves": 0.1039,
+     "bagging_fraction": 0.1007,
+     "feature_fraction": 0.0922,
+     "bagging_freq": 0.0692,
+     "mixture_hard_m_step": 0.061,
+     "max_depth": 0.0425,
+     "min_data_in_leaf": 0.0416,
+     "mixture_diversity_lambda": 0.022,
+     "learning_rate": 0.0204,
+     "extra_trees": 0.0137,
+     "mixture_warmup_iters": 0.013,
+     "mixture_balance_factor": 0.009,
+     "lambda_l1": 0.0061,
+     "mixture_r_smoothing": 0.0052,
+     "mixture_num_experts": 0.003,
+     "mixture_refit_leaves": 0.0016,
+     "mixture_routing_mode": 0.0012,
+     "lambda_l2": 0.001,
+     "mixture_e_step_mode": 0.0007
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 59,
+        "mean": 2.3841,
+        "std": 0.0311,
+        "min": 2.3375
+       },
+       "none": {
+        "n": 216,
+        "mean": 2.3752,
+        "std": 0.0383,
+        "min": 2.3351
+       },
+       "leaf_reuse": {
+        "n": 25,
+        "mean": 2.4314,
+        "std": 0.0551,
+        "min": 2.3571
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0089,
+       "p_value": 0.069893,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 52,
+        "mean": 2.4147,
+        "std": 0.0668,
+        "min": 2.3375
+       },
+       "token_choice": {
+        "n": 248,
+        "mean": 2.3747,
+        "std": 0.0298,
+        "min": 2.3351
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.04,
+       "p_value": 0.000103,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 201,
+        "mean": 2.3769,
+        "std": 0.0404,
+        "min": 2.3351
+       },
+       "em": {
+        "n": 28,
+        "mean": 2.4042,
+        "std": 0.0396,
+        "min": 2.361
+       },
+       "gate_only": {
+        "n": 71,
+        "mean": 2.3861,
+        "std": 0.0427,
+        "min": 2.3519
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0092,
+       "p_value": 0.116389,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 18,
+        "mean": 2.4654,
+        "std": 0.0749,
+        "min": 2.3654
+       },
+       "tree_hierarchical": {
+        "n": 55,
+        "mean": 2.3908,
+        "std": 0.0422,
+        "min": 2.348
+       },
+       "random": {
+        "n": 42,
+        "mean": 2.3997,
+        "std": 0.0378,
+        "min": 2.361
+       },
+       "uniform": {
+        "n": 185,
+        "mean": 2.3667,
+        "std": 0.0203,
+        "min": 2.3351
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0241,
+       "p_value": 0.000139,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 77,
+        "mean": 2.3998,
+        "std": 0.045,
+        "min": 2.3584
+       },
+       "none": {
+        "n": 178,
+        "mean": 2.3738,
+        "std": 0.0369,
+        "min": 2.3376
+       },
+       "markov": {
+        "n": 45,
+        "mean": 2.3815,
+        "std": 0.0437,
+        "min": 2.3351
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.0077,
+       "p_value": 0.28833,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 33,
+        "mean": 2.4363,
+        "std": 0.0544,
+        "min": 2.3654
+       },
+       "False": {
+        "n": 267,
+        "mean": 2.3749,
+        "std": 0.0342,
+        "min": 2.3351
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0614,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.3784,
+        "std": 0.0384,
+        "min": 2.3351
+       },
+       "True": {
+        "n": 20,
+        "mean": 2.4273,
+        "std": 0.0567,
+        "min": 2.3759
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0489,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 2.3816
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0464
+       ],
+       "n": 75,
+       "mean_rmse": 2.3806
+      },
+      "Q2": {
+       "range": [
+        0.0464,
+        0.0939
+       ],
+       "n": 75,
+       "mean_rmse": 2.3744
+      },
+      "Q3": {
+       "range": [
+        0.0939,
+        0.4125
+       ],
+       "n": 75,
+       "mean_rmse": 2.3967
+      },
+      "Q4": {
+       "range": [
+        0.4125,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3748
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        18.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3863
+      },
+      "Q2": {
+       "range": [
+        18.75,
+        35.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.3793
+      },
+      "Q3": {
+       "range": [
+        35.0,
+        41.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.3706
+      },
+      "Q4": {
+       "range": [
+        41.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.3904
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        5.0
+       ],
+       "n": 147,
+       "mean_rmse": 2.3838
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.3873
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 2.3729
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0549
+       ],
+       "n": 75,
+       "mean_rmse": 2.3933
+      },
+      "Q2": {
+       "range": [
+        0.0549,
+        0.0688
+       ],
+       "n": 75,
+       "mean_rmse": 2.3825
+      },
+      "Q3": {
+       "range": [
+        0.0688,
+        0.0795
+       ],
+       "n": 75,
+       "mean_rmse": 2.3635
+      },
+      "Q4": {
+       "range": [
+        0.0795,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3872
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.3754
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        26.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.37
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        35.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.3685
+      },
+      "Q4": {
+       "range": [
+        35.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.4102
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 219,
+       "mean_rmse": 2.3721
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.4074
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        38.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.399
+      },
+      "Q2": {
+       "range": [
+        38.0,
+        42.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.3666
+      },
+      "Q3": {
+       "range": [
+        42.0,
+        46.0
+       ],
+       "n": 81,
+       "mean_rmse": 2.3693
+      },
+      "Q4": {
+       "range": [
+        46.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.3954
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 249.3,
+    "holdout": {
+     "holdout_rmse": 2.5047535243482475,
+     "retrain_s": 0.0686,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.335125271030672
+    }
+   }
+  },
+  "hmm@s44": {
+   "dataset": "hmm",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.3382988881406865,
+    "std": 2.4175724001792345
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.1311368317391413,
+    "rmse_p10": 2.1347059782531117,
+    "rmse_median": 2.1422571636194356,
+    "train_s_median": 0.026574102230370045,
+    "train_s_mean": 0.030326428684095543,
+    "train_s_p90": 0.038844748511910464,
+    "best_params": {
+     "learning_rate": 0.04318059687956437,
+     "num_leaves": 111,
+     "max_depth": 3,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 7.813033892417652e-06,
+     "lambda_l2": 3.991685143866207e-05,
+     "feature_fraction": 0.7461439832744696,
+     "bagging_fraction": 0.9298644845780416,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4806,
+     "max_depth": 0.1546,
+     "bagging_fraction": 0.1229,
+     "learning_rate": 0.0904,
+     "min_data_in_leaf": 0.0829,
+     "feature_fraction": 0.0408,
+     "num_leaves": 0.0195,
+     "bagging_freq": 0.0055,
+     "lambda_l2": 0.0022,
+     "lambda_l1": 0.0006
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 22,
+        "mean": 2.1867,
+        "std": 0.0243,
+        "min": 2.157
+       },
+       "True": {
+        "n": 278,
+        "mean": 2.1441,
+        "std": 0.0129,
+        "min": 2.1311
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0426,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0406
+       ],
+       "n": 75,
+       "mean_rmse": 2.1514
+      },
+      "Q2": {
+       "range": [
+        0.0406,
+        0.0468
+       ],
+       "n": 75,
+       "mean_rmse": 2.1411
+      },
+      "Q3": {
+       "range": [
+        0.0468,
+        0.0612
+       ],
+       "n": 75,
+       "mean_rmse": 2.1454
+      },
+      "Q4": {
+       "range": [
+        0.0612,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1511
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        88.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.1552
+      },
+      "Q2": {
+       "range": [
+        88.0,
+        102.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.1441
+      },
+      "Q3": {
+       "range": [
+        102.0,
+        112.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.1438
+      },
+      "Q4": {
+       "range": [
+        112.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.1462
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 216,
+       "mean_rmse": 2.143
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 2.1581
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.1393
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.1438
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.25
+       ],
+       "n": 78,
+       "mean_rmse": 2.1472
+      },
+      "Q4": {
+       "range": [
+        14.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1582
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1468
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1476
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1447
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1498
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1443
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0006
+       ],
+       "n": 75,
+       "mean_rmse": 2.1449
+      },
+      "Q3": {
+       "range": [
+        0.0006,
+        0.0048
+       ],
+       "n": 75,
+       "mean_rmse": 2.1449
+      },
+      "Q4": {
+       "range": [
+        0.0048,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1548
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7138
+       ],
+       "n": 75,
+       "mean_rmse": 2.1508
+      },
+      "Q2": {
+       "range": [
+        0.7138,
+        0.7421
+       ],
+       "n": 75,
+       "mean_rmse": 2.1424
+      },
+      "Q3": {
+       "range": [
+        0.7421,
+        0.7952
+       ],
+       "n": 75,
+       "mean_rmse": 2.1434
+      },
+      "Q4": {
+       "range": [
+        0.7952,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1522
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8818
+       ],
+       "n": 75,
+       "mean_rmse": 2.159
+      },
+      "Q2": {
+       "range": [
+        0.8818,
+        0.9284
+       ],
+       "n": 75,
+       "mean_rmse": 2.1422
+      },
+      "Q3": {
+       "range": [
+        0.9284,
+        0.9542
+       ],
+       "n": 75,
+       "mean_rmse": 2.1434
+      },
+      "Q4": {
+       "range": [
+        0.9542,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1443
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 49.7,
+    "holdout": {
+     "holdout_rmse": 2.29552544390291,
+     "retrain_s": 0.0283,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.1311368317391413
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.1234260835489907,
+    "rmse_p10": 2.129516049488302,
+    "rmse_median": 2.1394670656530455,
+    "train_s_median": 0.12468931619077922,
+    "train_s_mean": 0.12400066213558117,
+    "train_s_p90": 0.154949865937233,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.1583856296088974,
+     "num_leaves": 17,
+     "max_depth": 7,
+     "min_data_in_leaf": 43,
+     "lambda_l1": 6.506292204409515e-06,
+     "lambda_l2": 4.710873309408515,
+     "feature_fraction": 0.5609414933801727,
+     "bagging_fraction": 0.9409588880042328,
+     "bagging_freq": 2,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 38,
+     "mixture_balance_factor": 8,
+     "mixture_diversity_lambda": 0.19516980371187928,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 28,
+     "mixture_gate_learning_rate": 0.020432145864748858,
+     "mixture_gate_lambda_l2": 1.9618528451119361,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 6,
+     "mixture_expert_capacity_factor": 0.9240753424047193,
+     "mixture_expert_choice_boost": 20.962261308797,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.7091,
+     "feature_fraction": 0.0882,
+     "learning_rate": 0.0608,
+     "mixture_gate_type": 0.021,
+     "mixture_warmup_iters": 0.021,
+     "min_data_in_leaf": 0.0171,
+     "mixture_num_experts": 0.015,
+     "extra_trees": 0.0126,
+     "mixture_diversity_lambda": 0.0117,
+     "num_leaves": 0.0081,
+     "bagging_freq": 0.0077,
+     "mixture_balance_factor": 0.0073,
+     "bagging_fraction": 0.0051,
+     "lambda_l2": 0.0045,
+     "mixture_e_step_mode": 0.0028,
+     "mixture_hard_m_step": 0.0028,
+     "max_depth": 0.0017,
+     "mixture_r_smoothing": 0.0016,
+     "mixture_refit_leaves": 0.0012,
+     "lambda_l1": 0.0003,
+     "mixture_routing_mode": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 16,
+        "mean": 2.1736,
+        "std": 0.0436,
+        "min": 2.1316
+       },
+       "none": {
+        "n": 40,
+        "mean": 2.1904,
+        "std": 0.0611,
+        "min": 2.1349
+       },
+       "leaf_reuse": {
+        "n": 244,
+        "mean": 2.1575,
+        "std": 0.0543,
+        "min": 2.1234
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0161,
+       "p_value": 0.189882,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 42,
+        "mean": 2.1853,
+        "std": 0.0582,
+        "min": 2.1349
+       },
+       "expert_choice": {
+        "n": 258,
+        "mean": 2.1591,
+        "std": 0.0547,
+        "min": 2.1234
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0262,
+       "p_value": 0.00936,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 250,
+        "mean": 2.1586,
+        "std": 0.0536,
+        "min": 2.1234
+       },
+       "em": {
+        "n": 27,
+        "mean": 2.1775,
+        "std": 0.0487,
+        "min": 2.1348
+       },
+       "loss_only": {
+        "n": 23,
+        "mean": 2.1908,
+        "std": 0.0744,
+        "min": 2.1335
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0189,
+       "p_value": 0.070334,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 253,
+        "mean": 2.1474,
+        "std": 0.0291,
+        "min": 2.1234
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 2.2893,
+        "std": 0.0679,
+        "min": 2.1589
+       },
+       "random": {
+        "n": 18,
+        "mean": 2.1668,
+        "std": 0.0279,
+        "min": 2.144
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 2.2986,
+        "std": 0.0767,
+        "min": 2.1679
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0194,
+       "p_value": 0.012145,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 205,
+        "mean": 2.1603,
+        "std": 0.0556,
+        "min": 2.1234
+       },
+       "ema": {
+        "n": 26,
+        "mean": 2.176,
+        "std": 0.0492,
+        "min": 2.1303
+       },
+       "markov": {
+        "n": 69,
+        "mean": 2.1651,
+        "std": 0.0584,
+        "min": 2.1297
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.0048,
+       "p_value": 0.557542,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 262,
+        "mean": 2.16,
+        "std": 0.0544,
+        "min": 2.1234
+       },
+       "False": {
+        "n": 38,
+        "mean": 2.182,
+        "std": 0.0621,
+        "min": 2.1382
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.022,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.1589,
+        "std": 0.0537,
+        "min": 2.1234
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.2146,
+        "std": 0.0591,
+        "min": 2.157
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0557,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 2.1628
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.201
+       ],
+       "n": 75,
+       "mean_rmse": 2.1668
+      },
+      "Q2": {
+       "range": [
+        0.201,
+        0.2876
+       ],
+       "n": 75,
+       "mean_rmse": 2.1581
+      },
+      "Q3": {
+       "range": [
+        0.2876,
+        0.3619
+       ],
+       "n": 75,
+       "mean_rmse": 2.1608
+      },
+      "Q4": {
+       "range": [
+        0.3619,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1653
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.1738
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        45.0
+       ],
+       "n": 66,
+       "mean_rmse": 2.1631
+      },
+      "Q3": {
+       "range": [
+        45.0,
+        48.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.1596
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 2.1561
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 54,
+       "mean_rmse": 2.1896
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 31,
+       "mean_rmse": 2.1671
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 215,
+       "mean_rmse": 2.1554
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1338
+       ],
+       "n": 75,
+       "mean_rmse": 2.1913
+      },
+      "Q2": {
+       "range": [
+        0.1338,
+        0.1582
+       ],
+       "n": 75,
+       "mean_rmse": 2.1463
+      },
+      "Q3": {
+       "range": [
+        0.1582,
+        0.1997
+       ],
+       "n": 75,
+       "mean_rmse": 2.1476
+      },
+      "Q4": {
+       "range": [
+        0.1997,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1658
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.1604
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        36.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.1579
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        50.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.1514
+      },
+      "Q4": {
+       "range": [
+        50.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.1812
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 33,
+       "mean_rmse": 2.1745
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 99,
+       "mean_rmse": 2.1558
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 32,
+       "mean_rmse": 2.191
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 136,
+       "mean_rmse": 2.1584
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        31.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.1776
+      },
+      "Q2": {
+       "range": [
+        31.75,
+        39.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.1494
+      },
+      "Q3": {
+       "range": [
+        39.0,
+        43.25
+       ],
+       "n": 77,
+       "mean_rmse": 2.1571
+      },
+      "Q4": {
+       "range": [
+        43.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1668
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 195.7,
+    "holdout": {
+     "holdout_rmse": 2.3020555586645948,
+     "retrain_s": 0.1847,
+     "predict_s": 0.0004,
+     "cv_rmse_of_winner": 2.1234260835489907
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_houses_report.md
+++ b/bench_results/meth2_v080/ds_houses_report.md
@@ -1,0 +1,515 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['houses'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| houses | naive-lightgbm | **49805.38271** ± 962.89058 | 50811.46230 | 0.0% | 0.49 |
+| houses | moe | **49077.47792** ± 338.55158 | 50401.78870 | 0.0% | 3.46 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| houses@s42 | naive-lightgbm | 50683.0901 | 51224.1336 | 0.198 | 301 |
+| houses@s42 | moe | 50407.5337 | 51276.1226 | 1.138 | 2413 |
+| houses@s43 | naive-lightgbm | 51076.3747 | 51723.6494 | 0.342 | 497 |
+| houses@s43 | moe | 50286.4728 | 51305.1561 | 0.769 | 1489 |
+| houses@s44 | naive-lightgbm | 50674.9222 | 51222.7143 | 0.430 | 571 |
+| houses@s44 | moe | 50511.3595 | 51281.7718 | 0.996 | 2730 |
+
+
+
+---
+
+## houses@s42  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 50760.44294** (winner retrained in 0.20s, cv score of winner: 50683.0901)
+- cv best RMSE: 50683.0901, median: 51224.1336, p10: 50895.5274
+- train: median 0.198s/fold, mean 0.195s, p90 0.244s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.675 |
+| `extra_trees` | 0.286 |
+| `min_data_in_leaf` | 0.010 |
+| `feature_fraction` | 0.009 |
+| `bagging_fraction` | 0.007 |
+| `max_depth` | 0.006 |
+| `num_leaves` | 0.004 |
+| `bagging_freq` | 0.002 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 51888.9305 | 3228.7653 | 50683.0901 |
+| True | 22 | 65625.9156 | 10037.1753 | 57820.1777 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 55845.0459 | 51310.6123 | 51856.6872 | 52572.8922 | **Q2** [0.0884, 0.1021] |
+| `num_leaves` | 53047.3600 | 51953.3869 | 51484.0810 | 55174.9507 | **Q3** [36.0, 44.0] |
+| `max_depth` | 56986.4618 | 52400.8256 | — | 51756.6192 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 52753.3685 | 51803.1950 | 51974.3697 | 54945.4953 | **Q2** [17.0, 21.0] |
+| `lambda_l1` | 53364.3411 | 52532.0795 | 53811.8016 | 51877.0154 | **Q4** [0.1035, ∞) |
+| `lambda_l2` | 55110.6574 | 51893.7303 | 51780.1980 | 52800.6519 | **Q3** [0.1017, 0.379] |
+| `feature_fraction` | 55369.3077 | 51491.1940 | 51682.8047 | 53041.9312 | **Q2** [0.7235, 0.7507] |
+| `bagging_fraction` | 53204.3996 | 52442.3521 | 53142.7276 | 52795.7583 | **Q2** [0.6939, 0.7489] |
+
+#### E. Slice plot
+
+![houses@s42/naive-lightgbm](slice_houses@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 49530.87620** (winner retrained in 8.95s, cv score of winner: 50407.5337)
+- cv best RMSE: 50407.5337, median: 51276.1226, p10: 50724.3187
+- train: median 1.138s/fold, mean 1.591s, p90 4.071s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_hard_m_step` | 0.389 |
+| `extra_trees` | 0.254 |
+| `learning_rate` | 0.220 |
+| `feature_fraction` | 0.034 |
+| `bagging_fraction` | 0.023 |
+| `mixture_gate_type` | 0.015 |
+| `num_leaves` | 0.015 |
+| `min_data_in_leaf` | 0.006 |
+| `mixture_diversity_lambda` | 0.006 |
+| `mixture_num_experts` | 0.006 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 53388.0952 (n=275) | token_choice | Δ +12290.6428 | p=5.83e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 195 | 53310.1990 | 6867.1164 | 50559.7323 |
+| none | 49 | 55523.8300 | 10168.5848 | 50407.5337 |
+| gbdt | 56 | 57277.4673 | 12995.4211 | 51074.0547 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 275 | 53388.0952 | 7455.6643 | 50407.5337 |
+| token_choice | 25 | 65678.7380 | 15137.3998 | 51158.6269 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 177 | 52936.9608 | 5894.2778 | 50407.5337 |
+| gate_only | 68 | 56376.4533 | 10080.6978 | 50829.7399 |
+| em | 55 | 56731.8865 | 13799.5880 | 50526.9366 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 86 | 53377.9221 | 6767.5864 | 50407.5337 |
+| uniform | 187 | 53792.6868 | 8015.7289 | 50702.9195 |
+| gmm | 12 | 58525.4573 | 8490.6653 | 51718.7702 |
+| tree_hierarchical | 15 | 64777.0275 | 19458.4270 | 51097.0453 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 171 | 53565.3070 | 7523.4264 | 50559.7323 |
+| markov | 61 | 54220.2270 | 7626.0443 | 50407.5337 |
+| none | 68 | 56714.6073 | 12582.0059 | 51008.1911 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 53135.2819 | 7227.0901 | 50407.5337 |
+| True | 20 | 72290.7855 | 12252.8821 | 54084.4628 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 53248.3850 | 7353.6555 | 50407.5337 |
+| True | 21 | 69875.9627 | 13783.8080 | 57075.3232 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 54753.4678 | — | 54105.7102 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 51747.1781 | 54390.0201 | 53146.2985 | 58365.7652 | **Q1** [None, 0.041] |
+| `mixture_warmup_iters` | 52022.6404 | 53644.2177 | 52869.0906 | 57823.9983 | **Q1** [None, 6.0] |
+| `mixture_balance_factor` | 58595.2707 | 56340.4032 | — | 52788.1832 | **Q4** [9.0, ∞) |
+| `learning_rate` | 59624.4941 | 51869.8134 | 52353.7975 | 53801.1569 | **Q2** [0.1152, 0.1363] |
+| `num_leaves` | 57338.1101 | 52234.5327 | 55604.5945 | 52695.2379 | **Q2** [71.0, 86.5] |
+| `max_depth` | 57919.9116 | — | — | 53461.1029 | **Q4** [10.0, ∞) |
+| `min_data_in_leaf` | 53450.9262 | 52759.8236 | 54572.3092 | 56860.4658 | **Q2** [15.0, 22.0] |
+
+#### E. Slice plot
+
+![houses@s42/moe](slice_houses@s42_moe.png)
+
+
+---
+
+## houses@s43  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 50168.46687** (winner retrained in 0.56s, cv score of winner: 51076.3747)
+- cv best RMSE: 51076.3747, median: 51723.6494, p10: 51396.0980
+- train: median 0.342s/fold, mean 0.325s, p90 0.439s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.557 |
+| `learning_rate` | 0.273 |
+| `feature_fraction` | 0.067 |
+| `max_depth` | 0.051 |
+| `min_data_in_leaf` | 0.028 |
+| `bagging_freq` | 0.013 |
+| `bagging_fraction` | 0.006 |
+| `num_leaves` | 0.002 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 52383.8445 | 2614.0622 | 51076.3747 |
+| True | 21 | 64191.2960 | 5869.1887 | 57331.5582 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54846.3206 | 52554.2688 | 52209.4324 | 53231.4426 | **Q3** [0.0676, 0.0786] |
+| `num_leaves` | 54728.3649 | 52898.7171 | 52641.8450 | 52584.7191 | **Q4** [117.0, ∞) |
+| `max_depth` | 55898.8596 | 52305.1409 | 53184.8689 | 53192.0540 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 52738.2128 | 52435.7065 | 52297.1280 | 55178.8607 | **Q3** [17.0, 24.0] |
+| `lambda_l1` | 53621.7121 | 52673.3426 | 52469.2696 | 54077.1402 | **Q3** [0.0, 0.0001] |
+| `lambda_l2` | 53797.3334 | 53224.9688 | 52603.0649 | 53216.0974 | **Q3** [0.222, 0.8473] |
+| `feature_fraction` | 54145.7746 | 52498.8939 | 52392.1659 | 53804.6301 | **Q3** [0.7851, 0.8138] |
+| `bagging_fraction` | 53940.5034 | 52654.5802 | 53087.9937 | 53158.3872 | **Q2** [0.782, 0.8405] |
+
+#### E. Slice plot
+
+![houses@s43/naive-lightgbm](slice_houses@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 48984.00134** (winner retrained in 0.90s, cv score of winner: 50286.4728)
+- cv best RMSE: 50286.4728, median: 51305.1561, p10: 50601.9288
+- train: median 0.769s/fold, mean 0.978s, p90 1.279s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.495 |
+| `mixture_hard_m_step` | 0.202 |
+| `extra_trees` | 0.100 |
+| `mixture_balance_factor` | 0.033 |
+| `mixture_init` | 0.031 |
+| `feature_fraction` | 0.030 |
+| `num_leaves` | 0.020 |
+| `mixture_e_step_mode` | 0.015 |
+| `mixture_diversity_lambda` | 0.014 |
+| `mixture_num_experts` | 0.010 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_r_smoothing` | **ema** | 52782.9066 (n=256) | markov | Δ +6136.9992 | p=1.90e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 178 | 53113.2660 | 6812.2550 | 50286.4728 |
+| gbdt | 97 | 54818.0059 | 8653.2220 | 50917.9606 |
+| leaf_reuse | 25 | 56687.1698 | 8241.7661 | 51311.1350 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 213 | 53547.5762 | 7918.8790 | 50286.4728 |
+| expert_choice | 87 | 54977.6257 | 6884.4908 | 51138.4745 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 177 | 52945.4514 | 5721.2863 | 50286.4728 |
+| loss_only | 98 | 54430.1107 | 7917.3156 | 50600.9454 |
+| em | 25 | 59327.6571 | 13777.9729 | 52121.3896 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 110 | 53701.2203 | 8169.1478 | 50600.9454 |
+| tree_hierarchical | 141 | 53781.7069 | 7724.4142 | 50286.4728 |
+| gmm | 23 | 54722.5486 | 3387.2029 | 51733.6953 |
+| uniform | 26 | 55373.6023 | 7625.4666 | 51884.4858 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 256 | 52782.9066 | 5744.1865 | 50286.4728 |
+| markov | 27 | 58919.9058 | 8950.4682 | 52121.3896 |
+| none | 17 | 63848.5659 | 15932.9593 | 51755.7322 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 277 | 52668.3577 | 5140.4971 | 50286.4728 |
+| True | 23 | 69545.7428 | 13574.1233 | 52536.4317 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 53227.4708 | 6913.9159 | 50286.4728 |
+| True | 20 | 64249.7681 | 9885.0296 | 56498.4203 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 55720.4137 | — | — | 53683.9777 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 53900.2291 | 52477.6863 | 52934.5061 | 56536.7409 | **Q2** [0.0173, 0.0362] |
+| `mixture_warmup_iters` | 52606.4120 | 52039.5121 | 55977.3914 | 55034.2302 | **Q2** [8.0, 12.0] |
+| `mixture_balance_factor` | — | — | 52709.2397 | 56584.6549 | **Q3** [2.0, 3.0] |
+| `learning_rate` | 58100.8467 | 52819.2616 | 52767.6855 | 52161.3687 | **Q4** [0.2488, ∞) |
+| `num_leaves` | 53434.8033 | 51903.3966 | 53952.1940 | 56605.9507 | **Q2** [29.0, 34.0] |
+| `max_depth` | 54917.4674 | — | 52868.4079 | 54899.0230 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | 52737.3513 | 53553.1347 | 53868.2030 | 55562.3937 | **Q1** [None, 11.0] |
+
+#### E. Slice plot
+
+![houses@s43/moe](slice_houses@s43_moe.png)
+
+
+---
+
+## houses@s44  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 48487.23831** (winner retrained in 0.71s, cv score of winner: 50674.9222)
+- cv best RMSE: 50674.9222, median: 51222.7143, p10: 50855.8811
+- train: median 0.430s/fold, mean 0.374s, p90 0.572s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.668 |
+| `learning_rate` | 0.247 |
+| `min_data_in_leaf` | 0.029 |
+| `max_depth` | 0.026 |
+| `feature_fraction` | 0.015 |
+| `bagging_fraction` | 0.006 |
+| `num_leaves` | 0.006 |
+| `bagging_freq` | 0.003 |
+| `lambda_l1` | 0.000 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 52023.0161 | 2849.5999 | 50674.9222 |
+| True | 20 | 65091.4977 | 4234.1415 | 58652.9668 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 55034.4959 | 51555.5742 | 52070.6520 | 52916.2707 | **Q2** [0.0547, 0.0629] |
+| `num_leaves` | 54040.3712 | 53077.1628 | 52163.2740 | 52344.9255 | **Q3** [110.0, 116.25] |
+| `max_depth` | 54770.7357 | 53077.9487 | — | 52205.8020 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 51813.2123 | 51580.5544 | 52392.5069 | 55575.1304 | **Q2** [12.0, 15.0] |
+| `lambda_l1` | 54635.0590 | 52656.6604 | 51978.5144 | 52306.7590 | **Q3** [0.1121, 0.6478] |
+| `lambda_l2` | 54169.3509 | 52512.7667 | 51859.7302 | 53035.1450 | **Q3** [0.0008, 0.0033] |
+| `feature_fraction` | 54831.5402 | 52020.4412 | 51598.4895 | 53126.5219 | **Q3** [0.7333, 0.7547] |
+| `bagging_fraction` | 53409.2827 | 52100.9552 | 53134.6432 | 52932.1117 | **Q2** [0.8281, 0.8641] |
+
+#### E. Slice plot
+
+![houses@s44/naive-lightgbm](slice_houses@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 48717.55622** (winner retrained in 0.51s, cv score of winner: 50511.3595)
+- cv best RMSE: 50511.3595, median: 51281.7718, p10: 50680.9809
+- train: median 0.996s/fold, mean 1.802s, p90 3.177s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.548 |
+| `extra_trees` | 0.211 |
+| `mixture_hard_m_step` | 0.085 |
+| `feature_fraction` | 0.045 |
+| `bagging_freq` | 0.018 |
+| `mixture_e_step_mode` | 0.017 |
+| `mixture_diversity_lambda` | 0.016 |
+| `max_depth` | 0.016 |
+| `mixture_warmup_iters` | 0.010 |
+| `min_data_in_leaf` | 0.007 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 53563.8494 (n=262) | expert_choice | Δ +7291.1001 | p=4.37e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 216 | 53239.4740 | 6174.8385 | 50614.2885 |
+| none | 65 | 55820.7813 | 9502.5677 | 50511.3595 |
+| leaf_reuse | 19 | 64112.6030 | 13611.0465 | 52329.1432 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 262 | 53563.8494 | 6215.6286 | 50511.3595 |
+| expert_choice | 38 | 60854.9495 | 14465.0411 | 50925.9556 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 215 | 53473.4440 | 7229.1807 | 50614.2885 |
+| em | 65 | 54803.0058 | 6661.4683 | 50511.3595 |
+| loss_only | 20 | 64361.5392 | 13302.9058 | 50763.5080 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 216 | 53032.8246 | 6577.1688 | 50511.3595 |
+| uniform | 15 | 57115.9751 | 7937.7804 | 51003.8473 |
+| tree_hierarchical | 45 | 58454.3180 | 12184.9311 | 51217.1212 |
+| gmm | 24 | 58497.6066 | 7107.0044 | 52184.7640 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 152 | 53234.0732 | 6288.3526 | 50614.2885 |
+| markov | 69 | 55572.5474 | 7563.6556 | 51193.0772 |
+| ema | 79 | 55951.0345 | 10902.3798 | 50511.3595 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 277 | 53528.9046 | 6754.4656 | 50511.3595 |
+| True | 23 | 66030.8717 | 12989.2217 | 54112.3439 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 53731.5198 | 7679.2356 | 50511.3595 |
+| True | 20 | 65069.5533 | 6804.2062 | 58478.2963 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 61405.1427 | — | — | 54248.8455 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 55427.6934 | 52319.9615 | 53967.8612 | 56234.0387 | **Q2** [0.1636, 0.21] |
+| `mixture_warmup_iters` | 53779.3357 | 54850.5701 | 54004.8640 | 55264.3893 | **Q1** [None, 15.0] |
+| `mixture_balance_factor` | 55924.3990 | 54692.5417 | 53927.6106 | 54292.9993 | **Q3** [6.0, 7.0] |
+| `learning_rate` | 57907.5149 | 52202.0028 | 52870.7757 | 54969.2615 | **Q2** [0.0859, 0.1039] |
+| `num_leaves` | 55757.3978 | 53911.4339 | 53394.3440 | 54886.3792 | **Q3** [59.5, 72.25] |
+| `max_depth` | 61058.6041 | 53829.9318 | — | 52512.8950 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 53959.0225 | 51878.8925 | 53234.6944 | 59297.7016 | **Q2** [12.0, 16.5] |
+
+#### E. Slice plot
+
+![houses@s44/moe](slice_houses@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| houses@s42 | `mixture_routing_mode` | **expert_choice** | +12290.6428 | 5.83e-04 |
+| houses@s43 | `mixture_r_smoothing` | **ema** | +6136.9992 | 1.90e-03 |
+| houses@s44 | `mixture_routing_mode` | **token_choice** | +7291.1001 | 4.37e-03 |

--- a/bench_results/meth2_v080/ds_houses_summary.json
+++ b/bench_results/meth2_v080/ds_houses_summary.json
@@ -1,0 +1,2721 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "houses"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "houses": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 50760.44294032335,
+      "cv_best": 50683.0900785632,
+      "crash_rate": 0.0,
+      "retrain_s": 0.197
+     },
+     "43": {
+      "holdout_rmse": 50168.46687248024,
+      "cv_best": 51076.37465143886,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5559
+     },
+     "44": {
+      "holdout_rmse": 48487.23831014311,
+      "cv_best": 50674.92215781791,
+      "crash_rate": 0.0,
+      "retrain_s": 0.7142
+     }
+    },
+    "holdout_mean": 49805.382708,
+    "holdout_std": 962.890581,
+    "cv_best_mean": 50811.462296
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 49530.876203775966,
+      "cv_best": 50407.533729480325,
+      "crash_rate": 0.0,
+      "retrain_s": 8.9523
+     },
+     "43": {
+      "holdout_rmse": 48984.00134499726,
+      "cv_best": 50286.472835561784,
+      "crash_rate": 0.0,
+      "retrain_s": 0.9045
+     },
+     "44": {
+      "holdout_rmse": 48717.55621562207,
+      "cv_best": 50511.359521001774,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5139
+     }
+    },
+    "holdout_mean": 49077.477921,
+    "holdout_std": 338.551575,
+    "cv_best_mean": 50401.788695
+   }
+  }
+ },
+ "runs": {
+  "houses@s42": {
+   "dataset": "houses",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 206067.006875,
+    "std": 114867.76939213117
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50683.0900785632,
+    "rmse_p10": 50895.52743146411,
+    "rmse_median": 51224.133646789225,
+    "train_s_median": 0.1977485202252865,
+    "train_s_mean": 0.19540720199172695,
+    "train_s_p90": 0.24379481315612792,
+    "best_params": {
+     "learning_rate": 0.09549031388166374,
+     "num_leaves": 33,
+     "max_depth": 12,
+     "min_data_in_leaf": 17,
+     "lambda_l1": 0.1387994234815757,
+     "lambda_l2": 0.12921075526430417,
+     "feature_fraction": 0.8036813953393781,
+     "bagging_fraction": 0.7461121609117708,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6753,
+     "extra_trees": 0.2862,
+     "min_data_in_leaf": 0.0102,
+     "feature_fraction": 0.0089,
+     "bagging_fraction": 0.007,
+     "max_depth": 0.0062,
+     "num_leaves": 0.0038,
+     "bagging_freq": 0.0019,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 65625.9156,
+        "std": 10037.1753,
+        "min": 57820.1777
+       },
+       "False": {
+        "n": 278,
+        "mean": 51888.9305,
+        "std": 3228.7653,
+        "min": 50683.0901
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 13736.9851,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0884
+       ],
+       "n": 75,
+       "mean_rmse": 55845.0459
+      },
+      "Q2": {
+       "range": [
+        0.0884,
+        0.1021
+       ],
+       "n": 75,
+       "mean_rmse": 51310.6123
+      },
+      "Q3": {
+       "range": [
+        0.1021,
+        0.117
+       ],
+       "n": 75,
+       "mean_rmse": 51856.6872
+      },
+      "Q4": {
+       "range": [
+        0.117,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52572.8922
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        31.0
+       ],
+       "n": 64,
+       "mean_rmse": 53047.36
+      },
+      "Q2": {
+       "range": [
+        31.0,
+        36.0
+       ],
+       "n": 84,
+       "mean_rmse": 51953.3869
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        44.0
+       ],
+       "n": 75,
+       "mean_rmse": 51484.081
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 55174.9507
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 57,
+       "mean_rmse": 56986.4618
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 68,
+       "mean_rmse": 52400.8256
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 175,
+       "mean_rmse": 51756.6192
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 70,
+       "mean_rmse": 52753.3685
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        21.0
+       ],
+       "n": 74,
+       "mean_rmse": 51803.195
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        26.0
+       ],
+       "n": 77,
+       "mean_rmse": 51974.3697
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 54945.4953
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 53364.3411
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0008
+       ],
+       "n": 75,
+       "mean_rmse": 52532.0795
+      },
+      "Q3": {
+       "range": [
+        0.0008,
+        0.1035
+       ],
+       "n": 75,
+       "mean_rmse": 53811.8016
+      },
+      "Q4": {
+       "range": [
+        0.1035,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 51877.0154
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0199
+       ],
+       "n": 75,
+       "mean_rmse": 55110.6574
+      },
+      "Q2": {
+       "range": [
+        0.0199,
+        0.1017
+       ],
+       "n": 75,
+       "mean_rmse": 51893.7303
+      },
+      "Q3": {
+       "range": [
+        0.1017,
+        0.379
+       ],
+       "n": 75,
+       "mean_rmse": 51780.198
+      },
+      "Q4": {
+       "range": [
+        0.379,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52800.6519
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7235
+       ],
+       "n": 75,
+       "mean_rmse": 55369.3077
+      },
+      "Q2": {
+       "range": [
+        0.7235,
+        0.7507
+       ],
+       "n": 75,
+       "mean_rmse": 51491.194
+      },
+      "Q3": {
+       "range": [
+        0.7507,
+        0.781
+       ],
+       "n": 75,
+       "mean_rmse": 51682.8047
+      },
+      "Q4": {
+       "range": [
+        0.781,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53041.9312
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6939
+       ],
+       "n": 75,
+       "mean_rmse": 53204.3996
+      },
+      "Q2": {
+       "range": [
+        0.6939,
+        0.7489
+       ],
+       "n": 75,
+       "mean_rmse": 52442.3521
+      },
+      "Q3": {
+       "range": [
+        0.7489,
+        0.8903
+       ],
+       "n": 75,
+       "mean_rmse": 53142.7276
+      },
+      "Q4": {
+       "range": [
+        0.8903,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52795.7583
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 301.3,
+    "holdout": {
+     "holdout_rmse": 50760.44294032335,
+     "retrain_s": 0.197,
+     "predict_s": 0.0022,
+     "cv_rmse_of_winner": 50683.0900785632
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50407.533729480325,
+    "rmse_p10": 50724.31872023624,
+    "rmse_median": 51276.122606690784,
+    "train_s_median": 1.1384289769455789,
+    "train_s_mean": 1.591114921769748,
+    "train_s_p90": 4.070642307661476,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.21777486886452002,
+     "num_leaves": 83,
+     "max_depth": 10,
+     "min_data_in_leaf": 34,
+     "lambda_l1": 3.8519887776437427,
+     "lambda_l2": 5.962124920850089,
+     "feature_fraction": 0.8611146499121174,
+     "bagging_fraction": 0.6292603476664759,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 14,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.03781611199690014,
+     "mixture_diversity_lambda": 0.13709477367381087,
+     "mixture_hard_m_step": false,
+     "mixture_expert_capacity_factor": 1.127355843995833,
+     "mixture_expert_choice_boost": 13.255773613624976,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.1632072388535363,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_hard_m_step": 0.3891,
+     "extra_trees": 0.2536,
+     "learning_rate": 0.2196,
+     "feature_fraction": 0.0338,
+     "bagging_fraction": 0.0231,
+     "mixture_gate_type": 0.0152,
+     "num_leaves": 0.0148,
+     "min_data_in_leaf": 0.0063,
+     "mixture_diversity_lambda": 0.0057,
+     "mixture_num_experts": 0.0056,
+     "mixture_routing_mode": 0.0054,
+     "mixture_warmup_iters": 0.0053,
+     "max_depth": 0.005,
+     "mixture_refit_leaves": 0.0045,
+     "mixture_e_step_mode": 0.0045,
+     "mixture_balance_factor": 0.0023,
+     "lambda_l1": 0.0021,
+     "mixture_r_smoothing": 0.0018,
+     "bagging_freq": 0.0009,
+     "mixture_init": 0.0008,
+     "lambda_l2": 0.0005
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 195,
+        "mean": 53310.199,
+        "std": 6867.1164,
+        "min": 50559.7323
+       },
+       "none": {
+        "n": 49,
+        "mean": 55523.83,
+        "std": 10168.5848,
+        "min": 50407.5337
+       },
+       "gbdt": {
+        "n": 56,
+        "mean": 57277.4673,
+        "std": 12995.4211,
+        "min": 51074.0547
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 2213.631,
+       "p_value": 0.158051,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 25,
+        "mean": 65678.738,
+        "std": 15137.3998,
+        "min": 51158.6269
+       },
+       "expert_choice": {
+        "n": 275,
+        "mean": 53388.0952,
+        "std": 7455.6643,
+        "min": 50407.5337
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 12290.6428,
+       "p_value": 0.000583,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 177,
+        "mean": 52936.9608,
+        "std": 5894.2778,
+        "min": 50407.5337
+       },
+       "gate_only": {
+        "n": 68,
+        "mean": 56376.4533,
+        "std": 10080.6978,
+        "min": 50829.7399
+       },
+       "em": {
+        "n": 55,
+        "mean": 56731.8865,
+        "std": 13799.588,
+        "min": 50526.9366
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 3439.4925,
+       "p_value": 0.010215,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 86,
+        "mean": 53377.9221,
+        "std": 6767.5864,
+        "min": 50407.5337
+       },
+       "gmm": {
+        "n": 12,
+        "mean": 58525.4573,
+        "std": 8490.6653,
+        "min": 51718.7702
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 64777.0275,
+        "std": 19458.427,
+        "min": 51097.0453
+       },
+       "uniform": {
+        "n": 187,
+        "mean": 53792.6868,
+        "std": 8015.7289,
+        "min": 50702.9195
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 414.7647,
+       "p_value": 0.659655,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 171,
+        "mean": 53565.307,
+        "std": 7523.4264,
+        "min": 50559.7323
+       },
+       "markov": {
+        "n": 61,
+        "mean": 54220.227,
+        "std": 7626.0443,
+        "min": 50407.5337
+       },
+       "none": {
+        "n": 68,
+        "mean": 56714.6073,
+        "std": 12582.0059,
+        "min": 51008.1911
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 654.92,
+       "p_value": 0.567267,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 72290.7855,
+        "std": 12252.8821,
+        "min": 54084.4628
+       },
+       "False": {
+        "n": 280,
+        "mean": 53135.2819,
+        "std": 7227.0901,
+        "min": 50407.5337
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 19155.5036,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 69875.9627,
+        "std": 13783.808,
+        "min": 57075.3232
+       },
+       "False": {
+        "n": 279,
+        "mean": 53248.385,
+        "std": 7353.6555,
+        "min": 50407.5337
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 16627.5777,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        4.0
+       ],
+       "n": 142,
+       "mean_rmse": 54753.4678
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 158,
+       "mean_rmse": 54105.7102
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.041
+       ],
+       "n": 75,
+       "mean_rmse": 51747.1781
+      },
+      "Q2": {
+       "range": [
+        0.041,
+        0.095
+       ],
+       "n": 75,
+       "mean_rmse": 54390.0201
+      },
+      "Q3": {
+       "range": [
+        0.095,
+        0.1455
+       ],
+       "n": 75,
+       "mean_rmse": 53146.2985
+      },
+      "Q4": {
+       "range": [
+        0.1455,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 58365.7652
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 40,
+       "mean_rmse": 52022.6404
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 104,
+       "mean_rmse": 53644.2177
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 72,
+       "mean_rmse": 52869.0906
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 57823.9983
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 68,
+       "mean_rmse": 58595.2707
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 26,
+       "mean_rmse": 56340.4032
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 206,
+       "mean_rmse": 52788.1832
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1152
+       ],
+       "n": 75,
+       "mean_rmse": 59624.4941
+      },
+      "Q2": {
+       "range": [
+        0.1152,
+        0.1363
+       ],
+       "n": 75,
+       "mean_rmse": 51869.8134
+      },
+      "Q3": {
+       "range": [
+        0.1363,
+        0.1805
+       ],
+       "n": 75,
+       "mean_rmse": 52353.7975
+      },
+      "Q4": {
+       "range": [
+        0.1805,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53801.1569
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        71.0
+       ],
+       "n": 74,
+       "mean_rmse": 57338.1101
+      },
+      "Q2": {
+       "range": [
+        71.0,
+        86.5
+       ],
+       "n": 76,
+       "mean_rmse": 52234.5327
+      },
+      "Q3": {
+       "range": [
+        86.5,
+        114.0
+       ],
+       "n": 71,
+       "mean_rmse": 55604.5945
+      },
+      "Q4": {
+       "range": [
+        114.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 52695.2379
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 64,
+       "mean_rmse": 57919.9116
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 236,
+       "mean_rmse": 53461.1029
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 73,
+       "mean_rmse": 53450.9262
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        22.0
+       ],
+       "n": 76,
+       "mean_rmse": 52759.8236
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        38.25
+       ],
+       "n": 76,
+       "mean_rmse": 54572.3092
+      },
+      "Q4": {
+       "range": [
+        38.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 56860.4658
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2413.2,
+    "holdout": {
+     "holdout_rmse": 49530.876203775966,
+     "retrain_s": 8.9523,
+     "predict_s": 0.015,
+     "cv_rmse_of_winner": 50407.533729480325
+    }
+   }
+  },
+  "houses@s43": {
+   "dataset": "houses",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 207292.308625,
+    "std": 114725.69189141605
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 51076.37465143886,
+    "rmse_p10": 51396.0980270342,
+    "rmse_median": 51723.64940425394,
+    "train_s_median": 0.3424683682620525,
+    "train_s_mean": 0.32502440180505315,
+    "train_s_p90": 0.4387575598433614,
+    "best_params": {
+     "learning_rate": 0.06050195723850515,
+     "num_leaves": 119,
+     "max_depth": 9,
+     "min_data_in_leaf": 13,
+     "lambda_l1": 3.016875278768682e-05,
+     "lambda_l2": 0.0789116553941158,
+     "feature_fraction": 0.7902336523801551,
+     "bagging_fraction": 0.8032336644229776,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.5575,
+     "learning_rate": 0.2734,
+     "feature_fraction": 0.0672,
+     "max_depth": 0.0511,
+     "min_data_in_leaf": 0.0278,
+     "bagging_freq": 0.0135,
+     "bagging_fraction": 0.0063,
+     "num_leaves": 0.002,
+     "lambda_l2": 0.0011,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 64191.296,
+        "std": 5869.1887,
+        "min": 57331.5582
+       },
+       "False": {
+        "n": 279,
+        "mean": 52383.8445,
+        "std": 2614.0622,
+        "min": 51076.3747
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11807.4515,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.059
+       ],
+       "n": 75,
+       "mean_rmse": 54846.3206
+      },
+      "Q2": {
+       "range": [
+        0.059,
+        0.0676
+       ],
+       "n": 75,
+       "mean_rmse": 52554.2688
+      },
+      "Q3": {
+       "range": [
+        0.0676,
+        0.0786
+       ],
+       "n": 75,
+       "mean_rmse": 52209.4324
+      },
+      "Q4": {
+       "range": [
+        0.0786,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53231.4426
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        82.75
+       ],
+       "n": 75,
+       "mean_rmse": 54728.3649
+      },
+      "Q2": {
+       "range": [
+        82.75,
+        105.0
+       ],
+       "n": 73,
+       "mean_rmse": 52898.7171
+      },
+      "Q3": {
+       "range": [
+        105.0,
+        117.0
+       ],
+       "n": 70,
+       "mean_rmse": 52641.845
+      },
+      "Q4": {
+       "range": [
+        117.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 52584.7191
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 35,
+       "mean_rmse": 55898.8596
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 100,
+       "mean_rmse": 52305.1409
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 77,
+       "mean_rmse": 53184.8689
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 88,
+       "mean_rmse": 53192.054
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 69,
+       "mean_rmse": 52738.2128
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        17.0
+       ],
+       "n": 73,
+       "mean_rmse": 52435.7065
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        24.0
+       ],
+       "n": 77,
+       "mean_rmse": 52297.128
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 55178.8607
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 53621.7121
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52673.3426
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 52469.2696
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54077.1402
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 53797.3334
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.222
+       ],
+       "n": 75,
+       "mean_rmse": 53224.9688
+      },
+      "Q3": {
+       "range": [
+        0.222,
+        0.8473
+       ],
+       "n": 75,
+       "mean_rmse": 52603.0649
+      },
+      "Q4": {
+       "range": [
+        0.8473,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53216.0974
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7286
+       ],
+       "n": 75,
+       "mean_rmse": 54145.7746
+      },
+      "Q2": {
+       "range": [
+        0.7286,
+        0.7851
+       ],
+       "n": 75,
+       "mean_rmse": 52498.8939
+      },
+      "Q3": {
+       "range": [
+        0.7851,
+        0.8138
+       ],
+       "n": 75,
+       "mean_rmse": 52392.1659
+      },
+      "Q4": {
+       "range": [
+        0.8138,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53804.6301
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.782
+       ],
+       "n": 75,
+       "mean_rmse": 53940.5034
+      },
+      "Q2": {
+       "range": [
+        0.782,
+        0.8405
+       ],
+       "n": 75,
+       "mean_rmse": 52654.5802
+      },
+      "Q3": {
+       "range": [
+        0.8405,
+        0.92
+       ],
+       "n": 75,
+       "mean_rmse": 53087.9937
+      },
+      "Q4": {
+       "range": [
+        0.92,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53158.3872
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 497.0,
+    "holdout": {
+     "holdout_rmse": 50168.46687248024,
+     "retrain_s": 0.5559,
+     "predict_s": 0.0035,
+     "cv_rmse_of_winner": 51076.37465143886
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50286.472835561784,
+    "rmse_p10": 50601.92877879925,
+    "rmse_median": 51305.15607494215,
+    "train_s_median": 0.7689731763675809,
+    "train_s_mean": 0.9780199596931538,
+    "train_s_p90": 1.278847336806357,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.2020326583825582,
+     "num_leaves": 32,
+     "max_depth": 9,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 5.3691936552026646e-08,
+     "lambda_l2": 6.890332611763123,
+     "feature_fraction": 0.8734302184653366,
+     "bagging_fraction": 0.8589121932604696,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 7,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.49502971841653287,
+     "mixture_diversity_lambda": 0.02108867901309567,
+     "mixture_hard_m_step": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.4948,
+     "mixture_hard_m_step": 0.2016,
+     "extra_trees": 0.0998,
+     "mixture_balance_factor": 0.0327,
+     "mixture_init": 0.0311,
+     "feature_fraction": 0.0301,
+     "num_leaves": 0.0204,
+     "mixture_e_step_mode": 0.0151,
+     "mixture_diversity_lambda": 0.0143,
+     "mixture_num_experts": 0.0096,
+     "mixture_r_smoothing": 0.0095,
+     "bagging_fraction": 0.0083,
+     "min_data_in_leaf": 0.008,
+     "mixture_refit_leaves": 0.0068,
+     "mixture_warmup_iters": 0.0059,
+     "bagging_freq": 0.0039,
+     "max_depth": 0.0035,
+     "mixture_gate_type": 0.002,
+     "lambda_l2": 0.0018,
+     "lambda_l1": 0.0005,
+     "mixture_routing_mode": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 97,
+        "mean": 54818.0059,
+        "std": 8653.222,
+        "min": 50917.9606
+       },
+       "none": {
+        "n": 178,
+        "mean": 53113.266,
+        "std": 6812.255,
+        "min": 50286.4728
+       },
+       "leaf_reuse": {
+        "n": 25,
+        "mean": 56687.1698,
+        "std": 8241.7661,
+        "min": 51311.135
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 1704.7399,
+       "p_value": 0.096877,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 87,
+        "mean": 54977.6257,
+        "std": 6884.4908,
+        "min": 51138.4745
+       },
+       "token_choice": {
+        "n": 213,
+        "mean": 53547.5762,
+        "std": 7918.879,
+        "min": 50286.4728
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 1430.0495,
+       "p_value": 0.12194,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 98,
+        "mean": 54430.1107,
+        "std": 7917.3156,
+        "min": 50600.9454
+       },
+       "em": {
+        "n": 25,
+        "mean": 59327.6571,
+        "std": 13777.9729,
+        "min": 52121.3896
+       },
+       "gate_only": {
+        "n": 177,
+        "mean": 52945.4514,
+        "std": 5721.2863,
+        "min": 50286.4728
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 1484.6593,
+       "p_value": 0.105686,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 23,
+        "mean": 54722.5486,
+        "std": 3387.2029,
+        "min": 51733.6953
+       },
+       "tree_hierarchical": {
+        "n": 141,
+        "mean": 53781.7069,
+        "std": 7724.4142,
+        "min": 50286.4728
+       },
+       "random": {
+        "n": 110,
+        "mean": 53701.2203,
+        "std": 8169.1478,
+        "min": 50600.9454
+       },
+       "uniform": {
+        "n": 26,
+        "mean": 55373.6023,
+        "std": 7625.4666,
+        "min": 51884.4858
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 80.4866,
+       "p_value": 0.937116,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 256,
+        "mean": 52782.9066,
+        "std": 5744.1865,
+        "min": 50286.4728
+       },
+       "none": {
+        "n": 17,
+        "mean": 63848.5659,
+        "std": 15932.9593,
+        "min": 51755.7322
+       },
+       "markov": {
+        "n": 27,
+        "mean": 58919.9058,
+        "std": 8950.4682,
+        "min": 52121.3896
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 6136.9992,
+       "p_value": 0.001901,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 23,
+        "mean": 69545.7428,
+        "std": 13574.1233,
+        "min": 52536.4317
+       },
+       "False": {
+        "n": 277,
+        "mean": 52668.3577,
+        "std": 5140.4971,
+        "min": 50286.4728
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 16877.3851,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 53227.4708,
+        "std": 6913.9159,
+        "min": 50286.4728
+       },
+       "True": {
+        "n": 20,
+        "mean": 64249.7681,
+        "std": 9885.0296,
+        "min": 56498.4203
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11022.2973,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 41,
+       "mean_rmse": 55720.4137
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 259,
+       "mean_rmse": 53683.9777
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0173
+       ],
+       "n": 75,
+       "mean_rmse": 53900.2291
+      },
+      "Q2": {
+       "range": [
+        0.0173,
+        0.0362
+       ],
+       "n": 75,
+       "mean_rmse": 52477.6863
+      },
+      "Q3": {
+       "range": [
+        0.0362,
+        0.0728
+       ],
+       "n": 75,
+       "mean_rmse": 52934.5061
+      },
+      "Q4": {
+       "range": [
+        0.0728,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 56536.7409
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 52606.412
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 82,
+       "mean_rmse": 52039.5121
+      },
+      "Q3": {
+       "range": [
+        12.0,
+        41.0
+       ],
+       "n": 79,
+       "mean_rmse": 55977.3914
+      },
+      "Q4": {
+       "range": [
+        41.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 55034.2302
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 203,
+       "mean_rmse": 52709.2397
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 97,
+       "mean_rmse": 56584.6549
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1607
+       ],
+       "n": 75,
+       "mean_rmse": 58100.8467
+      },
+      "Q2": {
+       "range": [
+        0.1607,
+        0.1996
+       ],
+       "n": 75,
+       "mean_rmse": 52819.2616
+      },
+      "Q3": {
+       "range": [
+        0.1996,
+        0.2488
+       ],
+       "n": 75,
+       "mean_rmse": 52767.6855
+      },
+      "Q4": {
+       "range": [
+        0.2488,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52161.3687
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        29.0
+       ],
+       "n": 66,
+       "mean_rmse": 53434.8033
+      },
+      "Q2": {
+       "range": [
+        29.0,
+        34.0
+       ],
+       "n": 79,
+       "mean_rmse": 51903.3966
+      },
+      "Q3": {
+       "range": [
+        34.0,
+        49.5
+       ],
+       "n": 80,
+       "mean_rmse": 53952.194
+      },
+      "Q4": {
+       "range": [
+        49.5,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 56605.9507
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 67,
+       "mean_rmse": 54917.4674
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 139,
+       "mean_rmse": 52868.4079
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 94,
+       "mean_rmse": 54899.023
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 71,
+       "mean_rmse": 52737.3513
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        19.0
+       ],
+       "n": 75,
+       "mean_rmse": 53553.1347
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        39.0
+       ],
+       "n": 76,
+       "mean_rmse": 53868.203
+      },
+      "Q4": {
+       "range": [
+        39.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 55562.3937
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 1489.2,
+    "holdout": {
+     "holdout_rmse": 48984.00134499726,
+     "retrain_s": 0.9045,
+     "predict_s": 0.012,
+     "cv_rmse_of_winner": 50286.472835561784
+    }
+   }
+  },
+  "houses@s44": {
+   "dataset": "houses",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 205256.982,
+    "std": 114405.72363980168
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50674.92215781791,
+    "rmse_p10": 50855.88106275756,
+    "rmse_median": 51222.7142666577,
+    "train_s_median": 0.4296430600807071,
+    "train_s_mean": 0.374224906142801,
+    "train_s_p90": 0.5724287275597453,
+    "best_params": {
+     "learning_rate": 0.05477397277828664,
+     "num_leaves": 122,
+     "max_depth": 12,
+     "min_data_in_leaf": 12,
+     "lambda_l1": 0.13887399753506954,
+     "lambda_l2": 0.00012684810086755052,
+     "feature_fraction": 0.727676773124258,
+     "bagging_fraction": 0.8709943863799496,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.6678,
+     "learning_rate": 0.2468,
+     "min_data_in_leaf": 0.0294,
+     "max_depth": 0.0258,
+     "feature_fraction": 0.0147,
+     "bagging_fraction": 0.0063,
+     "num_leaves": 0.006,
+     "bagging_freq": 0.003,
+     "lambda_l1": 0.0003,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 52023.0161,
+        "std": 2849.5999,
+        "min": 50674.9222
+       },
+       "True": {
+        "n": 20,
+        "mean": 65091.4977,
+        "std": 4234.1415,
+        "min": 58652.9668
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 13068.4816,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0547
+       ],
+       "n": 75,
+       "mean_rmse": 55034.4959
+      },
+      "Q2": {
+       "range": [
+        0.0547,
+        0.0629
+       ],
+       "n": 75,
+       "mean_rmse": 51555.5742
+      },
+      "Q3": {
+       "range": [
+        0.0629,
+        0.084
+       ],
+       "n": 75,
+       "mean_rmse": 52070.652
+      },
+      "Q4": {
+       "range": [
+        0.084,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52916.2707
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        59.75
+       ],
+       "n": 75,
+       "mean_rmse": 54040.3712
+      },
+      "Q2": {
+       "range": [
+        59.75,
+        110.0
+       ],
+       "n": 71,
+       "mean_rmse": 53077.1628
+      },
+      "Q3": {
+       "range": [
+        110.0,
+        116.25
+       ],
+       "n": 79,
+       "mean_rmse": 52163.274
+      },
+      "Q4": {
+       "range": [
+        116.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52344.9255
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 54,
+       "mean_rmse": 54770.7357
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 78,
+       "mean_rmse": 53077.9487
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 168,
+       "mean_rmse": 52205.802
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 68,
+       "mean_rmse": 51813.2123
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 64,
+       "mean_rmse": 51580.5544
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        24.0
+       ],
+       "n": 92,
+       "mean_rmse": 52392.5069
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 55575.1304
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 54635.059
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.1121
+       ],
+       "n": 75,
+       "mean_rmse": 52656.6604
+      },
+      "Q3": {
+       "range": [
+        0.1121,
+        0.6478
+       ],
+       "n": 75,
+       "mean_rmse": 51978.5144
+      },
+      "Q4": {
+       "range": [
+        0.6478,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52306.759
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 54169.3509
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.0008
+       ],
+       "n": 75,
+       "mean_rmse": 52512.7667
+      },
+      "Q3": {
+       "range": [
+        0.0008,
+        0.0033
+       ],
+       "n": 75,
+       "mean_rmse": 51859.7302
+      },
+      "Q4": {
+       "range": [
+        0.0033,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53035.145
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6858
+       ],
+       "n": 75,
+       "mean_rmse": 54831.5402
+      },
+      "Q2": {
+       "range": [
+        0.6858,
+        0.7333
+       ],
+       "n": 75,
+       "mean_rmse": 52020.4412
+      },
+      "Q3": {
+       "range": [
+        0.7333,
+        0.7547
+       ],
+       "n": 75,
+       "mean_rmse": 51598.4895
+      },
+      "Q4": {
+       "range": [
+        0.7547,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53126.5219
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8281
+       ],
+       "n": 75,
+       "mean_rmse": 53409.2827
+      },
+      "Q2": {
+       "range": [
+        0.8281,
+        0.8641
+       ],
+       "n": 75,
+       "mean_rmse": 52100.9552
+      },
+      "Q3": {
+       "range": [
+        0.8641,
+        0.9357
+       ],
+       "n": 75,
+       "mean_rmse": 53134.6432
+      },
+      "Q4": {
+       "range": [
+        0.9357,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52932.1117
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 570.9,
+    "holdout": {
+     "holdout_rmse": 48487.23831014311,
+     "retrain_s": 0.7142,
+     "predict_s": 0.0043,
+     "cv_rmse_of_winner": 50674.92215781791
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50511.359521001774,
+    "rmse_p10": 50680.98091739964,
+    "rmse_median": 51281.77178154932,
+    "train_s_median": 0.9956958951428533,
+    "train_s_mean": 1.8017229115019244,
+    "train_s_p90": 3.1771853929013014,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.12563855760143622,
+     "num_leaves": 30,
+     "max_depth": 11,
+     "min_data_in_leaf": 13,
+     "lambda_l1": 0.5992660514372548,
+     "lambda_l2": 7.402353471605689e-05,
+     "feature_fraction": 0.788747293130155,
+     "bagging_fraction": 0.9457520655667636,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 12,
+     "mixture_balance_factor": 7,
+     "mixture_smoothing_lambda": 0.5465550646832507,
+     "mixture_diversity_lambda": 0.2143537075322059,
+     "mixture_hard_m_step": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.5478,
+     "extra_trees": 0.2115,
+     "mixture_hard_m_step": 0.0847,
+     "feature_fraction": 0.0446,
+     "bagging_freq": 0.0178,
+     "mixture_e_step_mode": 0.0168,
+     "mixture_diversity_lambda": 0.0162,
+     "max_depth": 0.0159,
+     "mixture_warmup_iters": 0.0102,
+     "min_data_in_leaf": 0.0066,
+     "mixture_init": 0.0057,
+     "bagging_fraction": 0.0051,
+     "mixture_balance_factor": 0.0044,
+     "num_leaves": 0.0037,
+     "mixture_gate_type": 0.0036,
+     "mixture_routing_mode": 0.0016,
+     "mixture_r_smoothing": 0.0012,
+     "mixture_num_experts": 0.0012,
+     "lambda_l1": 0.0006,
+     "mixture_refit_leaves": 0.0005,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 216,
+        "mean": 53239.474,
+        "std": 6174.8385,
+        "min": 50614.2885
+       },
+       "none": {
+        "n": 65,
+        "mean": 55820.7813,
+        "std": 9502.5677,
+        "min": 50511.3595
+       },
+       "leaf_reuse": {
+        "n": 19,
+        "mean": 64112.603,
+        "std": 13611.0465,
+        "min": 52329.1432
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 2581.3073,
+       "p_value": 0.043788,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 262,
+        "mean": 53563.8494,
+        "std": 6215.6286,
+        "min": 50511.3595
+       },
+       "expert_choice": {
+        "n": 38,
+        "mean": 60854.9495,
+        "std": 14465.0411,
+        "min": 50925.9556
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 7291.1001,
+       "p_value": 0.004367,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 215,
+        "mean": 53473.444,
+        "std": 7229.1807,
+        "min": 50614.2885
+       },
+       "em": {
+        "n": 65,
+        "mean": 54803.0058,
+        "std": 6661.4683,
+        "min": 50511.3595
+       },
+       "loss_only": {
+        "n": 20,
+        "mean": 64361.5392,
+        "std": 13302.9058,
+        "min": 50763.508
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 1329.5618,
+       "p_value": 0.17244,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 15,
+        "mean": 57115.9751,
+        "std": 7937.7804,
+        "min": 51003.8473
+       },
+       "tree_hierarchical": {
+        "n": 45,
+        "mean": 58454.318,
+        "std": 12184.9311,
+        "min": 51217.1212
+       },
+       "random": {
+        "n": 216,
+        "mean": 53032.8246,
+        "std": 6577.1688,
+        "min": 50511.3595
+       },
+       "gmm": {
+        "n": 24,
+        "mean": 58497.6066,
+        "std": 7107.0044,
+        "min": 52184.764
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 4083.1505,
+       "p_value": 0.078875,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 152,
+        "mean": 53234.0732,
+        "std": 6288.3526,
+        "min": 50614.2885
+       },
+       "ema": {
+        "n": 79,
+        "mean": 55951.0345,
+        "std": 10902.3798,
+        "min": 50511.3595
+       },
+       "markov": {
+        "n": 69,
+        "mean": 55572.5474,
+        "std": 7563.6556,
+        "min": 51193.0772
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 2338.4742,
+       "p_value": 0.027986,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 23,
+        "mean": 66030.8717,
+        "std": 12989.2217,
+        "min": 54112.3439
+       },
+       "False": {
+        "n": 277,
+        "mean": 53528.9046,
+        "std": 6754.4656,
+        "min": 50511.3595
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12501.9671,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 65069.5533,
+        "std": 6804.2062,
+        "min": 58478.2963
+       },
+       "False": {
+        "n": 280,
+        "mean": 53731.5198,
+        "std": 7679.2356,
+        "min": 50511.3595
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11338.0335,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 10,
+       "mean_rmse": 61405.1427
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 290,
+       "mean_rmse": 54248.8455
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1636
+       ],
+       "n": 75,
+       "mean_rmse": 55427.6934
+      },
+      "Q2": {
+       "range": [
+        0.1636,
+        0.21
+       ],
+       "n": 75,
+       "mean_rmse": 52319.9615
+      },
+      "Q3": {
+       "range": [
+        0.21,
+        0.3595
+       ],
+       "n": 75,
+       "mean_rmse": 53967.8612
+      },
+      "Q4": {
+       "range": [
+        0.3595,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 56234.0387
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 73,
+       "mean_rmse": 53779.3357
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        23.0
+       ],
+       "n": 70,
+       "mean_rmse": 54850.5701
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        30.0
+       ],
+       "n": 76,
+       "mean_rmse": 54004.864
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 55264.3893
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 33,
+       "mean_rmse": 55924.399
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 67,
+       "mean_rmse": 54692.5417
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 61,
+       "mean_rmse": 53927.6106
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 139,
+       "mean_rmse": 54292.9993
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0859
+       ],
+       "n": 75,
+       "mean_rmse": 57907.5149
+      },
+      "Q2": {
+       "range": [
+        0.0859,
+        0.1039
+       ],
+       "n": 75,
+       "mean_rmse": 52202.0028
+      },
+      "Q3": {
+       "range": [
+        0.1039,
+        0.1312
+       ],
+       "n": 75,
+       "mean_rmse": 52870.7757
+      },
+      "Q4": {
+       "range": [
+        0.1312,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54969.2615
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        40.75
+       ],
+       "n": 75,
+       "mean_rmse": 55757.3978
+      },
+      "Q2": {
+       "range": [
+        40.75,
+        59.5
+       ],
+       "n": 75,
+       "mean_rmse": 53911.4339
+      },
+      "Q3": {
+       "range": [
+        59.5,
+        72.25
+       ],
+       "n": 75,
+       "mean_rmse": 53394.344
+      },
+      "Q4": {
+       "range": [
+        72.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54886.3792
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 65,
+       "mean_rmse": 61058.6041
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 28,
+       "mean_rmse": 53829.9318
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 207,
+       "mean_rmse": 52512.895
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 54,
+       "mean_rmse": 53959.0225
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.5
+       ],
+       "n": 96,
+       "mean_rmse": 51878.8925
+      },
+      "Q3": {
+       "range": [
+        16.5,
+        30.0
+       ],
+       "n": 73,
+       "mean_rmse": 53234.6944
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 59297.7016
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2729.6,
+    "holdout": {
+     "holdout_rmse": 48717.55621562207,
+     "retrain_s": 0.5139,
+     "predict_s": 0.0074,
+     "cv_rmse_of_winner": 50511.359521001774
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_sp500_basic_report.md
+++ b/bench_results/meth2_v080/ds_sp500_basic_report.md
@@ -1,0 +1,503 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['sp500_basic'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `d25c06cf3b86`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| sp500_basic | naive-lightgbm | **0.01104** ± 0.00001 | 0.00969 | 0.0% | 0.04 |
+| sp500_basic | moe | **0.01104** ± 0.00001 | 0.00969 | 0.0% | 0.15 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| sp500_basic@s42 | naive-lightgbm | 0.0097 | 0.0097 | 0.022 | 38 |
+| sp500_basic@s42 | moe | 0.0097 | 0.0097 | 0.060 | 240 |
+| sp500_basic@s43 | naive-lightgbm | 0.0097 | 0.0097 | 0.021 | 38 |
+| sp500_basic@s43 | moe | 0.0097 | 0.0097 | 0.108 | 299 |
+| sp500_basic@s44 | naive-lightgbm | 0.0097 | 0.0097 | 0.025 | 43 |
+| sp500_basic@s44 | moe | 0.0097 | 0.0097 | 0.148 | 296 |
+
+
+
+---
+
+## sp500_basic@s42  (search X=[3010, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01103** (winner retrained in 0.03s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.022s/fold, mean 0.022s, p90 0.028s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.535 |
+| `learning_rate` | 0.170 |
+| `feature_fraction` | 0.112 |
+| `lambda_l2` | 0.066 |
+| `bagging_fraction` | 0.038 |
+| `extra_trees` | 0.035 |
+| `num_leaves` | 0.022 |
+| `bagging_freq` | 0.017 |
+| `max_depth` | 0.005 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 0.0097 | 0.0000 | 0.0097 |
+| False | 20 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0464] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 19.0] |
+| `max_depth` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 59.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0004] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.6917] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.6112] |
+
+#### E. Slice plot
+
+![sp500_basic@s42/naive-lightgbm](slice_sp500_basic@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01106** (winner retrained in 0.08s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.060s/fold, mean 0.152s, p90 0.217s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.374 |
+| `mixture_init` | 0.160 |
+| `learning_rate` | 0.128 |
+| `mixture_warmup_iters` | 0.089 |
+| `feature_fraction` | 0.088 |
+| `bagging_fraction` | 0.043 |
+| `mixture_diversity_lambda` | 0.029 |
+| `mixture_e_step_mode` | 0.017 |
+| `num_leaves` | 0.016 |
+| `mixture_routing_mode` | 0.013 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 0.0097 (n=142) | expert_choice | Δ +0.0000 | p=2.16e-03 |
+| `mixture_init` | **random** | 0.0097 (n=255) | gmm | Δ +0.0000 | p=1.90e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 33 | 0.0097 | 0.0000 | 0.0097 |
+| none | 215 | 0.0097 | 0.0000 | 0.0097 |
+| gbdt | 52 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 142 | 0.0097 | 0.0000 | 0.0097 |
+| expert_choice | 158 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 138 | 0.0097 | 0.0000 | 0.0097 |
+| gate_only | 21 | 0.0097 | 0.0000 | 0.0097 |
+| em | 141 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 255 | 0.0097 | 0.0000 | 0.0097 |
+| gmm | 15 | 0.0097 | 0.0000 | 0.0097 |
+| uniform | 14 | 0.0097 | 0.0000 | 0.0097 |
+| tree_hierarchical | 16 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 48 | 0.0097 | 0.0000 | 0.0097 |
+| markov | 28 | 0.0097 | 0.0000 | 0.0097 |
+| none | 224 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 276 | 0.0097 | 0.0000 | 0.0097 |
+| False | 24 | 0.0097 | 0.0000 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 278 | 0.0097 | 0.0000 | 0.0097 |
+| False | 22 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0097 | — | — | 0.0097 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.2111] |
+| `mixture_warmup_iters` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 31.0] |
+| `mixture_balance_factor` | 0.0097 | — | — | 0.0097 | **Q1** [None, 5.0] |
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.089] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 16.0] |
+| `max_depth` | 0.0097 | 0.0097 | — | 0.0097 | **Q1** [None, 11.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 68.0] |
+
+#### E. Slice plot
+
+![sp500_basic@s42/moe](slice_sp500_basic@s42_moe.png)
+
+
+---
+
+## sp500_basic@s43  (search X=[3010, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01105** (winner retrained in 0.04s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.021s/fold, mean 0.022s, p90 0.029s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.497 |
+| `min_data_in_leaf` | 0.244 |
+| `learning_rate` | 0.080 |
+| `bagging_fraction` | 0.063 |
+| `num_leaves` | 0.033 |
+| `max_depth` | 0.025 |
+| `feature_fraction` | 0.025 |
+| `bagging_freq` | 0.023 |
+| `lambda_l2` | 0.010 |
+| `lambda_l1` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1027] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 87.5] |
+| `max_depth` | 0.0097 | 0.0097 | — | 0.0097 | **Q1** [None, 10.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 66.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.5668] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.5882] |
+
+#### E. Slice plot
+
+![sp500_basic@s43/naive-lightgbm](slice_sp500_basic@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01104** (winner retrained in 0.16s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.108s/fold, mean 0.191s, p90 0.335s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `num_leaves` | 0.526 |
+| `lambda_l2` | 0.224 |
+| `mixture_init` | 0.039 |
+| `extra_trees` | 0.035 |
+| `bagging_fraction` | 0.033 |
+| `min_data_in_leaf` | 0.026 |
+| `mixture_diversity_lambda` | 0.024 |
+| `mixture_gate_type` | 0.017 |
+| `learning_rate` | 0.015 |
+| `feature_fraction` | 0.014 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 266 | 0.0097 | 0.0000 | 0.0097 |
+| none | 17 | 0.0097 | 0.0000 | 0.0097 |
+| leaf_reuse | 17 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 237 | 0.0097 | 0.0000 | 0.0097 |
+| token_choice | 63 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 197 | 0.0097 | 0.0000 | 0.0097 |
+| em | 86 | 0.0097 | 0.0000 | 0.0097 |
+| gate_only | 17 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 237 | 0.0097 | 0.0000 | 0.0097 |
+| tree_hierarchical | 33 | 0.0097 | 0.0001 | 0.0097 |
+| random | 15 | 0.0097 | 0.0000 | 0.0097 |
+| uniform | 15 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 106 | 0.0097 | 0.0000 | 0.0097 |
+| none | 38 | 0.0097 | 0.0000 | 0.0097 |
+| markov | 156 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 56 | 0.0097 | 0.0000 | 0.0097 |
+| False | 244 | 0.0097 | 0.0000 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 277 | 0.0097 | 0.0000 | 0.0097 |
+| False | 23 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 0.0097 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1447] |
+| `mixture_warmup_iters` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 12.0] |
+| `mixture_balance_factor` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 8.0] |
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1097] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 27.0] |
+| `max_depth` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 5.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 59.75] |
+
+#### E. Slice plot
+
+![sp500_basic@s43/moe](slice_sp500_basic@s43_moe.png)
+
+
+---
+
+## sp500_basic@s44  (search X=[3010, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01102** (winner retrained in 0.04s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.025s/fold, mean 0.025s, p90 0.029s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.407 |
+| `min_data_in_leaf` | 0.264 |
+| `feature_fraction` | 0.139 |
+| `max_depth` | 0.074 |
+| `bagging_fraction` | 0.040 |
+| `num_leaves` | 0.036 |
+| `extra_trees` | 0.025 |
+| `bagging_freq` | 0.009 |
+| `lambda_l2` | 0.005 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 36 | 0.0097 | 0.0000 | 0.0097 |
+| True | 264 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0144] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 60.0] |
+| `max_depth` | — | — | 0.0097 | 0.0097 | **Q3** [3.0, 4.25] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 89.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.518] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.8957] |
+
+#### E. Slice plot
+
+![sp500_basic@s44/naive-lightgbm](slice_sp500_basic@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01102** (winner retrained in 0.22s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.148s/fold, mean 0.189s, p90 0.290s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.203 |
+| `mixture_diversity_lambda` | 0.163 |
+| `feature_fraction` | 0.137 |
+| `extra_trees` | 0.137 |
+| `num_leaves` | 0.105 |
+| `min_data_in_leaf` | 0.094 |
+| `mixture_warmup_iters` | 0.030 |
+| `learning_rate` | 0.027 |
+| `bagging_fraction` | 0.021 |
+| `mixture_balance_factor` | 0.020 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 215 | 0.0097 | 0.0000 | 0.0097 |
+| none | 26 | 0.0097 | 0.0000 | 0.0097 |
+| leaf_reuse | 59 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 182 | 0.0097 | 0.0000 | 0.0097 |
+| expert_choice | 118 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 59 | 0.0097 | 0.0000 | 0.0097 |
+| em | 167 | 0.0097 | 0.0000 | 0.0097 |
+| loss_only | 74 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 16 | 0.0097 | 0.0000 | 0.0097 |
+| random | 56 | 0.0097 | 0.0000 | 0.0097 |
+| gmm | 214 | 0.0097 | 0.0000 | 0.0097 |
+| tree_hierarchical | 14 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 51 | 0.0097 | 0.0000 | 0.0097 |
+| ema | 211 | 0.0097 | 0.0000 | 0.0097 |
+| markov | 38 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 30 | 0.0097 | 0.0000 | 0.0097 |
+| False | 270 | 0.0097 | 0.0000 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0097 | — | — | 0.0097 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1376] |
+| `mixture_warmup_iters` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 41.0] |
+| `mixture_balance_factor` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 5.0] |
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.129] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 87.0] |
+| `max_depth` | 0.0097 | — | 0.0097 | 0.0097 | **Q1** [None, 8.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 57.0] |
+
+#### E. Slice plot
+
+![sp500_basic@s44/moe](slice_sp500_basic@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| sp500_basic@s42 | `mixture_routing_mode` | **token_choice** | +0.0000 | 2.16e-03 |
+| sp500_basic@s42 | `mixture_init` | **random** | +0.0000 | 1.90e-05 |

--- a/bench_results/meth2_v080/ds_sp500_basic_summary.json
+++ b/bench_results/meth2_v080/ds_sp500_basic_summary.json
@@ -1,0 +1,2731 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "sp500_basic"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "d25c06cf3b8656e8f80fec7ac7bf0ccf6a1f07a1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "sp500_basic": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011032468776415732,
+      "cv_best": 0.009686834601527007,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0305
+     },
+     "43": {
+      "holdout_rmse": 0.01105462873690217,
+      "cv_best": 0.009684240261748616,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0382
+     },
+     "44": {
+      "holdout_rmse": 0.011024791982365001,
+      "cv_best": 0.009706063069291908,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0397
+     }
+    },
+    "holdout_mean": 0.011037,
+    "holdout_std": 1.3e-05,
+    "cv_best_mean": 0.009692
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011057739862484268,
+      "cv_best": 0.009693351704375654,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0845
+     },
+     "43": {
+      "holdout_rmse": 0.01104127493152533,
+      "cv_best": 0.009695179132064182,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1573
+     },
+     "44": {
+      "holdout_rmse": 0.011024106082302535,
+      "cv_best": 0.00969139752743958,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2157
+     }
+    },
+    "holdout_mean": 0.011041,
+    "holdout_std": 1.4e-05,
+    "cv_best_mean": 0.009693
+   }
+  }
+ },
+ "runs": {
+  "sp500_basic@s42": {
+   "dataset": "sp500_basic",
+   "seed": 42,
+   "X_search_shape": [
+    3010,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 0.0004722868029789814,
+    "std": 0.010864405234015438
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009686834601527007,
+    "rmse_p10": 0.009705640923933742,
+    "rmse_median": 0.009714640148453652,
+    "train_s_median": 0.02182126548141241,
+    "train_s_mean": 0.022219921418776115,
+    "train_s_p90": 0.027890698574483397,
+    "best_params": {
+     "learning_rate": 0.11807474627436634,
+     "num_leaves": 20,
+     "max_depth": 4,
+     "min_data_in_leaf": 49,
+     "lambda_l1": 2.6767473618736457e-05,
+     "lambda_l2": 6.200110175719046e-08,
+     "feature_fraction": 0.8499685159410041,
+     "bagging_fraction": 0.7129282300264405,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5351,
+     "learning_rate": 0.1699,
+     "feature_fraction": 0.1119,
+     "lambda_l2": 0.0661,
+     "bagging_fraction": 0.0385,
+     "extra_trees": 0.0345,
+     "num_leaves": 0.0216,
+     "bagging_freq": 0.0167,
+     "max_depth": 0.0055,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 280,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 20,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0464
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0464,
+        0.1187
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.1187,
+        0.1711
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1711,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        30.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        54.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        54.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 31,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 97,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 105,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        59.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        59.0,
+        71.5
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        71.5,
+        78.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        78.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.0021
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0021,
+        0.0131
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0131,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0012
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0012,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6917
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.6917,
+        0.8451
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.8451,
+        0.8824
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.8824,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6112
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.6112,
+        0.7185
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.7185,
+        0.7824
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.7824,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 38.2,
+    "holdout": {
+     "holdout_rmse": 0.011032468776415732,
+     "retrain_s": 0.0305,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.009686834601527007
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009693351704375654,
+    "rmse_p10": 0.009701219092742899,
+    "rmse_median": 0.009717486560076387,
+    "train_s_median": 0.05980870164930821,
+    "train_s_mean": 0.15217947200561566,
+    "train_s_p90": 0.217148096524179,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.2803370780092484,
+     "num_leaves": 75,
+     "max_depth": 12,
+     "min_data_in_leaf": 72,
+     "lambda_l1": 4.620338680655884e-08,
+     "lambda_l2": 2.5994501972574768e-06,
+     "feature_fraction": 0.6080056857256511,
+     "bagging_fraction": 0.8809998718450865,
+     "bagging_freq": 7,
+     "extra_trees": true,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 40,
+     "mixture_balance_factor": 5,
+     "mixture_diversity_lambda": 0.24095547882292417,
+     "mixture_hard_m_step": true,
+     "mixture_expert_capacity_factor": 1.0739258816135988,
+     "mixture_expert_choice_boost": 24.695570514840703,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.039440155248595066,
+     "mixture_elbo_drop_threshold": 0.0026104720818624196,
+     "mixture_elbo_plateau_threshold": 0.00028313177169961865,
+     "mixture_elbo_window": 5,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 5,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.3742,
+     "mixture_init": 0.1595,
+     "learning_rate": 0.1277,
+     "mixture_warmup_iters": 0.0894,
+     "feature_fraction": 0.0879,
+     "bagging_fraction": 0.0431,
+     "mixture_diversity_lambda": 0.0293,
+     "mixture_e_step_mode": 0.0172,
+     "num_leaves": 0.0161,
+     "mixture_routing_mode": 0.0125,
+     "bagging_freq": 0.0112,
+     "mixture_balance_factor": 0.0111,
+     "max_depth": 0.0046,
+     "mixture_num_experts": 0.004,
+     "extra_trees": 0.0032,
+     "mixture_gate_type": 0.0024,
+     "mixture_r_smoothing": 0.0021,
+     "lambda_l2": 0.002,
+     "mixture_refit_leaves": 0.0015,
+     "mixture_hard_m_step": 0.0009,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 33,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 215,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gbdt": {
+        "n": 52,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.012826,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 142,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "expert_choice": {
+        "n": 158,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.002158,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 138,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gate_only": {
+        "n": 21,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 141,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0,
+       "p_value": 0.093726,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 255,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gmm": {
+        "n": 15,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "gmm",
+       "delta_mean": 0.0,
+       "p_value": 1.9e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 48,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "markov": {
+        "n": 28,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 224,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0,
+       "p_value": 0.770247,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 276,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 24,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 278,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 22,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 10,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 290,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2111
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.2111,
+        0.2552
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.2552,
+        0.3481
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.3481,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        31.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        31.0,
+        40.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        40.0,
+        42.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        42.0,
+        null
+       ],
+       "n": 92,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 57,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 243,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.089
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.089,
+        0.2257
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.2257,
+        0.2591
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.2591,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        27.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        27.0,
+        80.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        80.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 43,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 43,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 214,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        68.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        68.0,
+        71.0
+       ],
+       "n": 55,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        71.0,
+        75.0
+       ],
+       "n": 94,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        75.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 239.7,
+    "holdout": {
+     "holdout_rmse": 0.011057739862484268,
+     "retrain_s": 0.0845,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.009693351704375654
+    }
+   }
+  },
+  "sp500_basic@s43": {
+   "dataset": "sp500_basic",
+   "seed": 43,
+   "X_search_shape": [
+    3010,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 0.0004722868029789814,
+    "std": 0.010864405234015438
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009684240261748616,
+    "rmse_p10": 0.009697805716752004,
+    "rmse_median": 0.009709819936674111,
+    "train_s_median": 0.020734975859522817,
+    "train_s_mean": 0.02205454522619645,
+    "train_s_p90": 0.028938941210508346,
+    "best_params": {
+     "learning_rate": 0.15189857204203183,
+     "num_leaves": 113,
+     "max_depth": 12,
+     "min_data_in_leaf": 79,
+     "lambda_l1": 6.478986147979264e-06,
+     "lambda_l2": 5.562212448046289e-08,
+     "feature_fraction": 0.5877067507153831,
+     "bagging_fraction": 0.615292804232275,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4967,
+     "min_data_in_leaf": 0.2437,
+     "learning_rate": 0.0804,
+     "bagging_fraction": 0.063,
+     "num_leaves": 0.0325,
+     "max_depth": 0.025,
+     "feature_fraction": 0.0249,
+     "bagging_freq": 0.0228,
+     "lambda_l2": 0.0097,
+     "lambda_l1": 0.0016
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1027
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1027,
+        0.1296
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.1296,
+        0.1564
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1564,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        87.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        87.5,
+        112.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        112.0,
+        119.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        119.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 59,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 177,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        66.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        66.0,
+        76.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        76.0,
+        82.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        82.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5668
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.5668,
+        0.5899
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5899,
+        0.6138
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6138,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5882
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.5882,
+        0.6082
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.6082,
+        0.6324
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6324,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 38.2,
+    "holdout": {
+     "holdout_rmse": 0.01105462873690217,
+     "retrain_s": 0.0382,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.009684240261748616
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009695179132064182,
+    "rmse_p10": 0.009707183039360644,
+    "rmse_median": 0.009722754598167672,
+    "train_s_median": 0.10797565337270498,
+    "train_s_mean": 0.1910356999163826,
+    "train_s_p90": 0.33509259101003414,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.25657415639060904,
+     "num_leaves": 66,
+     "max_depth": 7,
+     "min_data_in_leaf": 87,
+     "lambda_l1": 0.011187351569356132,
+     "lambda_l2": 9.840464699470141,
+     "feature_fraction": 0.5483791382693225,
+     "bagging_fraction": 0.8637668517005359,
+     "bagging_freq": 6,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 13,
+     "mixture_balance_factor": 10,
+     "mixture_smoothing_lambda": 0.016465091788278454,
+     "mixture_diversity_lambda": 0.23352415803619914,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 6,
+     "mixture_gate_learning_rate": 0.4419964200116955,
+     "mixture_gate_lambda_l2": 3.354883484663354,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 1.4695293252640258,
+     "mixture_expert_choice_boost": 18.30304762718805,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "num_leaves": 0.5256,
+     "lambda_l2": 0.2244,
+     "mixture_init": 0.0392,
+     "extra_trees": 0.0349,
+     "bagging_fraction": 0.0334,
+     "min_data_in_leaf": 0.0258,
+     "mixture_diversity_lambda": 0.0241,
+     "mixture_gate_type": 0.0172,
+     "learning_rate": 0.0155,
+     "feature_fraction": 0.014,
+     "mixture_warmup_iters": 0.0107,
+     "mixture_e_step_mode": 0.0103,
+     "bagging_freq": 0.0103,
+     "mixture_hard_m_step": 0.004,
+     "max_depth": 0.0032,
+     "mixture_balance_factor": 0.0024,
+     "mixture_refit_leaves": 0.0018,
+     "mixture_r_smoothing": 0.0018,
+     "mixture_routing_mode": 0.001,
+     "mixture_num_experts": 0.0005,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 266,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 17,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "leaf_reuse": {
+        "n": 17,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.071648,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 237,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "token_choice": {
+        "n": 63,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.13804,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 197,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 86,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gate_only": {
+        "n": 17,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 0.647229,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 237,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "tree_hierarchical": {
+        "n": 33,
+        "mean": 0.0097,
+        "std": 0.0001,
+        "min": 0.0097
+       },
+       "random": {
+        "n": 15,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "uniform": {
+        "n": 15,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.030084,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 106,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 38,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "markov": {
+        "n": 156,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.396417,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 56,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 244,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 23,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 277,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1447
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1447,
+        0.2014
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.2014,
+        0.2289
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.2289,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        30.0
+       ],
+       "n": 84,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        44.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 42,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 47,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 145,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1097
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1097,
+        0.1913
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.1913,
+        0.2399
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.2399,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        27.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        27.0,
+        50.5
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        50.5,
+        66.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        66.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 84,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        59.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        59.75,
+        82.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        82.0,
+        88.25
+       ],
+       "n": 78,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        88.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 299.0,
+    "holdout": {
+     "holdout_rmse": 0.01104127493152533,
+     "retrain_s": 0.1573,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.009695179132064182
+    }
+   }
+  },
+  "sp500_basic@s44": {
+   "dataset": "sp500_basic",
+   "seed": 44,
+   "X_search_shape": [
+    3010,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 0.0004722868029789814,
+    "std": 0.010864405234015438
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009706063069291908,
+    "rmse_p10": 0.009708561266976171,
+    "rmse_median": 0.009712304447526974,
+    "train_s_median": 0.02496042922139168,
+    "train_s_mean": 0.025068478617817164,
+    "train_s_p90": 0.02949957586824894,
+    "best_params": {
+     "learning_rate": 0.016232402169128753,
+     "num_leaves": 56,
+     "max_depth": 3,
+     "min_data_in_leaf": 94,
+     "lambda_l1": 3.176343674604407e-06,
+     "lambda_l2": 2.382224760072087e-05,
+     "feature_fraction": 0.535190958185494,
+     "bagging_fraction": 0.9027915868211681,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.4071,
+     "min_data_in_leaf": 0.2644,
+     "feature_fraction": 0.1389,
+     "max_depth": 0.0745,
+     "bagging_fraction": 0.04,
+     "num_leaves": 0.0361,
+     "extra_trees": 0.025,
+     "bagging_freq": 0.0085,
+     "lambda_l2": 0.005,
+     "lambda_l1": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 36,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 264,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0144
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0144,
+        0.0177
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0177,
+        0.0241
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0241,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        60.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        60.0,
+        105.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        105.0,
+        121.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.25
+       ],
+       "n": 225,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        4.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        89.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        89.0,
+        94.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        94.5,
+        97.25
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        97.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.518
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.518,
+        0.5333
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5333,
+        0.5616
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.5616,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8957
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.8957,
+        0.9272
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.9272,
+        0.9514
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.9514,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 43.0,
+    "holdout": {
+     "holdout_rmse": 0.011024791982365001,
+     "retrain_s": 0.0397,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 0.009706063069291908
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00969139752743958,
+    "rmse_p10": 0.009710308356079745,
+    "rmse_median": 0.009724363244381933,
+    "train_s_median": 0.1478035818785429,
+    "train_s_mean": 0.1894484810506304,
+    "train_s_p90": 0.29013219077140096,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.23069618038033637,
+     "num_leaves": 101,
+     "max_depth": 8,
+     "min_data_in_leaf": 59,
+     "lambda_l1": 5.838160639105535e-07,
+     "lambda_l2": 0.00024409790434979926,
+     "feature_fraction": 0.780620479850114,
+     "bagging_fraction": 0.5699203514493225,
+     "bagging_freq": 5,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 50,
+     "mixture_balance_factor": 10,
+     "mixture_diversity_lambda": 0.15147042854177137,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 49,
+     "mixture_gate_learning_rate": 0.17359619310580157,
+     "mixture_gate_lambda_l2": 0.00427376784483113,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_expert_capacity_factor": 0.9665808709571103,
+     "mixture_expert_choice_boost": 21.281176290724524,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.2032,
+     "mixture_diversity_lambda": 0.1629,
+     "feature_fraction": 0.1374,
+     "extra_trees": 0.1372,
+     "num_leaves": 0.1051,
+     "min_data_in_leaf": 0.0939,
+     "mixture_warmup_iters": 0.0304,
+     "learning_rate": 0.0268,
+     "bagging_fraction": 0.0211,
+     "mixture_balance_factor": 0.02,
+     "max_depth": 0.0164,
+     "mixture_r_smoothing": 0.0126,
+     "bagging_freq": 0.0102,
+     "mixture_hard_m_step": 0.008,
+     "mixture_e_step_mode": 0.0057,
+     "mixture_gate_type": 0.005,
+     "mixture_routing_mode": 0.0026,
+     "mixture_num_experts": 0.0009,
+     "mixture_refit_leaves": 0.0005,
+     "lambda_l2": 0.0001,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 215,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 26,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "leaf_reuse": {
+        "n": 59,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.198744,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 182,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "expert_choice": {
+        "n": 118,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.013903,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 59,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 167,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "loss_only": {
+        "n": 74,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 0.019432,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "random": {
+        "n": 56,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gmm": {
+        "n": 214,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0,
+       "p_value": 0.540897,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 51,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "ema": {
+        "n": 211,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "markov": {
+        "n": 38,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0,
+       "p_value": 0.40247,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 30,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 270,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 17,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 283,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1376
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1376,
+        0.165
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.165,
+        0.1979
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1979,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        41.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        41.0,
+        46.0
+       ],
+       "n": 57,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        46.0,
+        48.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 110,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 21,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 135,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.129
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.129,
+        0.2005
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.2005,
+        0.2491
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.2491,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        87.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        87.0,
+        100.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        100.0,
+        107.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        107.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 160,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        57.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        57.0,
+        62.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        62.0,
+        79.0
+       ],
+       "n": 86,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        79.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 295.8,
+    "holdout": {
+     "holdout_rmse": 0.011024106082302535,
+     "retrain_s": 0.2157,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.00969139752743958
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_sp500_report.md
+++ b/bench_results/meth2_v080/ds_sp500_report.md
@@ -1,0 +1,518 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['sp500'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `d25c06cf3b86`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| sp500 | naive-lightgbm | **0.01105** ± 0.00001 | 0.00975 | 0.0% | 0.04 |
+| sp500 | moe | **0.01104** ± 0.00002 | 0.00976 | 0.0% | 0.31 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| sp500@s42 | naive-lightgbm | 0.0098 | 0.0098 | 0.022 | 39 |
+| sp500@s42 | moe | 0.0098 | 0.0098 | 0.250 | 432 |
+| sp500@s43 | naive-lightgbm | 0.0097 | 0.0098 | 0.022 | 44 |
+| sp500@s43 | moe | 0.0097 | 0.0098 | 0.261 | 638 |
+| sp500@s44 | naive-lightgbm | 0.0097 | 0.0098 | 0.026 | 45 |
+| sp500@s44 | moe | 0.0098 | 0.0098 | 0.091 | 209 |
+
+
+
+---
+
+## sp500@s42  (search X=[2969, 28], holdout n=742)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01103** (winner retrained in 0.06s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.022s/fold, mean 0.023s, p90 0.029s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.475 |
+| `num_leaves` | 0.212 |
+| `min_data_in_leaf` | 0.164 |
+| `max_depth` | 0.075 |
+| `bagging_fraction` | 0.033 |
+| `extra_trees` | 0.021 |
+| `feature_fraction` | 0.016 |
+| `bagging_freq` | 0.004 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 0.0098 | 0.0000 | 0.0098 |
+| False | 20 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0459] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 17.0] |
+| `max_depth` | 0.0098 | 0.0098 | — | 0.0098 | **Q1** [None, 6.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 82.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.6921] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.6104] |
+
+#### E. Slice plot
+
+![sp500@s42/naive-lightgbm](slice_sp500@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01102** (winner retrained in 0.65s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.250s/fold, mean 0.280s, p90 0.327s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_diversity_lambda` | 0.562 |
+| `mixture_init` | 0.137 |
+| `learning_rate` | 0.053 |
+| `bagging_fraction` | 0.051 |
+| `min_data_in_leaf` | 0.045 |
+| `feature_fraction` | 0.027 |
+| `mixture_balance_factor` | 0.022 |
+| `mixture_gate_type` | 0.016 |
+| `num_leaves` | 0.013 |
+| `mixture_num_experts` | 0.013 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 0.0098 (n=210) | none | Δ +0.0000 | p=5.74e-03 |
+| `mixture_routing_mode` | **token_choice** | 0.0098 (n=102) | expert_choice | Δ +0.0000 | p=1.46e-04 |
+| `mixture_e_step_mode` | **loss_only** | 0.0098 (n=203) | gate_only | Δ +0.0000 | p=3.28e-03 |
+| `mixture_r_smoothing` | **ema** | 0.0098 (n=103) | markov | Δ +0.0000 | p=5.16e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 210 | 0.0098 | 0.0000 | 0.0098 |
+| none | 40 | 0.0098 | 0.0000 | 0.0098 |
+| gbdt | 50 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 102 | 0.0098 | 0.0000 | 0.0098 |
+| expert_choice | 198 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 203 | 0.0098 | 0.0000 | 0.0098 |
+| gate_only | 76 | 0.0098 | 0.0000 | 0.0098 |
+| em | 21 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 25 | 0.0098 | 0.0000 | 0.0098 |
+| gmm | 15 | 0.0098 | 0.0000 | 0.0098 |
+| tree_hierarchical | 20 | 0.0098 | 0.0000 | 0.0098 |
+| uniform | 240 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 103 | 0.0098 | 0.0000 | 0.0098 |
+| markov | 104 | 0.0098 | 0.0000 | 0.0098 |
+| none | 93 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 274 | 0.0098 | 0.0000 | 0.0098 |
+| False | 26 | 0.0098 | 0.0000 | 0.0098 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 260 | 0.0098 | 0.0000 | 0.0098 |
+| False | 40 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0098 | — | — | 0.0098 | **Q1** [None, 4.0] |
+| `mixture_diversity_lambda` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.1379] |
+| `mixture_warmup_iters` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 10.0] |
+| `mixture_balance_factor` | 0.0098 | 0.0098 | — | 0.0098 | **Q1** [None, 5.0] |
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0559] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 94.0] |
+| `max_depth` | — | — | 0.0098 | 0.0098 | **Q3** [3.0, 5.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 35.0] |
+
+#### E. Slice plot
+
+![sp500@s42/moe](slice_sp500@s42_moe.png)
+
+
+---
+
+## sp500@s43  (search X=[2969, 28], holdout n=742)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01105** (winner retrained in 0.02s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0098
+- train: median 0.022s/fold, mean 0.026s, p90 0.039s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `bagging_fraction` | 0.413 |
+| `learning_rate` | 0.246 |
+| `min_data_in_leaf` | 0.078 |
+| `bagging_freq` | 0.067 |
+| `feature_fraction` | 0.066 |
+| `max_depth` | 0.048 |
+| `num_leaves` | 0.031 |
+| `lambda_l1` | 0.024 |
+| `lambda_l2` | 0.015 |
+| `extra_trees` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 21 | 0.0098 | 0.0000 | 0.0098 |
+| False | 279 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0873] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 12.0] |
+| `max_depth` | — | — | 0.0098 | 0.0098 | **Q3** [3.0, 6.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 34.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0001] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.9045] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.8034] |
+
+#### E. Slice plot
+
+![sp500@s43/naive-lightgbm](slice_sp500@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01104** (winner retrained in 0.12s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0098
+- train: median 0.261s/fold, mean 0.418s, p90 1.194s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_warmup_iters` | 0.224 |
+| `lambda_l2` | 0.156 |
+| `max_depth` | 0.155 |
+| `learning_rate` | 0.113 |
+| `num_leaves` | 0.080 |
+| `mixture_num_experts` | 0.074 |
+| `mixture_diversity_lambda` | 0.070 |
+| `feature_fraction` | 0.029 |
+| `bagging_freq` | 0.025 |
+| `min_data_in_leaf` | 0.025 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 0.0098 (n=229) | none | Δ +0.0000 | p=8.00e-06 |
+| `mixture_e_step_mode` | **loss_only** | 0.0098 (n=229) | em | Δ +0.0000 | p=5.00e-06 |
+| `mixture_r_smoothing` | **ema** | 0.0098 (n=217) | none | Δ +0.0000 | p=3.00e-06 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 229 | 0.0098 | 0.0000 | 0.0097 |
+| none | 48 | 0.0098 | 0.0000 | 0.0098 |
+| leaf_reuse | 23 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 241 | 0.0098 | 0.0000 | 0.0097 |
+| token_choice | 59 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 229 | 0.0098 | 0.0000 | 0.0097 |
+| em | 48 | 0.0098 | 0.0000 | 0.0098 |
+| gate_only | 23 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 116 | 0.0098 | 0.0000 | 0.0098 |
+| tree_hierarchical | 31 | 0.0098 | 0.0000 | 0.0098 |
+| random | 11 | 0.0098 | 0.0000 | 0.0098 |
+| uniform | 142 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 217 | 0.0098 | 0.0000 | 0.0097 |
+| none | 44 | 0.0098 | 0.0000 | 0.0098 |
+| markov | 39 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 24 | 0.0098 | 0.0000 | 0.0098 |
+| False | 276 | 0.0098 | 0.0000 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 252 | 0.0098 | 0.0000 | 0.0097 |
+| True | 48 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 0.0098 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.331] |
+| `mixture_warmup_iters` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 16.0] |
+| `mixture_balance_factor` | — | 0.0098 | 0.0098 | 0.0098 | **Q2** [2.0, 3.0] |
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.042] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 22.0] |
+| `max_depth` | — | — | 0.0098 | 0.0098 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 9.0] |
+
+#### E. Slice plot
+
+![sp500@s43/moe](slice_sp500@s43_moe.png)
+
+
+---
+
+## sp500@s44  (search X=[2969, 28], holdout n=742)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01106** (winner retrained in 0.03s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0097
+- train: median 0.026s/fold, mean 0.027s, p90 0.035s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.768 |
+| `num_leaves` | 0.098 |
+| `min_data_in_leaf` | 0.058 |
+| `feature_fraction` | 0.028 |
+| `bagging_fraction` | 0.019 |
+| `extra_trees` | 0.010 |
+| `bagging_freq` | 0.009 |
+| `lambda_l2` | 0.007 |
+| `max_depth` | 0.003 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.0098 | 0.0000 | 0.0097 |
+| True | 20 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0152] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 39.0] |
+| `max_depth` | 0.0098 | — | — | 0.0098 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 8.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0001] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.65] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.5556] |
+
+#### E. Slice plot
+
+![sp500@s44/naive-lightgbm](slice_sp500@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01107** (winner retrained in 0.15s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.091s/fold, mean 0.133s, p90 0.244s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.473 |
+| `extra_trees` | 0.158 |
+| `mixture_balance_factor` | 0.086 |
+| `feature_fraction` | 0.059 |
+| `num_leaves` | 0.046 |
+| `mixture_diversity_lambda` | 0.040 |
+| `min_data_in_leaf` | 0.033 |
+| `learning_rate` | 0.025 |
+| `mixture_warmup_iters` | 0.018 |
+| `mixture_gate_type` | 0.014 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 243 | 0.0098 | 0.0001 | 0.0098 |
+| none | 27 | 0.0098 | 0.0000 | 0.0098 |
+| leaf_reuse | 30 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 280 | 0.0098 | 0.0001 | 0.0098 |
+| expert_choice | 20 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 67 | 0.0098 | 0.0000 | 0.0098 |
+| em | 188 | 0.0098 | 0.0001 | 0.0098 |
+| loss_only | 45 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 254 | 0.0098 | 0.0000 | 0.0098 |
+| random | 16 | 0.0098 | 0.0000 | 0.0098 |
+| gmm | 16 | 0.0098 | 0.0000 | 0.0098 |
+| tree_hierarchical | 14 | 0.0099 | 0.0003 | 0.0098 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 230 | 0.0098 | 0.0001 | 0.0098 |
+| ema | 29 | 0.0098 | 0.0000 | 0.0098 |
+| markov | 41 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0098 | 0.0001 | 0.0098 |
+| False | 21 | 0.0098 | 0.0000 | 0.0098 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0098 | 0.0000 | 0.0098 |
+| False | 21 | 0.0098 | 0.0003 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 0.0098 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.1487] |
+| `mixture_warmup_iters` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 10.0] |
+| `mixture_balance_factor` | 0.0098 | — | 0.0098 | 0.0098 | **Q1** [None, 3.0] |
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0839] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 97.75] |
+| `max_depth` | 0.0098 | 0.0098 | — | 0.0098 | **Q1** [None, 10.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 86.0] |
+
+#### E. Slice plot
+
+![sp500@s44/moe](slice_sp500@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| sp500@s42 | `mixture_gate_type` | **leaf_reuse** | +0.0000 | 5.74e-03 |
+| sp500@s42 | `mixture_routing_mode` | **token_choice** | +0.0000 | 1.46e-04 |
+| sp500@s42 | `mixture_e_step_mode` | **loss_only** | +0.0000 | 3.28e-03 |
+| sp500@s42 | `mixture_r_smoothing` | **ema** | +0.0000 | 5.16e-03 |
+| sp500@s43 | `mixture_gate_type` | **gbdt** | +0.0000 | 8.00e-06 |
+| sp500@s43 | `mixture_e_step_mode` | **loss_only** | +0.0000 | 5.00e-06 |
+| sp500@s43 | `mixture_r_smoothing` | **ema** | +0.0000 | 3.00e-06 |

--- a/bench_results/meth2_v080/ds_sp500_summary.json
+++ b/bench_results/meth2_v080/ds_sp500_summary.json
@@ -1,0 +1,2674 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "sp500"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "d25c06cf3b8656e8f80fec7ac7bf0ccf6a1f07a1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "sp500": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011028538111712062,
+      "cv_best": 0.00976344388074939,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0612
+     },
+     "43": {
+      "holdout_rmse": 0.011050137943706165,
+      "cv_best": 0.009745865977441242,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0217
+     },
+     "44": {
+      "holdout_rmse": 0.011058687134332574,
+      "cv_best": 0.009739215992744327,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0264
+     }
+    },
+    "holdout_mean": 0.011046,
+    "holdout_std": 1.3e-05,
+    "cv_best_mean": 0.00975
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011018427124085359,
+      "cv_best": 0.009770190534615772,
+      "crash_rate": 0.0,
+      "retrain_s": 0.6455
+     },
+     "43": {
+      "holdout_rmse": 0.011043329723889293,
+      "cv_best": 0.009744418150306836,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1208
+     },
+     "44": {
+      "holdout_rmse": 0.011072197807857653,
+      "cv_best": 0.009765690106037376,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1535
+     }
+    },
+    "holdout_mean": 0.011045,
+    "holdout_std": 2.2e-05,
+    "cv_best_mean": 0.00976
+   }
+  }
+ },
+ "runs": {
+  "sp500@s42": {
+   "dataset": "sp500",
+   "seed": 42,
+   "X_search_shape": [
+    2969,
+    28
+   ],
+   "n_holdout": 742,
+   "y_stats": {
+    "mean": 0.00046336272131137016,
+    "std": 0.010883884492578235
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00976344388074939,
+    "rmse_p10": 0.009767962228564443,
+    "rmse_median": 0.009773511085124573,
+    "train_s_median": 0.021960590034723282,
+    "train_s_mean": 0.022733029179275034,
+    "train_s_p90": 0.029058570712804797,
+    "best_params": {
+     "learning_rate": 0.04895596520583819,
+     "num_leaves": 22,
+     "max_depth": 8,
+     "min_data_in_leaf": 93,
+     "lambda_l1": 4.077405201786748e-07,
+     "lambda_l2": 0.0003592995087490544,
+     "feature_fraction": 0.7266048013790695,
+     "bagging_fraction": 0.6331779201740483,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.4749,
+     "num_leaves": 0.2125,
+     "min_data_in_leaf": 0.1642,
+     "max_depth": 0.0746,
+     "bagging_fraction": 0.0326,
+     "extra_trees": 0.0205,
+     "feature_fraction": 0.0164,
+     "bagging_freq": 0.004,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0459
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0459,
+        0.0595
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0595,
+        0.0711
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0711,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        22.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        31.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 162,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        82.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        82.0,
+        90.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        90.0,
+        94.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        94.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0005
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0005,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6921
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.6921,
+        0.7195
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.7195,
+        0.745
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.745,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6104
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.6104,
+        0.63
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.63,
+        0.6577
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.6577,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 38.9,
+    "holdout": {
+     "holdout_rmse": 0.011028538111712062,
+     "retrain_s": 0.0612,
+     "predict_s": 0.0004,
+     "cv_rmse_of_winner": 0.00976344388074939
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009770190534615772,
+    "rmse_p10": 0.009775781157517961,
+    "rmse_median": 0.009781420298039188,
+    "train_s_median": 0.24960160832852124,
+    "train_s_mean": 0.2799465693061551,
+    "train_s_p90": 0.3265546576306224,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.06592490959920959,
+     "num_leaves": 116,
+     "max_depth": 3,
+     "min_data_in_leaf": 38,
+     "lambda_l1": 7.963842517771393e-08,
+     "lambda_l2": 1.0509422583514887,
+     "feature_fraction": 0.9340403480580238,
+     "bagging_fraction": 0.899672614897304,
+     "bagging_freq": 7,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 12,
+     "mixture_balance_factor": 6,
+     "mixture_diversity_lambda": 0.15558279671035175,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 64,
+     "mixture_gate_learning_rate": 0.30931760311128853,
+     "mixture_gate_lambda_l2": 0.007600681158050098,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 29,
+     "mixture_expert_capacity_factor": 0.899565405505812,
+     "mixture_expert_choice_boost": 18.292840914511892,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_diversity_lambda": 0.562,
+     "mixture_init": 0.1368,
+     "learning_rate": 0.0532,
+     "bagging_fraction": 0.0506,
+     "min_data_in_leaf": 0.0452,
+     "feature_fraction": 0.0274,
+     "mixture_balance_factor": 0.0221,
+     "mixture_gate_type": 0.0157,
+     "num_leaves": 0.0135,
+     "mixture_num_experts": 0.0129,
+     "mixture_warmup_iters": 0.0114,
+     "mixture_routing_mode": 0.0101,
+     "mixture_e_step_mode": 0.009,
+     "max_depth": 0.0069,
+     "mixture_r_smoothing": 0.0054,
+     "mixture_hard_m_step": 0.0052,
+     "lambda_l2": 0.0044,
+     "bagging_freq": 0.0035,
+     "extra_trees": 0.0023,
+     "mixture_refit_leaves": 0.0023,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 210,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 40,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gbdt": {
+        "n": 50,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.005741,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 102,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "expert_choice": {
+        "n": 198,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.000146,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 203,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gate_only": {
+        "n": 76,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "em": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0,
+       "p_value": 0.003284,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 25,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gmm": {
+        "n": 15,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "tree_hierarchical": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "uniform": {
+        "n": 240,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "gmm",
+       "delta_mean": 0.0,
+       "p_value": 0.087348,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 103,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "markov": {
+        "n": 104,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 93,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0,
+       "p_value": 0.005161,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 274,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 26,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 260,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 40,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 50,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 250,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1379
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.1379,
+        0.165
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.165,
+        0.2104
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2104,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 56,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        13.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        19.25
+       ],
+       "n": 101,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        19.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 43,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 203,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0559
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0559,
+        0.0673
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0673,
+        0.0895
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0895,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        94.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        94.0,
+        104.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        104.0,
+        114.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        114.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 214,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 86,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        38.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        38.0,
+        42.25
+       ],
+       "n": 90,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        42.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 431.7,
+    "holdout": {
+     "holdout_rmse": 0.011018427124085359,
+     "retrain_s": 0.6455,
+     "predict_s": 0.0022,
+     "cv_rmse_of_winner": 0.009770190534615772
+    }
+   }
+  },
+  "sp500@s43": {
+   "dataset": "sp500",
+   "seed": 43,
+   "X_search_shape": [
+    2969,
+    28
+   ],
+   "n_holdout": 742,
+   "y_stats": {
+    "mean": 0.00046336272131137016,
+    "std": 0.010883884492578235
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009745865977441242,
+    "rmse_p10": 0.0097517442602634,
+    "rmse_median": 0.009774288082855097,
+    "train_s_median": 0.022069171629846097,
+    "train_s_mean": 0.02595949781189362,
+    "train_s_p90": 0.038592824153602136,
+    "best_params": {
+     "learning_rate": 0.2614268943050323,
+     "num_leaves": 24,
+     "max_depth": 3,
+     "min_data_in_leaf": 34,
+     "lambda_l1": 0.003175726071744946,
+     "lambda_l2": 5.8130045289794776e-08,
+     "feature_fraction": 0.9739263503911815,
+     "bagging_fraction": 0.9723000906314205,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "bagging_fraction": 0.4131,
+     "learning_rate": 0.2463,
+     "min_data_in_leaf": 0.0781,
+     "bagging_freq": 0.0665,
+     "feature_fraction": 0.066,
+     "max_depth": 0.048,
+     "num_leaves": 0.0311,
+     "lambda_l1": 0.0243,
+     "lambda_l2": 0.0146,
+     "extra_trees": 0.0119
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0873
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0873,
+        0.2328
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.2328,
+        0.2758
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2758,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        20.0
+       ],
+       "n": 84,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        20.0,
+        54.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        54.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        6.0
+       ],
+       "n": 209,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 91,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        34.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        34.0,
+        42.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        42.0,
+        49.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0006
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0006,
+        0.0021
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0021,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0008
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0008,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9045
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.9045,
+        0.9662
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.9662,
+        0.9839
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9839,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8034
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.8034,
+        0.927
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.927,
+        0.9584
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9584,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 44.1,
+    "holdout": {
+     "holdout_rmse": 0.011050137943706165,
+     "retrain_s": 0.0217,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.009745865977441242
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009744418150306836,
+    "rmse_p10": 0.009757833119294245,
+    "rmse_median": 0.009779288479354047,
+    "train_s_median": 0.2609423648566008,
+    "train_s_mean": 0.41783824473371106,
+    "train_s_p90": 1.193683488704265,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.091842766052883,
+     "num_leaves": 47,
+     "max_depth": 3,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 2.7615035270685046e-08,
+     "lambda_l2": 3.5602179548866135,
+     "feature_fraction": 0.7588464101891416,
+     "bagging_fraction": 0.6416900954503713,
+     "bagging_freq": 2,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 22,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.8279785074940029,
+     "mixture_diversity_lambda": 0.36011114676223704,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 5,
+     "mixture_gate_learning_rate": 0.03601453965247452,
+     "mixture_gate_lambda_l2": 0.14386959724813259,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_expert_capacity_factor": 1.1276660312981899,
+     "mixture_expert_choice_boost": 29.491483574584763,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.3359849683724799,
+     "mixture_refit_every_n": 20,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_warmup_iters": 0.2235,
+     "lambda_l2": 0.1563,
+     "max_depth": 0.1546,
+     "learning_rate": 0.1126,
+     "num_leaves": 0.0801,
+     "mixture_num_experts": 0.0742,
+     "mixture_diversity_lambda": 0.0698,
+     "feature_fraction": 0.0292,
+     "bagging_freq": 0.0247,
+     "min_data_in_leaf": 0.0247,
+     "bagging_fraction": 0.0223,
+     "mixture_refit_leaves": 0.007,
+     "mixture_init": 0.0049,
+     "mixture_r_smoothing": 0.0039,
+     "mixture_balance_factor": 0.0037,
+     "mixture_hard_m_step": 0.0027,
+     "mixture_e_step_mode": 0.0019,
+     "mixture_routing_mode": 0.0016,
+     "extra_trees": 0.0013,
+     "mixture_gate_type": 0.0009,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 229,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 48,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "leaf_reuse": {
+        "n": 23,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 8e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 241,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "token_choice": {
+        "n": 59,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.127919,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 229,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 48,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gate_only": {
+        "n": 23,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 5e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 116,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "tree_hierarchical": {
+        "n": 31,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "random": {
+        "n": 11,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "uniform": {
+        "n": 142,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.028135,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 217,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 44,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "markov": {
+        "n": 39,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 3e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 24,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 276,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 252,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 48,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.331
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.331,
+        0.3788
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.3788,
+        0.4398
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.4398,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        21.0
+       ],
+       "n": 79,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        24.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 88,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 146,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        7.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.042
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.042,
+        0.0661
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0661,
+        0.0958
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0958,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        36.5
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        36.5,
+        48.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 207,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        17.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        29.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 638.4,
+    "holdout": {
+     "holdout_rmse": 0.011043329723889293,
+     "retrain_s": 0.1208,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.009744418150306836
+    }
+   }
+  },
+  "sp500@s44": {
+   "dataset": "sp500",
+   "seed": 44,
+   "X_search_shape": [
+    2969,
+    28
+   ],
+   "n_holdout": 742,
+   "y_stats": {
+    "mean": 0.00046336272131137016,
+    "std": 0.010883884492578235
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009739215992744327,
+    "rmse_p10": 0.00974452012556568,
+    "rmse_median": 0.009768822756168041,
+    "train_s_median": 0.025690915621817113,
+    "train_s_mean": 0.027017641390363376,
+    "train_s_p90": 0.035168726444244396,
+    "best_params": {
+     "learning_rate": 0.031405431231896,
+     "num_leaves": 42,
+     "max_depth": 4,
+     "min_data_in_leaf": 8,
+     "lambda_l1": 0.00017586878336817366,
+     "lambda_l2": 2.4278998842963964e-06,
+     "feature_fraction": 0.6938019580482039,
+     "bagging_fraction": 0.516535726456921,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.7677,
+     "num_leaves": 0.0982,
+     "min_data_in_leaf": 0.0584,
+     "feature_fraction": 0.0278,
+     "bagging_fraction": 0.0188,
+     "extra_trees": 0.01,
+     "bagging_freq": 0.0089,
+     "lambda_l2": 0.007,
+     "max_depth": 0.0032,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0152
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0152,
+        0.0241
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0241,
+        0.0301
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0301,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        45.0
+       ],
+       "n": 79,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        45.0,
+        71.25
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        71.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 48,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 252,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        15.25
+       ],
+       "n": 81,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        15.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0011
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0011,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.65
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.65,
+        0.6756
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.6756,
+        0.6979
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.6979,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5556
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.5556,
+        0.6236
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.6236,
+        0.9115
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9115,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 45.1,
+    "holdout": {
+     "holdout_rmse": 0.011058687134332574,
+     "retrain_s": 0.0264,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.009739215992744327
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009765690106037376,
+    "rmse_p10": 0.009770419338553256,
+    "rmse_median": 0.009781275945630281,
+    "train_s_median": 0.09121376480907202,
+    "train_s_mean": 0.13321076562255618,
+    "train_s_p90": 0.24429502598941327,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.14329216990447427,
+     "num_leaves": 106,
+     "max_depth": 12,
+     "min_data_in_leaf": 93,
+     "lambda_l1": 1.3621393292573133e-06,
+     "lambda_l2": 2.2258513476811112e-05,
+     "feature_fraction": 0.8468305585030389,
+     "bagging_fraction": 0.8251073170780171,
+     "bagging_freq": 0,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 11,
+     "mixture_balance_factor": 3,
+     "mixture_diversity_lambda": 0.27938575466256627,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 53,
+     "mixture_gate_learning_rate": 0.13953856598053158,
+     "mixture_gate_lambda_l2": 3.2434632056179393,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.4732,
+     "extra_trees": 0.1581,
+     "mixture_balance_factor": 0.0861,
+     "feature_fraction": 0.0587,
+     "num_leaves": 0.0456,
+     "mixture_diversity_lambda": 0.0398,
+     "min_data_in_leaf": 0.0333,
+     "learning_rate": 0.0245,
+     "mixture_warmup_iters": 0.0178,
+     "mixture_gate_type": 0.0138,
+     "bagging_fraction": 0.0137,
+     "bagging_freq": 0.0134,
+     "mixture_num_experts": 0.0087,
+     "mixture_r_smoothing": 0.0039,
+     "mixture_refit_leaves": 0.0038,
+     "mixture_routing_mode": 0.0029,
+     "mixture_hard_m_step": 0.0014,
+     "mixture_e_step_mode": 0.0007,
+     "max_depth": 0.0002,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 243,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 27,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "leaf_reuse": {
+        "n": 30,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.81709,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "expert_choice": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.404576,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 67,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "em": {
+        "n": 188,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "loss_only": {
+        "n": 45,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 0.696171,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 254,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 0.0099,
+        "std": 0.0003,
+        "min": 0.0098
+       },
+       "random": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gmm": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0,
+       "p_value": 0.022796,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 230,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "ema": {
+        "n": 29,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "markov": {
+        "n": 41,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0,
+       "p_value": 0.824245,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0003,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1487
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.1487,
+        0.2488
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.2488,
+        0.2805
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2805,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.5
+       ],
+       "n": 82,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        12.5,
+        23.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 32,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 181,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0839
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0839,
+        0.1171
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.1171,
+        0.1394
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.1394,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        97.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        97.75,
+        109.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        109.0,
+        116.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        116.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 170,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        86.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        86.0,
+        91.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        91.5,
+        95.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        95.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 209.1,
+    "holdout": {
+     "holdout_rmse": 0.011072197807857653,
+     "retrain_s": 0.1535,
+     "predict_s": 0.0004,
+     "cv_rmse_of_winner": 0.009765690106037376
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_synthetic_report.md
+++ b/bench_results/meth2_v080/ds_synthetic_report.md
@@ -1,0 +1,535 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['synthetic'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `0cf3634c544c`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| synthetic | naive-lightgbm | **4.81200** ± 0.33985 | 5.55933 | 0.0% | 0.21 |
+| synthetic | moe | **3.91713** ± 0.17942 | 4.44177 | 0.0% | 0.93 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| synthetic@s42 | naive-lightgbm | 5.3381 | 5.5618 | 0.137 | 196 |
+| synthetic@s42 | moe | 4.7737 | 5.5156 | 0.245 | 610 |
+| synthetic@s43 | naive-lightgbm | 5.5380 | 5.8312 | 0.099 | 148 |
+| synthetic@s43 | moe | 4.2523 | 4.7785 | 0.637 | 1584 |
+| synthetic@s44 | naive-lightgbm | 5.8019 | 6.1616 | 0.104 | 150 |
+| synthetic@s44 | moe | 4.2994 | 4.9003 | 0.268 | 680 |
+
+
+
+---
+
+## synthetic@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 4.34766** (winner retrained in 0.19s, cv score of winner: 5.3381)
+- cv best RMSE: 5.3381, median: 5.5618, p10: 5.4179
+- train: median 0.137s/fold, mean 0.126s, p90 0.169s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.570 |
+| `learning_rate` | 0.318 |
+| `feature_fraction` | 0.064 |
+| `extra_trees` | 0.018 |
+| `bagging_freq` | 0.011 |
+| `bagging_fraction` | 0.010 |
+| `max_depth` | 0.005 |
+| `num_leaves` | 0.003 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 5.7325 | 0.4837 | 5.3381 |
+| True | 22 | 7.1469 | 1.5229 | 5.6091 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.1776 | 5.6327 | 5.6468 | 5.8878 | **Q2** [0.0423, 0.0493] |
+| `num_leaves` | 5.6674 | 5.7401 | 5.6392 | 6.3012 | **Q3** [33.0, 50.25] |
+| `max_depth` | 6.5140 | 5.7722 | — | 5.7153 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | 5.5472 | 5.5529 | 5.6385 | 6.5512 | **Q1** [None, 6.0] |
+| `lambda_l1` | 6.3199 | 5.7260 | 5.6546 | 5.6443 | **Q4** [2.3125, ∞) |
+| `lambda_l2` | 5.7133 | 5.6388 | 5.9086 | 6.0841 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.3681 | 5.6851 | 5.6903 | 5.6013 | **Q4** [0.9868, ∞) |
+| `bagging_fraction` | 5.7752 | 5.6650 | 5.8987 | 6.0059 | **Q2** [0.6994, 0.7301] |
+
+#### E. Slice plot
+
+![synthetic@s42/naive-lightgbm](slice_synthetic@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 3.88413** (winner retrained in 0.35s, cv score of winner: 4.7737)
+- cv best RMSE: 4.7737, median: 5.5156, p10: 5.0740
+- train: median 0.245s/fold, mean 0.398s, p90 0.489s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.190 |
+| `learning_rate` | 0.187 |
+| `min_data_in_leaf` | 0.104 |
+| `feature_fraction` | 0.088 |
+| `num_leaves` | 0.086 |
+| `mixture_hard_m_step` | 0.074 |
+| `max_depth` | 0.047 |
+| `mixture_warmup_iters` | 0.035 |
+| `mixture_diversity_lambda` | 0.034 |
+| `bagging_freq` | 0.033 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.4934 (n=202) | leaf_reuse | Δ +0.6374 | p=0.00e+00 |
+| `mixture_routing_mode` | **token_choice** | 5.6582 (n=260) | expert_choice | Δ +1.2065 | p=0.00e+00 |
+| `mixture_e_step_mode` | **loss_only** | 5.5455 (n=135) | gate_only | Δ +0.3284 | p=4.76e-03 |
+| `mixture_init` | **tree_hierarchical** | 5.5444 (n=203) | uniform | Δ +0.4319 | p=1.21e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 202 | 5.4934 | 0.7390 | 4.7737 |
+| leaf_reuse | 68 | 6.1308 | 0.8089 | 5.4802 |
+| none | 30 | 7.3053 | 1.8121 | 5.9024 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 260 | 5.6582 | 0.9597 | 4.7737 |
+| expert_choice | 40 | 6.8647 | 1.2010 | 5.7083 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 135 | 5.5455 | 1.1367 | 4.7817 |
+| gate_only | 122 | 5.8739 | 0.6614 | 5.3656 |
+| em | 43 | 6.5223 | 1.4315 | 4.7737 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 203 | 5.5444 | 0.9617 | 4.7737 |
+| uniform | 43 | 5.9763 | 0.5468 | 5.5791 |
+| gmm | 20 | 6.5660 | 1.3702 | 5.5208 |
+| random | 34 | 6.8206 | 1.1859 | 5.7083 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 156 | 5.5997 | 1.2307 | 4.7737 |
+| ema | 104 | 5.8665 | 0.6522 | 5.3669 |
+| markov | 40 | 6.5508 | 0.9740 | 5.5807 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 147 | 5.6300 | 1.2569 | 4.7737 |
+| False | 153 | 6.0007 | 0.8289 | 5.2491 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 203 | 5.6941 | 0.7402 | 4.9784 |
+| True | 97 | 6.0805 | 1.5285 | 4.7737 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 5.8190 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 6.3100 | 6.0757 | 5.4736 | 5.4169 | **Q4** [0.4642, ∞) |
+| `mixture_warmup_iters` | 5.9982 | 6.0584 | 5.6153 | 5.6075 | **Q4** [43.0, ∞) |
+| `mixture_balance_factor` | 6.5738 | 5.7364 | — | 5.7011 | **Q4** [7.0, ∞) |
+| `learning_rate` | 6.1802 | 5.8306 | 5.6124 | 5.6529 | **Q3** [0.1356, 0.1978] |
+| `num_leaves` | 6.3095 | 5.8174 | 5.8043 | 5.3762 | **Q4** [119.0, ∞) |
+| `max_depth` | 6.1976 | — | 5.4463 | 6.0925 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 5.6602 | 5.5857 | 5.7656 | 6.1979 | **Q2** [10.0, 16.0] |
+
+#### E. Slice plot
+
+![synthetic@s42/moe](slice_synthetic@s42_moe.png)
+
+
+---
+
+## synthetic@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 5.15155** (winner retrained in 0.24s, cv score of winner: 5.5380)
+- cv best RMSE: 5.5380, median: 5.8312, p10: 5.6698
+- train: median 0.099s/fold, mean 0.095s, p90 0.135s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.671 |
+| `learning_rate` | 0.149 |
+| `feature_fraction` | 0.102 |
+| `bagging_fraction` | 0.037 |
+| `bagging_freq` | 0.018 |
+| `max_depth` | 0.008 |
+| `lambda_l2` | 0.005 |
+| `lambda_l1` | 0.005 |
+| `extra_trees` | 0.003 |
+| `num_leaves` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 256 | 5.9714 | 0.4971 | 5.5380 |
+| False | 44 | 6.4221 | 0.7100 | 5.7045 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.4069 | 5.8382 | 5.9328 | 5.9722 | **Q2** [0.1026, 0.1194] |
+| `num_leaves` | 6.3075 | 5.9478 | 5.9577 | 5.9388 | **Q4** [121.0, ∞) |
+| `max_depth` | 6.2932 | — | — | 5.9612 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | — | 5.7937 | 5.9089 | 6.5790 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 6.2461 | 5.9448 | 5.9221 | 6.0371 | **Q3** [0.0012, 0.0059] |
+| `lambda_l2` | 6.0309 | 5.9283 | 5.8122 | 6.3787 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 6.4122 | 5.9660 | 5.8785 | 5.8934 | **Q3** [0.9478, 0.969] |
+| `bagging_fraction` | 6.1562 | 5.9145 | 6.0390 | 6.0404 | **Q2** [0.8748, 0.9009] |
+
+#### E. Slice plot
+
+![synthetic@s43/naive-lightgbm](slice_synthetic@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 3.71575** (winner retrained in 2.14s, cv score of winner: 4.2523)
+- cv best RMSE: 4.2523, median: 4.7785, p10: 4.3963
+- train: median 0.637s/fold, mean 1.048s, p90 1.859s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.525 |
+| `mixture_init` | 0.068 |
+| `learning_rate` | 0.066 |
+| `feature_fraction` | 0.062 |
+| `mixture_e_step_mode` | 0.048 |
+| `mixture_diversity_lambda` | 0.041 |
+| `bagging_fraction` | 0.035 |
+| `mixture_hard_m_step` | 0.032 |
+| `num_leaves` | 0.024 |
+| `mixture_r_smoothing` | 0.024 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.1310 (n=266) | leaf_reuse | Δ +2.4720 | p=0.00e+00 |
+| `mixture_routing_mode` | **token_choice** | 5.3706 (n=264) | expert_choice | Δ +1.0233 | p=5.00e-05 |
+| `mixture_e_step_mode` | **em** | 5.2194 (n=238) | loss_only | Δ +1.1151 | p=2.00e-06 |
+| `mixture_init` | **tree_hierarchical** | 5.2260 (n=208) | gmm | Δ +0.7928 | p=8.30e-05 |
+| `mixture_r_smoothing` | **none** | 5.2524 (n=200) | markov | Δ +0.6288 | p=8.11e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 266 | 5.1310 | 1.0485 | 4.2523 |
+| leaf_reuse | 18 | 7.6030 | 1.1073 | 5.9746 |
+| none | 16 | 9.1449 | 1.9282 | 5.9136 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 264 | 5.3706 | 1.5242 | 4.2523 |
+| expert_choice | 36 | 6.3939 | 1.2458 | 4.9919 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 238 | 5.2194 | 1.4699 | 4.2523 |
+| loss_only | 45 | 6.3345 | 1.2535 | 4.6909 |
+| gate_only | 17 | 7.1038 | 1.1790 | 5.9746 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 208 | 5.2260 | 1.5817 | 4.2523 |
+| gmm | 64 | 6.0188 | 1.2779 | 4.4616 |
+| uniform | 14 | 6.2757 | 0.7266 | 5.0953 |
+| random | 14 | 6.2825 | 1.2034 | 4.7805 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 200 | 5.2524 | 1.5932 | 4.2523 |
+| markov | 83 | 5.8812 | 1.3225 | 4.4616 |
+| ema | 17 | 6.4357 | 0.7792 | 5.6523 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 175 | 5.4841 | 1.2931 | 4.3517 |
+| True | 125 | 5.5064 | 1.8105 | 4.2523 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 248 | 5.2876 | 1.5034 | 4.2523 |
+| False | 52 | 6.4750 | 1.2497 | 4.9655 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | 5.2526 | 6.1909 | **Q3** [2.0, 3.0] |
+| `mixture_diversity_lambda` | 5.6943 | 5.2881 | 5.2949 | 5.6964 | **Q2** [0.1189, 0.1818] |
+| `mixture_warmup_iters` | 5.3903 | 5.2059 | 5.2202 | 6.1591 | **Q2** [8.0, 18.0] |
+| `mixture_balance_factor` | — | — | 5.3048 | 5.9865 | **Q3** [2.0, 7.0] |
+| `learning_rate` | 5.7240 | 5.1158 | 5.3578 | 5.7760 | **Q2** [0.0638, 0.0766] |
+| `num_leaves` | 6.1580 | 5.0508 | 5.2212 | 5.5831 | **Q2** [61.0, 67.5] |
+| `max_depth` | 5.3931 | 5.2488 | 5.1931 | 6.1402 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 5.3889 | 5.0408 | 5.3662 | 6.2829 | **Q2** [7.0, 11.0] |
+
+#### E. Slice plot
+
+![synthetic@s43/moe](slice_synthetic@s43_moe.png)
+
+
+---
+
+## synthetic@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 4.93679** (winner retrained in 0.21s, cv score of winner: 5.8019)
+- cv best RMSE: 5.8019, median: 6.1616, p10: 5.9403
+- train: median 0.104s/fold, mean 0.097s, p90 0.150s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.876 |
+| `learning_rate` | 0.073 |
+| `feature_fraction` | 0.015 |
+| `extra_trees` | 0.010 |
+| `bagging_fraction` | 0.009 |
+| `max_depth` | 0.007 |
+| `lambda_l2` | 0.003 |
+| `num_leaves` | 0.003 |
+| `bagging_freq` | 0.003 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 6.3322 | 0.5460 | 5.8019 |
+| True | 20 | 7.2502 | 0.9051 | 6.1956 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.6490 | 6.1474 | 6.2803 | 6.4967 | **Q2** [0.04, 0.0469] |
+| `num_leaves` | 6.8672 | 6.1468 | 6.3410 | 6.2123 | **Q2** [84.75, 98.0] |
+| `max_depth` | 6.8683 | 6.4367 | — | 6.2094 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 6.1255 | 6.1508 | 6.1991 | 7.0654 | **Q1** [None, 7.0] |
+| `lambda_l1` | 6.8510 | 6.3558 | 6.1514 | 6.2152 | **Q3** [1.2129, 3.1615] |
+| `lambda_l2` | 6.2652 | 6.2468 | 6.4952 | 6.5662 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.8683 | 6.2573 | 6.2016 | 6.2462 | **Q3** [0.9281, 0.955] |
+| `bagging_fraction` | 6.3800 | 6.2264 | 6.3471 | 6.6200 | **Q2** [0.5741, 0.6123] |
+
+#### E. Slice plot
+
+![synthetic@s44/naive-lightgbm](slice_synthetic@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 4.15151** (winner retrained in 0.29s, cv score of winner: 4.2994)
+- cv best RMSE: 4.2994, median: 4.9003, p10: 4.4679
+- train: median 0.268s/fold, mean 0.447s, p90 0.504s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.213 |
+| `bagging_freq` | 0.156 |
+| `mixture_diversity_lambda` | 0.118 |
+| `feature_fraction` | 0.097 |
+| `bagging_fraction` | 0.077 |
+| `num_leaves` | 0.058 |
+| `learning_rate` | 0.046 |
+| `min_data_in_leaf` | 0.043 |
+| `mixture_init` | 0.038 |
+| `mixture_r_smoothing` | 0.033 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.3180 (n=262) | leaf_reuse | Δ +1.7961 | p=0.00e+00 |
+| `mixture_routing_mode` | **expert_choice** | 5.1367 (n=186) | token_choice | Δ +1.2994 | p=0.00e+00 |
+| `mixture_e_step_mode` | **em** | 5.0897 (n=199) | loss_only | Δ +1.6041 | p=1.00e-06 |
+| `mixture_init` | **gmm** | 5.0239 (n=183) | tree_hierarchical | Δ +1.4198 | p=0.00e+00 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 262 | 5.3180 | 1.1816 | 4.2994 |
+| leaf_reuse | 22 | 7.1141 | 0.9927 | 6.2259 |
+| none | 16 | 8.7069 | 1.7853 | 6.3379 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 186 | 5.1367 | 1.0762 | 4.2994 |
+| token_choice | 114 | 6.4361 | 1.6992 | 4.3910 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 199 | 5.0897 | 0.9727 | 4.2994 |
+| loss_only | 33 | 6.6938 | 1.4543 | 4.3837 |
+| gate_only | 68 | 6.6970 | 1.8509 | 4.8632 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 183 | 5.0239 | 1.0265 | 4.2994 |
+| tree_hierarchical | 85 | 6.4437 | 1.7861 | 4.7319 |
+| random | 18 | 6.8949 | 0.8795 | 6.1000 |
+| uniform | 14 | 6.9955 | 0.7366 | 6.0316 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 117 | 5.2322 | 1.3448 | 4.2994 |
+| none | 156 | 5.6482 | 1.3747 | 4.3910 |
+| markov | 27 | 7.2541 | 1.5832 | 5.0885 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 207 | 5.1117 | 0.9957 | 4.2994 |
+| True | 93 | 6.7852 | 1.7318 | 4.8632 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 213 | 5.1365 | 1.0840 | 4.2994 |
+| False | 87 | 6.8398 | 1.6414 | 5.1454 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 5.0482 | — | 5.9924 | **Q2** [2.0, 3.0] |
+| `mixture_diversity_lambda` | 4.9775 | 4.9707 | 5.6058 | 6.9679 | **Q2** [0.0173, 0.0388] |
+| `mixture_warmup_iters` | 6.9080 | 5.7789 | 5.0792 | 4.9526 | **Q4** [49.0, ∞) |
+| `mixture_balance_factor` | 6.9899 | 5.5101 | 4.9258 | 5.1898 | **Q3** [8.5, 10.0] |
+| `learning_rate` | 6.8058 | 5.4919 | 4.9571 | 5.2670 | **Q3** [0.1155, 0.1387] |
+| `num_leaves` | 4.8938 | 5.0128 | 5.7023 | 6.8623 | **Q1** [None, 21.0] |
+| `max_depth` | 5.1094 | 5.1518 | 5.2200 | 6.9531 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 4.9579 | 5.2095 | 5.3734 | 6.7676 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![synthetic@s44/moe](slice_synthetic@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| synthetic@s42 | `mixture_gate_type` | **gbdt** | +0.6374 | 0.00e+00 |
+| synthetic@s42 | `mixture_routing_mode` | **token_choice** | +1.2065 | 0.00e+00 |
+| synthetic@s42 | `mixture_e_step_mode` | **loss_only** | +0.3284 | 4.76e-03 |
+| synthetic@s42 | `mixture_init` | **tree_hierarchical** | +0.4319 | 1.21e-04 |
+| synthetic@s43 | `mixture_gate_type` | **gbdt** | +2.4720 | 0.00e+00 |
+| synthetic@s43 | `mixture_routing_mode` | **token_choice** | +1.0233 | 5.00e-05 |
+| synthetic@s43 | `mixture_e_step_mode` | **em** | +1.1151 | 2.00e-06 |
+| synthetic@s43 | `mixture_init` | **tree_hierarchical** | +0.7928 | 8.30e-05 |
+| synthetic@s43 | `mixture_r_smoothing` | **none** | +0.6288 | 8.11e-04 |
+| synthetic@s44 | `mixture_gate_type` | **gbdt** | +1.7961 | 0.00e+00 |
+| synthetic@s44 | `mixture_routing_mode` | **expert_choice** | +1.2994 | 0.00e+00 |
+| synthetic@s44 | `mixture_e_step_mode` | **em** | +1.6041 | 1.00e-06 |
+| synthetic@s44 | `mixture_init` | **gmm** | +1.4198 | 0.00e+00 |

--- a/bench_results/meth2_v080/ds_synthetic_summary.json
+++ b/bench_results/meth2_v080/ds_synthetic_summary.json
@@ -1,0 +1,2729 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "synthetic"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "0cf3634c544c8f91ada2261bdf448aad9bd4b491",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "synthetic": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 4.347658266639995,
+      "cv_best": 5.3380991356020875,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1867
+     },
+     "43": {
+      "holdout_rmse": 5.15155263864032,
+      "cv_best": 5.538030049821659,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2373
+     },
+     "44": {
+      "holdout_rmse": 4.936794793854299,
+      "cv_best": 5.801861659134396,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2121
+     }
+    },
+    "holdout_mean": 4.812002,
+    "holdout_std": 0.339845,
+    "cv_best_mean": 5.55933
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 3.8841250685490234,
+      "cv_best": 4.7736758589941095,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3497
+     },
+     "43": {
+      "holdout_rmse": 3.7157509149749233,
+      "cv_best": 4.252250069172163,
+      "crash_rate": 0.0,
+      "retrain_s": 2.1438
+     },
+     "44": {
+      "holdout_rmse": 4.15150677012212,
+      "cv_best": 4.299394091322588,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2855
+     }
+    },
+    "holdout_mean": 3.917128,
+    "holdout_std": 0.179421,
+    "cv_best_mean": 4.441773
+   }
+  }
+ },
+ "runs": {
+  "synthetic@s42": {
+   "dataset": "synthetic",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -1.1238261010719193,
+    "std": 12.024415840059472
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.3380991356020875,
+    "rmse_p10": 5.417855251283722,
+    "rmse_median": 5.561809105917167,
+    "train_s_median": 0.13684442434459926,
+    "train_s_mean": 0.12646259300659102,
+    "train_s_p90": 0.16859882071614268,
+    "best_params": {
+     "learning_rate": 0.05929790561270315,
+     "num_leaves": 36,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.16280342621975077,
+     "lambda_l2": 0.0005784736031637255,
+     "feature_fraction": 0.966030446363386,
+     "bagging_fraction": 0.6679177387820032,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5702,
+     "learning_rate": 0.3177,
+     "feature_fraction": 0.0643,
+     "extra_trees": 0.018,
+     "bagging_freq": 0.0105,
+     "bagging_fraction": 0.0103,
+     "max_depth": 0.0051,
+     "num_leaves": 0.003,
+     "lambda_l1": 0.0008,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 7.1469,
+        "std": 1.5229,
+        "min": 5.6091
+       },
+       "False": {
+        "n": 278,
+        "mean": 5.7325,
+        "std": 0.4837,
+        "min": 5.3381
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.4144,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0423
+       ],
+       "n": 75,
+       "mean_rmse": 6.1776
+      },
+      "Q2": {
+       "range": [
+        0.0423,
+        0.0493
+       ],
+       "n": 75,
+       "mean_rmse": 5.6327
+      },
+      "Q3": {
+       "range": [
+        0.0493,
+        0.0602
+       ],
+       "n": 75,
+       "mean_rmse": 5.6468
+      },
+      "Q4": {
+       "range": [
+        0.0602,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.8878
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 67,
+       "mean_rmse": 5.6674
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        33.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.7401
+      },
+      "Q3": {
+       "range": [
+        33.0,
+        50.25
+       ],
+       "n": 83,
+       "mean_rmse": 5.6392
+      },
+      "Q4": {
+       "range": [
+        50.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.3012
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 42,
+       "mean_rmse": 6.514
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 48,
+       "mean_rmse": 5.7722
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 210,
+       "mean_rmse": 5.7153
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 72,
+       "mean_rmse": 5.5472
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 5.5529
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 88,
+       "mean_rmse": 5.6385
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 6.5512
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0095
+       ],
+       "n": 75,
+       "mean_rmse": 6.3199
+      },
+      "Q2": {
+       "range": [
+        0.0095,
+        0.4952
+       ],
+       "n": 75,
+       "mean_rmse": 5.726
+      },
+      "Q3": {
+       "range": [
+        0.4952,
+        2.3125
+       ],
+       "n": 75,
+       "mean_rmse": 5.6546
+      },
+      "Q4": {
+       "range": [
+        2.3125,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.6443
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.7133
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.6388
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.9086
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0841
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9316
+       ],
+       "n": 75,
+       "mean_rmse": 6.3681
+      },
+      "Q2": {
+       "range": [
+        0.9316,
+        0.9681
+       ],
+       "n": 75,
+       "mean_rmse": 5.6851
+      },
+      "Q3": {
+       "range": [
+        0.9681,
+        0.9868
+       ],
+       "n": 75,
+       "mean_rmse": 5.6903
+      },
+      "Q4": {
+       "range": [
+        0.9868,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.6013
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6994
+       ],
+       "n": 75,
+       "mean_rmse": 5.7752
+      },
+      "Q2": {
+       "range": [
+        0.6994,
+        0.7301
+       ],
+       "n": 75,
+       "mean_rmse": 5.665
+      },
+      "Q3": {
+       "range": [
+        0.7301,
+        0.8577
+       ],
+       "n": 75,
+       "mean_rmse": 5.8987
+      },
+      "Q4": {
+       "range": [
+        0.8577,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0059
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 196.0,
+    "holdout": {
+     "holdout_rmse": 4.347658266639995,
+     "retrain_s": 0.1867,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 5.3380991356020875
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 4.7736758589941095,
+    "rmse_p10": 5.0739749020457845,
+    "rmse_median": 5.5155831148573915,
+    "train_s_median": 0.24549682680517435,
+    "train_s_mean": 0.397707413289696,
+    "train_s_p90": 0.48905974287539755,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.251589340586671,
+     "num_leaves": 119,
+     "max_depth": 10,
+     "min_data_in_leaf": 32,
+     "lambda_l1": 0.003461037820018395,
+     "lambda_l2": 5.1349489713129314e-05,
+     "feature_fraction": 0.7347364028001461,
+     "bagging_fraction": 0.9643084929188981,
+     "bagging_freq": 0,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 50,
+     "mixture_balance_factor": 6,
+     "mixture_diversity_lambda": 0.46439052661719604,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 2,
+     "mixture_gate_num_leaves": 14,
+     "mixture_gate_learning_rate": 0.34463219976239473,
+     "mixture_gate_lambda_l2": 0.3434642684822416,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.19576800705131214,
+     "mixture_refit_every_n": 8,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.1901,
+     "learning_rate": 0.1867,
+     "min_data_in_leaf": 0.1036,
+     "feature_fraction": 0.0877,
+     "num_leaves": 0.0859,
+     "mixture_hard_m_step": 0.0738,
+     "max_depth": 0.047,
+     "mixture_warmup_iters": 0.0349,
+     "mixture_diversity_lambda": 0.0335,
+     "bagging_freq": 0.0331,
+     "mixture_init": 0.0307,
+     "mixture_balance_factor": 0.0255,
+     "bagging_fraction": 0.0249,
+     "mixture_routing_mode": 0.0139,
+     "mixture_num_experts": 0.011,
+     "mixture_r_smoothing": 0.0067,
+     "mixture_refit_leaves": 0.0046,
+     "mixture_e_step_mode": 0.0029,
+     "extra_trees": 0.0024,
+     "lambda_l2": 0.001,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 68,
+        "mean": 6.1308,
+        "std": 0.8089,
+        "min": 5.4802
+       },
+       "none": {
+        "n": 30,
+        "mean": 7.3053,
+        "std": 1.8121,
+        "min": 5.9024
+       },
+       "gbdt": {
+        "n": 202,
+        "mean": 5.4934,
+        "std": 0.739,
+        "min": 4.7737
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.6374,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 260,
+        "mean": 5.6582,
+        "std": 0.9597,
+        "min": 4.7737
+       },
+       "expert_choice": {
+        "n": 40,
+        "mean": 6.8647,
+        "std": 1.201,
+        "min": 5.7083
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 1.2065,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 135,
+        "mean": 5.5455,
+        "std": 1.1367,
+        "min": 4.7817
+       },
+       "gate_only": {
+        "n": 122,
+        "mean": 5.8739,
+        "std": 0.6614,
+        "min": 5.3656
+       },
+       "em": {
+        "n": 43,
+        "mean": 6.5223,
+        "std": 1.4315,
+        "min": 4.7737
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.3284,
+       "p_value": 0.004761,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 34,
+        "mean": 6.8206,
+        "std": 1.1859,
+        "min": 5.7083
+       },
+       "gmm": {
+        "n": 20,
+        "mean": 6.566,
+        "std": 1.3702,
+        "min": 5.5208
+       },
+       "tree_hierarchical": {
+        "n": 203,
+        "mean": 5.5444,
+        "std": 0.9617,
+        "min": 4.7737
+       },
+       "uniform": {
+        "n": 43,
+        "mean": 5.9763,
+        "std": 0.5468,
+        "min": 5.5791
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "uniform",
+       "delta_mean": 0.4319,
+       "p_value": 0.000121,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 104,
+        "mean": 5.8665,
+        "std": 0.6522,
+        "min": 5.3669
+       },
+       "markov": {
+        "n": 40,
+        "mean": 6.5508,
+        "std": 0.974,
+        "min": 5.5807
+       },
+       "none": {
+        "n": 156,
+        "mean": 5.5997,
+        "std": 1.2307,
+        "min": 4.7737
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.2668,
+       "p_value": 0.024517,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 147,
+        "mean": 5.63,
+        "std": 1.2569,
+        "min": 4.7737
+       },
+       "False": {
+        "n": 153,
+        "mean": 6.0007,
+        "std": 0.8289,
+        "min": 5.2491
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.3707,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 97,
+        "mean": 6.0805,
+        "std": 1.5285,
+        "min": 4.7737
+       },
+       "False": {
+        "n": 203,
+        "mean": 5.6941,
+        "std": 0.7402,
+        "min": 4.9784
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3864,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 5.819
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1783
+       ],
+       "n": 75,
+       "mean_rmse": 6.31
+      },
+      "Q2": {
+       "range": [
+        0.1783,
+        0.4041
+       ],
+       "n": 75,
+       "mean_rmse": 6.0757
+      },
+      "Q3": {
+       "range": [
+        0.4041,
+        0.4642
+       ],
+       "n": 75,
+       "mean_rmse": 5.4736
+      },
+      "Q4": {
+       "range": [
+        0.4642,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.4169
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.9982
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        32.0
+       ],
+       "n": 78,
+       "mean_rmse": 6.0584
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        43.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.6153
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 5.6075
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 38,
+       "mean_rmse": 6.5738
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 63,
+       "mean_rmse": 5.7364
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 199,
+       "mean_rmse": 5.7011
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0942
+       ],
+       "n": 75,
+       "mean_rmse": 6.1802
+      },
+      "Q2": {
+       "range": [
+        0.0942,
+        0.1356
+       ],
+       "n": 75,
+       "mean_rmse": 5.8306
+      },
+      "Q3": {
+       "range": [
+        0.1356,
+        0.1978
+       ],
+       "n": 75,
+       "mean_rmse": 5.6124
+      },
+      "Q4": {
+       "range": [
+        0.1978,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.6529
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        76.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.3095
+      },
+      "Q2": {
+       "range": [
+        76.0,
+        94.0
+       ],
+       "n": 77,
+       "mean_rmse": 5.8174
+      },
+      "Q3": {
+       "range": [
+        94.0,
+        119.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.8043
+      },
+      "Q4": {
+       "range": [
+        119.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 5.3762
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 74,
+       "mean_rmse": 6.1976
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 139,
+       "mean_rmse": 5.4463
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 6.0925
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 72,
+       "mean_rmse": 5.6602
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        16.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.5857
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        28.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.7656
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 6.1979
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 610.2,
+    "holdout": {
+     "holdout_rmse": 3.8841250685490234,
+     "retrain_s": 0.3497,
+     "predict_s": 0.0012,
+     "cv_rmse_of_winner": 4.7736758589941095
+    }
+   }
+  },
+  "synthetic@s43": {
+   "dataset": "synthetic",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.875910802699441,
+    "std": 11.885024346049207
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.538030049821659,
+    "rmse_p10": 5.6697810332661875,
+    "rmse_median": 5.831239336433313,
+    "train_s_median": 0.0990380009636283,
+    "train_s_mean": 0.09483593489974737,
+    "train_s_p90": 0.13496186930686235,
+    "best_params": {
+     "learning_rate": 0.11323766572590263,
+     "num_leaves": 126,
+     "max_depth": 8,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.0543552575190996e-05,
+     "lambda_l2": 3.2699268648303626e-08,
+     "feature_fraction": 0.916284747594103,
+     "bagging_fraction": 0.9452386259835922,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6711,
+     "learning_rate": 0.149,
+     "feature_fraction": 0.1015,
+     "bagging_fraction": 0.037,
+     "bagging_freq": 0.0176,
+     "max_depth": 0.0084,
+     "lambda_l2": 0.0054,
+     "lambda_l1": 0.0046,
+     "extra_trees": 0.0031,
+     "num_leaves": 0.0023
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 256,
+        "mean": 5.9714,
+        "std": 0.4971,
+        "min": 5.538
+       },
+       "False": {
+        "n": 44,
+        "mean": 6.4221,
+        "std": 0.71,
+        "min": 5.7045
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.4507,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1026
+       ],
+       "n": 75,
+       "mean_rmse": 6.4069
+      },
+      "Q2": {
+       "range": [
+        0.1026,
+        0.1194
+       ],
+       "n": 75,
+       "mean_rmse": 5.8382
+      },
+      "Q3": {
+       "range": [
+        0.1194,
+        0.1399
+       ],
+       "n": 75,
+       "mean_rmse": 5.9328
+      },
+      "Q4": {
+       "range": [
+        0.1399,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.9722
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        97.75
+       ],
+       "n": 75,
+       "mean_rmse": 6.3075
+      },
+      "Q2": {
+       "range": [
+        97.75,
+        116.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.9478
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        121.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.9577
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 5.9388
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 69,
+       "mean_rmse": 6.2932
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 231,
+       "mean_rmse": 5.9612
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 142,
+       "mean_rmse": 5.7937
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 76,
+       "mean_rmse": 5.9089
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 6.579
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.2461
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0012
+       ],
+       "n": 75,
+       "mean_rmse": 5.9448
+      },
+      "Q3": {
+       "range": [
+        0.0012,
+        0.0059
+       ],
+       "n": 75,
+       "mean_rmse": 5.9221
+      },
+      "Q4": {
+       "range": [
+        0.0059,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0371
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.0309
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.9283
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.8122
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.3787
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.917
+       ],
+       "n": 75,
+       "mean_rmse": 6.4122
+      },
+      "Q2": {
+       "range": [
+        0.917,
+        0.9478
+       ],
+       "n": 75,
+       "mean_rmse": 5.966
+      },
+      "Q3": {
+       "range": [
+        0.9478,
+        0.969
+       ],
+       "n": 75,
+       "mean_rmse": 5.8785
+      },
+      "Q4": {
+       "range": [
+        0.969,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.8934
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8748
+       ],
+       "n": 75,
+       "mean_rmse": 6.1562
+      },
+      "Q2": {
+       "range": [
+        0.8748,
+        0.9009
+       ],
+       "n": 75,
+       "mean_rmse": 5.9145
+      },
+      "Q3": {
+       "range": [
+        0.9009,
+        0.9357
+       ],
+       "n": 75,
+       "mean_rmse": 6.039
+      },
+      "Q4": {
+       "range": [
+        0.9357,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0404
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 147.9,
+    "holdout": {
+     "holdout_rmse": 5.15155263864032,
+     "retrain_s": 0.2373,
+     "predict_s": 0.0007,
+     "cv_rmse_of_winner": 5.538030049821659
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 4.252250069172163,
+    "rmse_p10": 4.396251737533404,
+    "rmse_median": 4.778491439172955,
+    "train_s_median": 0.6367296339944005,
+    "train_s_mean": 1.047831597360472,
+    "train_s_p90": 1.8587548842653632,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.06865320421802538,
+     "num_leaves": 73,
+     "max_depth": 8,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 8.187026729578062e-05,
+     "lambda_l2": 8.018231267250238e-07,
+     "feature_fraction": 0.9357262708170576,
+     "bagging_fraction": 0.6927007959351451,
+     "bagging_freq": 4,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 7,
+     "mixture_balance_factor": 2,
+     "mixture_diversity_lambda": 0.23760415535512464,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 38,
+     "mixture_gate_learning_rate": 0.22793789721133367,
+     "mixture_gate_lambda_l2": 0.027132659211601462,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.2138997033901366,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.5253,
+     "mixture_init": 0.0681,
+     "learning_rate": 0.0655,
+     "feature_fraction": 0.0618,
+     "mixture_e_step_mode": 0.0478,
+     "mixture_diversity_lambda": 0.0411,
+     "bagging_fraction": 0.0351,
+     "mixture_hard_m_step": 0.0316,
+     "num_leaves": 0.0242,
+     "mixture_r_smoothing": 0.024,
+     "mixture_warmup_iters": 0.02,
+     "min_data_in_leaf": 0.0141,
+     "mixture_num_experts": 0.0129,
+     "bagging_freq": 0.009,
+     "lambda_l2": 0.0052,
+     "max_depth": 0.0048,
+     "mixture_balance_factor": 0.0034,
+     "mixture_refit_leaves": 0.0024,
+     "extra_trees": 0.0023,
+     "lambda_l1": 0.0008,
+     "mixture_routing_mode": 0.0005
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 266,
+        "mean": 5.131,
+        "std": 1.0485,
+        "min": 4.2523
+       },
+       "none": {
+        "n": 16,
+        "mean": 9.1449,
+        "std": 1.9282,
+        "min": 5.9136
+       },
+       "leaf_reuse": {
+        "n": 18,
+        "mean": 7.603,
+        "std": 1.1073,
+        "min": 5.9746
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 2.472,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 36,
+        "mean": 6.3939,
+        "std": 1.2458,
+        "min": 4.9919
+       },
+       "token_choice": {
+        "n": 264,
+        "mean": 5.3706,
+        "std": 1.5242,
+        "min": 4.2523
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 1.0233,
+       "p_value": 5e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 45,
+        "mean": 6.3345,
+        "std": 1.2535,
+        "min": 4.6909
+       },
+       "em": {
+        "n": 238,
+        "mean": 5.2194,
+        "std": 1.4699,
+        "min": 4.2523
+       },
+       "gate_only": {
+        "n": 17,
+        "mean": 7.1038,
+        "std": 1.179,
+        "min": 5.9746
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 1.1151,
+       "p_value": 2e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 64,
+        "mean": 6.0188,
+        "std": 1.2779,
+        "min": 4.4616
+       },
+       "tree_hierarchical": {
+        "n": 208,
+        "mean": 5.226,
+        "std": 1.5817,
+        "min": 4.2523
+       },
+       "random": {
+        "n": 14,
+        "mean": 6.2825,
+        "std": 1.2034,
+        "min": 4.7805
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 6.2757,
+        "std": 0.7266,
+        "min": 5.0953
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "gmm",
+       "delta_mean": 0.7928,
+       "p_value": 8.3e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 17,
+        "mean": 6.4357,
+        "std": 0.7792,
+        "min": 5.6523
+       },
+       "none": {
+        "n": 200,
+        "mean": 5.2524,
+        "std": 1.5932,
+        "min": 4.2523
+       },
+       "markov": {
+        "n": 83,
+        "mean": 5.8812,
+        "std": 1.3225,
+        "min": 4.4616
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.6288,
+       "p_value": 0.000811,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 125,
+        "mean": 5.5064,
+        "std": 1.8105,
+        "min": 4.2523
+       },
+       "False": {
+        "n": 175,
+        "mean": 5.4841,
+        "std": 1.2931,
+        "min": 4.3517
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0223,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 52,
+        "mean": 6.475,
+        "std": 1.2497,
+        "min": 4.9655
+       },
+       "True": {
+        "n": 248,
+        "mean": 5.2876,
+        "std": 1.5034,
+        "min": 4.2523
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 1.1874,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q3": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 223,
+       "mean_rmse": 5.2526
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 6.1909
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1189
+       ],
+       "n": 75,
+       "mean_rmse": 5.6943
+      },
+      "Q2": {
+       "range": [
+        0.1189,
+        0.1818
+       ],
+       "n": 75,
+       "mean_rmse": 5.2881
+      },
+      "Q3": {
+       "range": [
+        0.1818,
+        0.2298
+       ],
+       "n": 75,
+       "mean_rmse": 5.2949
+      },
+      "Q4": {
+       "range": [
+        0.2298,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.6964
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 64,
+       "mean_rmse": 5.3903
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        18.0
+       ],
+       "n": 85,
+       "mean_rmse": 5.2059
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        26.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.2202
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 6.1591
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        7.0
+       ],
+       "n": 217,
+       "mean_rmse": 5.3048
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 5.9865
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0638
+       ],
+       "n": 75,
+       "mean_rmse": 5.724
+      },
+      "Q2": {
+       "range": [
+        0.0638,
+        0.0766
+       ],
+       "n": 75,
+       "mean_rmse": 5.1158
+      },
+      "Q3": {
+       "range": [
+        0.0766,
+        0.1223
+       ],
+       "n": 75,
+       "mean_rmse": 5.3578
+      },
+      "Q4": {
+       "range": [
+        0.1223,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.776
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        61.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.158
+      },
+      "Q2": {
+       "range": [
+        61.0,
+        67.5
+       ],
+       "n": 78,
+       "mean_rmse": 5.0508
+      },
+      "Q3": {
+       "range": [
+        67.5,
+        74.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.2212
+      },
+      "Q4": {
+       "range": [
+        74.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 5.5831
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 58,
+       "mean_rmse": 5.3931
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 66,
+       "mean_rmse": 5.2488
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 97,
+       "mean_rmse": 5.1931
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 6.1402
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 43,
+       "mean_rmse": 5.3889
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 97,
+       "mean_rmse": 5.0408
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        27.25
+       ],
+       "n": 85,
+       "mean_rmse": 5.3662
+      },
+      "Q4": {
+       "range": [
+        27.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.2829
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1583.7,
+    "holdout": {
+     "holdout_rmse": 3.7157509149749233,
+     "retrain_s": 2.1438,
+     "predict_s": 0.002,
+     "cv_rmse_of_winner": 4.252250069172163
+    }
+   }
+  },
+  "synthetic@s44": {
+   "dataset": "synthetic",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.8513872282377526,
+    "std": 12.522023281908787
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.801861659134396,
+    "rmse_p10": 5.940281846725884,
+    "rmse_median": 6.161574685902847,
+    "train_s_median": 0.1040064373984933,
+    "train_s_mean": 0.09714463503410418,
+    "train_s_p90": 0.15006884783506394,
+    "best_params": {
+     "learning_rate": 0.04041929816413736,
+     "num_leaves": 90,
+     "max_depth": 12,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 1.2253123595844413,
+     "lambda_l2": 3.3666154467191345,
+     "feature_fraction": 0.9740594797703594,
+     "bagging_fraction": 0.909025436817853,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8763,
+     "learning_rate": 0.0728,
+     "feature_fraction": 0.0145,
+     "extra_trees": 0.0104,
+     "bagging_fraction": 0.0093,
+     "max_depth": 0.0072,
+     "lambda_l2": 0.0034,
+     "num_leaves": 0.0033,
+     "bagging_freq": 0.0026,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 6.3322,
+        "std": 0.546,
+        "min": 5.8019
+       },
+       "True": {
+        "n": 20,
+        "mean": 7.2502,
+        "std": 0.9051,
+        "min": 6.1956
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.918,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.04
+       ],
+       "n": 75,
+       "mean_rmse": 6.649
+      },
+      "Q2": {
+       "range": [
+        0.04,
+        0.0469
+       ],
+       "n": 75,
+       "mean_rmse": 6.1474
+      },
+      "Q3": {
+       "range": [
+        0.0469,
+        0.0562
+       ],
+       "n": 75,
+       "mean_rmse": 6.2803
+      },
+      "Q4": {
+       "range": [
+        0.0562,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.4967
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        84.75
+       ],
+       "n": 75,
+       "mean_rmse": 6.8672
+      },
+      "Q2": {
+       "range": [
+        84.75,
+        98.0
+       ],
+       "n": 70,
+       "mean_rmse": 6.1468
+      },
+      "Q3": {
+       "range": [
+        98.0,
+        121.0
+       ],
+       "n": 76,
+       "mean_rmse": 6.341
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 6.2123
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 71,
+       "mean_rmse": 6.8683
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 37,
+       "mean_rmse": 6.4367
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 192,
+       "mean_rmse": 6.2094
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.1255
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 65,
+       "mean_rmse": 6.1508
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 86,
+       "mean_rmse": 6.1991
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 7.0654
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0041
+       ],
+       "n": 75,
+       "mean_rmse": 6.851
+      },
+      "Q2": {
+       "range": [
+        0.0041,
+        1.2129
+       ],
+       "n": 75,
+       "mean_rmse": 6.3558
+      },
+      "Q3": {
+       "range": [
+        1.2129,
+        3.1615
+       ],
+       "n": 75,
+       "mean_rmse": 6.1514
+      },
+      "Q4": {
+       "range": [
+        3.1615,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.2152
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.2652
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.2468
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 6.4952
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.5662
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8372
+       ],
+       "n": 75,
+       "mean_rmse": 6.8683
+      },
+      "Q2": {
+       "range": [
+        0.8372,
+        0.9281
+       ],
+       "n": 75,
+       "mean_rmse": 6.2573
+      },
+      "Q3": {
+       "range": [
+        0.9281,
+        0.955
+       ],
+       "n": 75,
+       "mean_rmse": 6.2016
+      },
+      "Q4": {
+       "range": [
+        0.955,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.2462
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5741
+       ],
+       "n": 75,
+       "mean_rmse": 6.38
+      },
+      "Q2": {
+       "range": [
+        0.5741,
+        0.6123
+       ],
+       "n": 75,
+       "mean_rmse": 6.2264
+      },
+      "Q3": {
+       "range": [
+        0.6123,
+        0.6768
+       ],
+       "n": 75,
+       "mean_rmse": 6.3471
+      },
+      "Q4": {
+       "range": [
+        0.6768,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.62
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 150.3,
+    "holdout": {
+     "holdout_rmse": 4.936794793854299,
+     "retrain_s": 0.2121,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 5.801861659134396
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 4.299394091322588,
+    "rmse_p10": 4.467866023655659,
+    "rmse_median": 4.900308902321576,
+    "train_s_median": 0.2684066228568554,
+    "train_s_mean": 0.44663707262277597,
+    "train_s_p90": 0.5035487039014703,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.11904940194692189,
+     "num_leaves": 18,
+     "max_depth": 4,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 0.061854431038973305,
+     "lambda_l2": 0.24742720277894242,
+     "feature_fraction": 0.9954709335913889,
+     "bagging_fraction": 0.9202889736665429,
+     "bagging_freq": 7,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 47,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.15436310943977216,
+     "mixture_diversity_lambda": 0.0010598178926346548,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 34,
+     "mixture_gate_learning_rate": 0.47310020782902895,
+     "mixture_gate_lambda_l2": 0.004447492274752511,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 0.8435393589476156,
+     "mixture_expert_choice_boost": 5.940324293729473,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.2135,
+     "bagging_freq": 0.156,
+     "mixture_diversity_lambda": 0.1176,
+     "feature_fraction": 0.0972,
+     "bagging_fraction": 0.0768,
+     "num_leaves": 0.0583,
+     "learning_rate": 0.0458,
+     "min_data_in_leaf": 0.043,
+     "mixture_init": 0.038,
+     "mixture_r_smoothing": 0.033,
+     "mixture_balance_factor": 0.0308,
+     "mixture_warmup_iters": 0.0239,
+     "max_depth": 0.0196,
+     "mixture_routing_mode": 0.0165,
+     "mixture_e_step_mode": 0.0162,
+     "mixture_num_experts": 0.0035,
+     "lambda_l2": 0.0032,
+     "mixture_hard_m_step": 0.0024,
+     "extra_trees": 0.0022,
+     "mixture_refit_leaves": 0.0015,
+     "lambda_l1": 0.0009
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 262,
+        "mean": 5.318,
+        "std": 1.1816,
+        "min": 4.2994
+       },
+       "none": {
+        "n": 16,
+        "mean": 8.7069,
+        "std": 1.7853,
+        "min": 6.3379
+       },
+       "leaf_reuse": {
+        "n": 22,
+        "mean": 7.1141,
+        "std": 0.9927,
+        "min": 6.2259
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 1.7961,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 114,
+        "mean": 6.4361,
+        "std": 1.6992,
+        "min": 4.391
+       },
+       "expert_choice": {
+        "n": 186,
+        "mean": 5.1367,
+        "std": 1.0762,
+        "min": 4.2994
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 1.2994,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 68,
+        "mean": 6.697,
+        "std": 1.8509,
+        "min": 4.8632
+       },
+       "em": {
+        "n": 199,
+        "mean": 5.0897,
+        "std": 0.9727,
+        "min": 4.2994
+       },
+       "loss_only": {
+        "n": 33,
+        "mean": 6.6938,
+        "std": 1.4543,
+        "min": 4.3837
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 1.6041,
+       "p_value": 1e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 14,
+        "mean": 6.9955,
+        "std": 0.7366,
+        "min": 6.0316
+       },
+       "tree_hierarchical": {
+        "n": 85,
+        "mean": 6.4437,
+        "std": 1.7861,
+        "min": 4.7319
+       },
+       "random": {
+        "n": 18,
+        "mean": 6.8949,
+        "std": 0.8795,
+        "min": 6.1
+       },
+       "gmm": {
+        "n": 183,
+        "mean": 5.0239,
+        "std": 1.0265,
+        "min": 4.2994
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 1.4198,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 156,
+        "mean": 5.6482,
+        "std": 1.3747,
+        "min": 4.391
+       },
+       "ema": {
+        "n": 117,
+        "mean": 5.2322,
+        "std": 1.3448,
+        "min": 4.2994
+       },
+       "markov": {
+        "n": 27,
+        "mean": 7.2541,
+        "std": 1.5832,
+        "min": 5.0885
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.416,
+       "p_value": 0.013218,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 93,
+        "mean": 6.7852,
+        "std": 1.7318,
+        "min": 4.8632
+       },
+       "False": {
+        "n": 207,
+        "mean": 5.1117,
+        "std": 0.9957,
+        "min": 4.2994
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.6735,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 213,
+        "mean": 5.1365,
+        "std": 1.084,
+        "min": 4.2994
+       },
+       "False": {
+        "n": 87,
+        "mean": 6.8398,
+        "std": 1.6414,
+        "min": 5.1454
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 1.7033,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 115,
+       "mean_rmse": 5.0482
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 185,
+       "mean_rmse": 5.9924
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0173
+       ],
+       "n": 75,
+       "mean_rmse": 4.9775
+      },
+      "Q2": {
+       "range": [
+        0.0173,
+        0.0388
+       ],
+       "n": 75,
+       "mean_rmse": 4.9707
+      },
+      "Q3": {
+       "range": [
+        0.0388,
+        0.1358
+       ],
+       "n": 75,
+       "mean_rmse": 5.6058
+      },
+      "Q4": {
+       "range": [
+        0.1358,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.9679
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        42.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.908
+      },
+      "Q2": {
+       "range": [
+        42.0,
+        47.0
+       ],
+       "n": 65,
+       "mean_rmse": 5.7789
+      },
+      "Q3": {
+       "range": [
+        47.0,
+        49.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.0792
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 4.9526
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 69,
+       "mean_rmse": 6.9899
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.5
+       ],
+       "n": 81,
+       "mean_rmse": 5.5101
+      },
+      "Q3": {
+       "range": [
+        8.5,
+        10.0
+       ],
+       "n": 68,
+       "mean_rmse": 4.9258
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 5.1898
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0756
+       ],
+       "n": 75,
+       "mean_rmse": 6.8058
+      },
+      "Q2": {
+       "range": [
+        0.0756,
+        0.1155
+       ],
+       "n": 75,
+       "mean_rmse": 5.4919
+      },
+      "Q3": {
+       "range": [
+        0.1155,
+        0.1387
+       ],
+       "n": 75,
+       "mean_rmse": 4.9571
+      },
+      "Q4": {
+       "range": [
+        0.1387,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.267
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        21.0
+       ],
+       "n": 72,
+       "mean_rmse": 4.8938
+      },
+      "Q2": {
+       "range": [
+        21.0,
+        27.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.0128
+      },
+      "Q3": {
+       "range": [
+        27.0,
+        72.25
+       ],
+       "n": 80,
+       "mean_rmse": 5.7023
+      },
+      "Q4": {
+       "range": [
+        72.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.8623
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 65,
+       "mean_rmse": 5.1094
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.1518
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 86,
+       "mean_rmse": 5.22
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 6.9531
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 58,
+       "mean_rmse": 4.9579
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 80,
+       "mean_rmse": 5.2095
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        16.0
+       ],
+       "n": 80,
+       "mean_rmse": 5.3734
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 6.7676
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 679.8,
+    "holdout": {
+     "holdout_rmse": 4.15150677012212,
+     "retrain_s": 0.2855,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 4.299394091322588
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_vix_report.md
+++ b/bench_results/meth2_v080/ds_vix_report.md
@@ -1,0 +1,492 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['vix'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `d25c06cf3b86`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| vix | naive-lightgbm | **1.79451** ± 0.06340 | 2.64148 | 0.0% | 0.06 |
+| vix | moe | **1.92614** ± 0.15307 | 2.50119 | 0.0% | 1.13 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| vix@s42 | naive-lightgbm | 2.6702 | 2.7291 | 0.069 | 110 |
+| vix@s42 | moe | 2.4733 | 2.6340 | 0.623 | 1038 |
+| vix@s43 | naive-lightgbm | 2.5971 | 2.7157 | 0.038 | 72 |
+| vix@s43 | moe | 2.5539 | 2.6418 | 0.208 | 587 |
+| vix@s44 | naive-lightgbm | 2.6572 | 2.7332 | 0.043 | 75 |
+| vix@s44 | moe | 2.4764 | 2.5709 | 0.196 | 617 |
+
+
+
+---
+
+## vix@s42  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.76644** (winner retrained in 0.07s, cv score of winner: 2.6702)
+- cv best RMSE: 2.6702, median: 2.7291, p10: 2.6885
+- train: median 0.069s/fold, mean 0.070s, p90 0.095s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.764 |
+| `min_data_in_leaf` | 0.115 |
+| `extra_trees` | 0.044 |
+| `bagging_fraction` | 0.043 |
+| `max_depth` | 0.011 |
+| `feature_fraction` | 0.011 |
+| `num_leaves` | 0.006 |
+| `bagging_freq` | 0.005 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 2.7555 | 0.1312 | 2.6702 |
+| True | 22 | 3.2067 | 0.5093 | 2.7210 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8875 | 2.7324 | 2.7454 | 2.7890 | **Q2** [0.039, 0.0468] |
+| `num_leaves` | 2.7864 | 2.8612 | 2.7577 | 2.7486 | **Q4** [124.0, ∞) |
+| `max_depth` | 2.8009 | — | 2.7644 | 2.8274 | **Q3** [5.0, 7.0] |
+| `min_data_in_leaf` | 2.8082 | 2.7191 | 2.7264 | 2.9041 | **Q2** [24.0, 28.0] |
+| `lambda_l1` | 2.7204 | 2.7450 | 2.8155 | 2.8734 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.8117 | 2.8035 | 2.7477 | 2.7914 | **Q3** [0.0724, 0.9155] |
+| `feature_fraction` | 2.8579 | 2.7613 | 2.7567 | 2.7784 | **Q3** [0.7364, 0.7762] |
+| `bagging_fraction` | 2.8140 | 2.7434 | 2.7894 | 2.8075 | **Q2** [0.6679, 0.7205] |
+
+#### E. Slice plot
+
+![vix@s42/naive-lightgbm](slice_vix@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.94873** (winner retrained in 1.17s, cv score of winner: 2.4733)
+- cv best RMSE: 2.4733, median: 2.6340, p10: 2.5143
+- train: median 0.623s/fold, mean 0.683s, p90 0.842s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.238 |
+| `mixture_hard_m_step` | 0.211 |
+| `lambda_l2` | 0.199 |
+| `mixture_warmup_iters` | 0.070 |
+| `min_data_in_leaf` | 0.036 |
+| `mixture_init` | 0.034 |
+| `bagging_fraction` | 0.034 |
+| `bagging_freq` | 0.034 |
+| `num_leaves` | 0.031 |
+| `extra_trees` | 0.023 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 263 | 2.7514 | 0.5868 | 2.4733 |
+| leaf_reuse | 19 | 3.1461 | 0.6717 | 2.6347 |
+| none | 18 | 3.2263 | 0.4783 | 2.6754 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 265 | 2.7565 | 0.5098 | 2.4733 |
+| expert_choice | 35 | 3.1717 | 1.0031 | 2.6737 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 215 | 2.7292 | 0.4715 | 2.4733 |
+| em | 70 | 2.9600 | 0.8288 | 2.5273 |
+| loss_only | 15 | 3.1656 | 0.7600 | 2.6404 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 225 | 2.7200 | 0.4497 | 2.4733 |
+| gmm | 33 | 2.9760 | 0.5467 | 2.5273 |
+| random | 16 | 3.0022 | 0.3318 | 2.6734 |
+| uniform | 26 | 3.2011 | 1.3155 | 2.6347 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 234 | 2.7362 | 0.5084 | 2.4733 |
+| markov | 36 | 2.9846 | 0.5970 | 2.5862 |
+| none | 30 | 3.1254 | 1.0125 | 2.6020 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7454 | 0.5318 | 2.4733 |
+| True | 20 | 3.6378 | 0.8759 | 2.8363 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.7560 | 0.5478 | 2.4733 |
+| True | 21 | 3.4540 | 0.8779 | 2.8968 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 3.0487 | — | — | 2.7375 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 2.7223 | 2.7573 | 2.7202 | 3.0198 | **Q3** [0.0588, 0.1068] |
+| `mixture_warmup_iters` | 2.9073 | 2.8253 | 2.6566 | 2.8082 | **Q3** [22.0, 25.0] |
+| `mixture_balance_factor` | 2.8867 | 2.7182 | 3.1081 | 2.8148 | **Q2** [4.0, 7.0] |
+| `learning_rate` | 2.9660 | 2.6767 | 2.6801 | 2.8968 | **Q2** [0.0349, 0.0416] |
+| `num_leaves` | 2.8594 | 2.7486 | 2.7053 | 2.9124 | **Q3** [36.0, 51.25] |
+| `max_depth` | 2.9972 | — | 2.6485 | 2.9602 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 2.8699 | 2.7468 | 2.7820 | 2.8247 | **Q2** [35.0, 44.0] |
+
+#### E. Slice plot
+
+![vix@s42/moe](slice_vix@s42_moe.png)
+
+
+---
+
+## vix@s43  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.88229** (winner retrained in 0.05s, cv score of winner: 2.5971)
+- cv best RMSE: 2.5971, median: 2.7157, p10: 2.6491
+- train: median 0.038s/fold, mean 0.045s, p90 0.067s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.598 |
+| `min_data_in_leaf` | 0.363 |
+| `feature_fraction` | 0.009 |
+| `bagging_freq` | 0.008 |
+| `num_leaves` | 0.007 |
+| `max_depth` | 0.006 |
+| `bagging_fraction` | 0.004 |
+| `lambda_l2` | 0.002 |
+| `lambda_l1` | 0.002 |
+| `extra_trees` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 259 | 2.7476 | 0.1920 | 2.5971 |
+| False | 41 | 2.8651 | 0.2764 | 2.7016 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8913 | 2.7394 | 2.7050 | 2.7191 | **Q3** [0.1647, 0.2004] |
+| `num_leaves` | 2.8080 | 2.7553 | 2.7171 | 2.7735 | **Q3** [88.0, 97.0] |
+| `max_depth` | — | — | 2.7211 | 2.8585 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.7595 | 2.7150 | 2.7161 | 2.8668 | **Q2** [12.0, 16.0] |
+| `lambda_l1` | 2.8272 | 2.7260 | 2.7374 | 2.7642 | **Q2** [0.0, 0.0003] |
+| `lambda_l2` | 2.7599 | 2.7436 | 2.7289 | 2.8225 | **Q3** [0.0, 0.0002] |
+| `feature_fraction` | 2.7704 | 2.7048 | 2.7763 | 2.8033 | **Q2** [0.6959, 0.7244] |
+| `bagging_fraction` | 2.7301 | 2.7381 | 2.7229 | 2.8637 | **Q3** [0.6232, 0.6579] |
+
+#### E. Slice plot
+
+![vix@s43/naive-lightgbm](slice_vix@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.72840** (winner retrained in 0.28s, cv score of winner: 2.5539)
+- cv best RMSE: 2.5539, median: 2.6418, p10: 2.5864
+- train: median 0.208s/fold, mean 0.385s, p90 0.506s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `num_leaves` | 0.379 |
+| `learning_rate` | 0.233 |
+| `mixture_hard_m_step` | 0.129 |
+| `mixture_diversity_lambda` | 0.077 |
+| `max_depth` | 0.057 |
+| `mixture_balance_factor` | 0.024 |
+| `mixture_warmup_iters` | 0.022 |
+| `min_data_in_leaf` | 0.022 |
+| `feature_fraction` | 0.014 |
+| `extra_trees` | 0.011 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 256 | 2.8613 | 0.9423 | 2.5539 |
+| gbdt | 26 | 2.9954 | 0.9048 | 2.6127 |
+| leaf_reuse | 18 | 3.0606 | 0.5741 | 2.6037 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 279 | 2.8581 | 0.9222 | 2.5539 |
+| token_choice | 21 | 3.2410 | 0.8560 | 2.6758 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 190 | 2.7078 | 0.3720 | 2.5539 |
+| loss_only | 47 | 3.0882 | 1.0097 | 2.6127 |
+| em | 63 | 3.2673 | 1.6144 | 2.5864 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 141 | 2.7895 | 0.7303 | 2.5539 |
+| tree_hierarchical | 71 | 2.8820 | 0.7706 | 2.5583 |
+| random | 21 | 2.9795 | 0.8121 | 2.5717 |
+| gmm | 67 | 3.0590 | 1.3428 | 2.5864 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 132 | 2.8060 | 0.4215 | 2.5583 |
+| none | 115 | 2.8536 | 0.8523 | 2.5539 |
+| markov | 53 | 3.1492 | 1.6478 | 2.5730 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 276 | 2.8018 | 0.8406 | 2.5539 |
+| True | 24 | 3.8402 | 1.2365 | 2.8073 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.8627 | 0.9445 | 2.5539 |
+| True | 20 | 3.1958 | 0.4273 | 2.8540 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 3.5484 | — | — | 2.8596 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 2.8214 | 2.6499 | 2.7191 | 3.3492 | **Q2** [0.165, 0.1983] |
+| `mixture_warmup_iters` | 3.0207 | 2.7764 | 2.7868 | 2.9775 | **Q2** [11.0, 16.0] |
+| `mixture_balance_factor` | 2.9763 | — | 2.7883 | 3.0671 | **Q3** [4.0, 7.0] |
+| `learning_rate` | 3.1494 | 2.8086 | 2.6777 | 2.9039 | **Q3** [0.0572, 0.0676] |
+| `num_leaves` | 2.7506 | 2.6884 | 2.8862 | 3.2076 | **Q2** [23.0, 30.0] |
+| `max_depth` | 2.8504 | 2.8250 | — | 2.9165 | **Q2** [6.0, 8.0] |
+| `min_data_in_leaf` | 2.8904 | 2.7282 | 2.9542 | 2.9555 | **Q2** [39.0, 44.0] |
+
+#### E. Slice plot
+
+![vix@s43/moe](slice_vix@s43_moe.png)
+
+
+---
+
+## vix@s44  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.73480** (winner retrained in 0.06s, cv score of winner: 2.6572)
+- cv best RMSE: 2.6572, median: 2.7332, p10: 2.6860
+- train: median 0.043s/fold, mean 0.047s, p90 0.070s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.652 |
+| `learning_rate` | 0.261 |
+| `max_depth` | 0.026 |
+| `bagging_freq` | 0.017 |
+| `num_leaves` | 0.014 |
+| `bagging_fraction` | 0.011 |
+| `extra_trees` | 0.010 |
+| `feature_fraction` | 0.008 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7684 | 0.1413 | 2.6572 |
+| True | 20 | 3.0293 | 0.3142 | 2.7179 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8491 | 2.7598 | 2.7368 | 2.7976 | **Q3** [0.064, 0.0859] |
+| `num_leaves` | 2.7942 | 2.7757 | 2.7561 | 2.8183 | **Q3** [66.0, 74.0] |
+| `max_depth` | 2.7874 | 2.8004 | 2.7434 | 2.8354 | **Q3** [5.0, 5.25] |
+| `min_data_in_leaf` | 2.7875 | 2.7352 | 2.7481 | 2.8533 | **Q2** [18.75, 25.0] |
+| `lambda_l1` | 2.7688 | 2.8312 | 2.7583 | 2.7851 | **Q3** [0.0061, 0.0448] |
+| `lambda_l2` | 2.7600 | 2.7385 | 2.7683 | 2.8766 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 2.8228 | 2.7617 | 2.7847 | 2.7742 | **Q2** [0.7432, 0.7862] |
+| `bagging_fraction` | 2.8646 | 2.7674 | 2.7518 | 2.7594 | **Q3** [0.8516, 0.8933] |
+
+#### E. Slice plot
+
+![vix@s44/naive-lightgbm](slice_vix@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.10129** (winner retrained in 1.94s, cv score of winner: 2.4764)
+- cv best RMSE: 2.4764, median: 2.5709, p10: 2.5095
+- train: median 0.196s/fold, mean 0.404s, p90 1.052s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.306 |
+| `lambda_l2` | 0.212 |
+| `mixture_init` | 0.121 |
+| `lambda_l1` | 0.053 |
+| `bagging_freq` | 0.048 |
+| `mixture_r_smoothing` | 0.039 |
+| `mixture_warmup_iters` | 0.028 |
+| `feature_fraction` | 0.028 |
+| `num_leaves` | 0.027 |
+| `min_data_in_leaf` | 0.025 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 116 | 2.7948 | 0.7756 | 2.4764 |
+| none | 156 | 2.9808 | 1.5066 | 2.4910 |
+| leaf_reuse | 28 | 2.9821 | 0.3557 | 2.5693 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 269 | 2.8774 | 1.1930 | 2.4764 |
+| token_choice | 31 | 3.1833 | 1.1973 | 2.5352 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 186 | 2.7720 | 0.9052 | 2.4910 |
+| gate_only | 78 | 3.0676 | 1.6068 | 2.4764 |
+| loss_only | 36 | 3.2732 | 1.3526 | 2.5156 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 244 | 2.7307 | 0.9073 | 2.4764 |
+| tree_hierarchical | 14 | 3.2093 | 0.6778 | 2.7208 |
+| random | 28 | 3.2839 | 1.2193 | 2.5316 |
+| gmm | 14 | 4.9662 | 2.7869 | 2.7395 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 112 | 2.7501 | 0.5338 | 2.4764 |
+| none | 160 | 2.9911 | 1.5297 | 2.4910 |
+| ema | 28 | 3.0754 | 0.8209 | 2.5147 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 264 | 2.8395 | 1.2017 | 2.4764 |
+| True | 36 | 3.4189 | 1.0274 | 2.6220 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.8867 | 1.2248 | 2.4764 |
+| True | 21 | 3.2049 | 0.6676 | 2.7368 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.9280 | — | — | 2.9077 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 3.0911 | 2.8717 | 2.7907 | 2.8825 | **Q3** [0.1471, 0.1935] |
+| `mixture_warmup_iters` | 3.2059 | 3.0074 | 2.7036 | 2.7348 | **Q3** [42.0, 47.0] |
+| `mixture_balance_factor` | — | 2.7410 | 2.9937 | 3.0844 | **Q2** [2.0, 3.0] |
+| `learning_rate` | 3.1472 | 2.6381 | 3.0879 | 2.7629 | **Q2** [0.0474, 0.0847] |
+| `num_leaves` | 3.1835 | 2.8463 | 2.7443 | 2.8723 | **Q3** [90.0, 97.0] |
+| `max_depth` | 2.8998 | 3.1751 | 2.9037 | 2.7082 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 2.8441 | 2.8499 | 2.7422 | 3.1560 | **Q3** [10.0, 15.0] |
+
+#### E. Slice plot
+
+![vix@s44/moe](slice_vix@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v080/ds_vix_summary.json
+++ b/bench_results/meth2_v080/ds_vix_summary.json
@@ -1,0 +1,2735 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "vix"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "d25c06cf3b8656e8f80fec7ac7bf0ccf6a1f07a1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "vix": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.7664386562996477,
+      "cv_best": 2.670171239836421,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0693
+     },
+     "43": {
+      "holdout_rmse": 1.8822932958707213,
+      "cv_best": 2.5970787740095105,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0497
+     },
+     "44": {
+      "holdout_rmse": 1.7348027059232993,
+      "cv_best": 2.6571905806562492,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0602
+     }
+    },
+    "holdout_mean": 1.794512,
+    "holdout_std": 0.0634,
+    "cv_best_mean": 2.64148
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.9487328932023726,
+      "cv_best": 2.4732706106758306,
+      "crash_rate": 0.0,
+      "retrain_s": 1.1689
+     },
+     "43": {
+      "holdout_rmse": 1.7283988119624654,
+      "cv_best": 2.553919459655303,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2795
+     },
+     "44": {
+      "holdout_rmse": 2.101292550354496,
+      "cv_best": 2.4763809593546178,
+      "crash_rate": 0.0,
+      "retrain_s": 1.935
+     }
+    },
+    "holdout_mean": 1.926141,
+    "holdout_std": 0.153069,
+    "cv_best_mean": 2.50119
+   }
+  }
+ },
+ "runs": {
+  "vix@s42": {
+   "dataset": "vix",
+   "seed": 42,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.670171239836421,
+    "rmse_p10": 2.688531065726293,
+    "rmse_median": 2.7290990394558583,
+    "train_s_median": 0.0688081270083785,
+    "train_s_mean": 0.06988361257811387,
+    "train_s_p90": 0.09549139253795147,
+    "best_params": {
+     "learning_rate": 0.0735706065963684,
+     "num_leaves": 23,
+     "max_depth": 5,
+     "min_data_in_leaf": 27,
+     "lambda_l1": 6.52351819567189e-07,
+     "lambda_l2": 0.023485572598806136,
+     "feature_fraction": 0.6655272959539883,
+     "bagging_fraction": 0.8542387126464255,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.7642,
+     "min_data_in_leaf": 0.115,
+     "extra_trees": 0.0437,
+     "bagging_fraction": 0.0428,
+     "max_depth": 0.0113,
+     "feature_fraction": 0.0108,
+     "num_leaves": 0.0061,
+     "bagging_freq": 0.0052,
+     "lambda_l2": 0.0008,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 3.2067,
+        "std": 0.5093,
+        "min": 2.721
+       },
+       "False": {
+        "n": 278,
+        "mean": 2.7555,
+        "std": 0.1312,
+        "min": 2.6702
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.4512,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.039
+       ],
+       "n": 75,
+       "mean_rmse": 2.8875
+      },
+      "Q2": {
+       "range": [
+        0.039,
+        0.0468
+       ],
+       "n": 75,
+       "mean_rmse": 2.7324
+      },
+      "Q3": {
+       "range": [
+        0.0468,
+        0.0645
+       ],
+       "n": 75,
+       "mean_rmse": 2.7454
+      },
+      "Q4": {
+       "range": [
+        0.0645,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.789
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        29.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7864
+      },
+      "Q2": {
+       "range": [
+        29.0,
+        99.5
+       ],
+       "n": 76,
+       "mean_rmse": 2.8612
+      },
+      "Q3": {
+       "range": [
+        99.5,
+        124.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.7577
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.7486
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 45,
+       "mean_rmse": 2.8009
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 166,
+       "mean_rmse": 2.7644
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 89,
+       "mean_rmse": 2.8274
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        24.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.8082
+      },
+      "Q2": {
+       "range": [
+        24.0,
+        28.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7191
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        33.0
+       ],
+       "n": 84,
+       "mean_rmse": 2.7264
+      },
+      "Q4": {
+       "range": [
+        33.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.9041
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7204
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.745
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.8155
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8734
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.8117
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0724
+       ],
+       "n": 75,
+       "mean_rmse": 2.8035
+      },
+      "Q3": {
+       "range": [
+        0.0724,
+        0.9155
+       ],
+       "n": 75,
+       "mean_rmse": 2.7477
+      },
+      "Q4": {
+       "range": [
+        0.9155,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7914
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6765
+       ],
+       "n": 75,
+       "mean_rmse": 2.8579
+      },
+      "Q2": {
+       "range": [
+        0.6765,
+        0.7364
+       ],
+       "n": 75,
+       "mean_rmse": 2.7613
+      },
+      "Q3": {
+       "range": [
+        0.7364,
+        0.7762
+       ],
+       "n": 75,
+       "mean_rmse": 2.7567
+      },
+      "Q4": {
+       "range": [
+        0.7762,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7784
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6679
+       ],
+       "n": 75,
+       "mean_rmse": 2.814
+      },
+      "Q2": {
+       "range": [
+        0.6679,
+        0.7205
+       ],
+       "n": 75,
+       "mean_rmse": 2.7434
+      },
+      "Q3": {
+       "range": [
+        0.7205,
+        0.8505
+       ],
+       "n": 75,
+       "mean_rmse": 2.7894
+      },
+      "Q4": {
+       "range": [
+        0.8505,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8075
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 110.2,
+    "holdout": {
+     "holdout_rmse": 1.7664386562996477,
+     "retrain_s": 0.0693,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 2.670171239836421
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4732706106758306,
+    "rmse_p10": 2.514348317378876,
+    "rmse_median": 2.633999110618154,
+    "train_s_median": 0.6232601474970579,
+    "train_s_mean": 0.6827221838931242,
+    "train_s_p90": 0.841858841367066,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.04022996170961278,
+     "num_leaves": 39,
+     "max_depth": 8,
+     "min_data_in_leaf": 51,
+     "lambda_l1": 0.0001254630173059525,
+     "lambda_l2": 6.546110666796504e-07,
+     "feature_fraction": 0.75734466766286,
+     "bagging_fraction": 0.8445223558888499,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 24,
+     "mixture_balance_factor": 4,
+     "mixture_smoothing_lambda": 0.32495448565346186,
+     "mixture_diversity_lambda": 0.06433559336166907,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 26,
+     "mixture_gate_learning_rate": 0.37705241006539253,
+     "mixture_gate_lambda_l2": 1.2168289285964868,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.2382,
+     "mixture_hard_m_step": 0.2114,
+     "lambda_l2": 0.1986,
+     "mixture_warmup_iters": 0.07,
+     "min_data_in_leaf": 0.0356,
+     "mixture_init": 0.0343,
+     "bagging_fraction": 0.0342,
+     "bagging_freq": 0.0337,
+     "num_leaves": 0.0306,
+     "extra_trees": 0.0229,
+     "lambda_l1": 0.0203,
+     "mixture_r_smoothing": 0.0164,
+     "max_depth": 0.016,
+     "mixture_diversity_lambda": 0.0154,
+     "mixture_gate_type": 0.0105,
+     "mixture_balance_factor": 0.0087,
+     "feature_fraction": 0.0017,
+     "mixture_e_step_mode": 0.0013,
+     "mixture_routing_mode": 0.0002,
+     "mixture_num_experts": 0.0,
+     "mixture_refit_leaves": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 19,
+        "mean": 3.1461,
+        "std": 0.6717,
+        "min": 2.6347
+       },
+       "none": {
+        "n": 18,
+        "mean": 3.2263,
+        "std": 0.4783,
+        "min": 2.6754
+       },
+       "gbdt": {
+        "n": 263,
+        "mean": 2.7514,
+        "std": 0.5868,
+        "min": 2.4733
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.3947,
+       "p_value": 0.024686,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 265,
+        "mean": 2.7565,
+        "std": 0.5098,
+        "min": 2.4733
+       },
+       "expert_choice": {
+        "n": 35,
+        "mean": 3.1717,
+        "std": 1.0031,
+        "min": 2.6737
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.4152,
+       "p_value": 0.022985,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 15,
+        "mean": 3.1656,
+        "std": 0.76,
+        "min": 2.6404
+       },
+       "gate_only": {
+        "n": 215,
+        "mean": 2.7292,
+        "std": 0.4715,
+        "min": 2.4733
+       },
+       "em": {
+        "n": 70,
+        "mean": 2.96,
+        "std": 0.8288,
+        "min": 2.5273
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.2308,
+       "p_value": 0.030509,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 16,
+        "mean": 3.0022,
+        "std": 0.3318,
+        "min": 2.6734
+       },
+       "gmm": {
+        "n": 33,
+        "mean": 2.976,
+        "std": 0.5467,
+        "min": 2.5273
+       },
+       "tree_hierarchical": {
+        "n": 225,
+        "mean": 2.72,
+        "std": 0.4497,
+        "min": 2.4733
+       },
+       "uniform": {
+        "n": 26,
+        "mean": 3.2011,
+        "std": 1.3155,
+        "min": 2.6347
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "gmm",
+       "delta_mean": 0.256,
+       "p_value": 0.015657,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 234,
+        "mean": 2.7362,
+        "std": 0.5084,
+        "min": 2.4733
+       },
+       "markov": {
+        "n": 36,
+        "mean": 2.9846,
+        "std": 0.597,
+        "min": 2.5862
+       },
+       "none": {
+        "n": 30,
+        "mean": 3.1254,
+        "std": 1.0125,
+        "min": 2.602
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.2484,
+       "p_value": 0.024092,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 3.6378,
+        "std": 0.8759,
+        "min": 2.8363
+       },
+       "False": {
+        "n": 280,
+        "mean": 2.7454,
+        "std": 0.5318,
+        "min": 2.4733
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.8924,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 3.454,
+        "std": 0.8779,
+        "min": 2.8968
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.756,
+        "std": 0.5478,
+        "min": 2.4733
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.698,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 65,
+       "mean_rmse": 3.0487
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 235,
+       "mean_rmse": 2.7375
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0174
+       ],
+       "n": 75,
+       "mean_rmse": 2.7223
+      },
+      "Q2": {
+       "range": [
+        0.0174,
+        0.0588
+       ],
+       "n": 75,
+       "mean_rmse": 2.7573
+      },
+      "Q3": {
+       "range": [
+        0.0588,
+        0.1068
+       ],
+       "n": 75,
+       "mean_rmse": 2.7202
+      },
+      "Q4": {
+       "range": [
+        0.1068,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.0198
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.9073
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        22.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.8253
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        25.0
+       ],
+       "n": 59,
+       "mean_rmse": 2.6566
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 102,
+       "mean_rmse": 2.8082
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 26,
+       "mean_rmse": 2.8867
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        7.0
+       ],
+       "n": 117,
+       "mean_rmse": 2.7182
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 22,
+       "mean_rmse": 3.1081
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 2.8148
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0349
+       ],
+       "n": 75,
+       "mean_rmse": 2.966
+      },
+      "Q2": {
+       "range": [
+        0.0349,
+        0.0416
+       ],
+       "n": 75,
+       "mean_rmse": 2.6767
+      },
+      "Q3": {
+       "range": [
+        0.0416,
+        0.0499
+       ],
+       "n": 75,
+       "mean_rmse": 2.6801
+      },
+      "Q4": {
+       "range": [
+        0.0499,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8968
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        21.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.8594
+      },
+      "Q2": {
+       "range": [
+        21.0,
+        36.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7486
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        51.25
+       ],
+       "n": 78,
+       "mean_rmse": 2.7053
+      },
+      "Q4": {
+       "range": [
+        51.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9124
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 55,
+       "mean_rmse": 2.9972
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 156,
+       "mean_rmse": 2.6485
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 89,
+       "mean_rmse": 2.9602
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.8699
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        44.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.7468
+      },
+      "Q3": {
+       "range": [
+        44.0,
+        55.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.782
+      },
+      "Q4": {
+       "range": [
+        55.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.8247
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1038.0,
+    "holdout": {
+     "holdout_rmse": 1.9487328932023726,
+     "retrain_s": 1.1689,
+     "predict_s": 0.0045,
+     "cv_rmse_of_winner": 2.4732706106758306
+    }
+   }
+  },
+  "vix@s43": {
+   "dataset": "vix",
+   "seed": 43,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.5970787740095105,
+    "rmse_p10": 2.6491217234898046,
+    "rmse_median": 2.7157383565950144,
+    "train_s_median": 0.0381287632510066,
+    "train_s_mean": 0.044633085409800204,
+    "train_s_p90": 0.06741928745061164,
+    "best_params": {
+     "learning_rate": 0.20281037258953272,
+     "num_leaves": 34,
+     "max_depth": 3,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 0.5584858923075698,
+     "lambda_l2": 2.485244401438317e-06,
+     "feature_fraction": 0.6940812157677723,
+     "bagging_fraction": 0.6169902728165328,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.5983,
+     "min_data_in_leaf": 0.3632,
+     "feature_fraction": 0.0095,
+     "bagging_freq": 0.0076,
+     "num_leaves": 0.0073,
+     "max_depth": 0.0059,
+     "bagging_fraction": 0.004,
+     "lambda_l2": 0.0021,
+     "lambda_l1": 0.002,
+     "extra_trees": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 259,
+        "mean": 2.7476,
+        "std": 0.192,
+        "min": 2.5971
+       },
+       "False": {
+        "n": 41,
+        "mean": 2.8651,
+        "std": 0.2764,
+        "min": 2.7016
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.1175,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1185
+       ],
+       "n": 75,
+       "mean_rmse": 2.8913
+      },
+      "Q2": {
+       "range": [
+        0.1185,
+        0.1647
+       ],
+       "n": 75,
+       "mean_rmse": 2.7394
+      },
+      "Q3": {
+       "range": [
+        0.1647,
+        0.2004
+       ],
+       "n": 75,
+       "mean_rmse": 2.705
+      },
+      "Q4": {
+       "range": [
+        0.2004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7191
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        77.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.808
+      },
+      "Q2": {
+       "range": [
+        77.0,
+        88.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7553
+      },
+      "Q3": {
+       "range": [
+        88.0,
+        97.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7171
+      },
+      "Q4": {
+       "range": [
+        97.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.7735
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 207,
+       "mean_rmse": 2.7211
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 2.8585
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 57,
+       "mean_rmse": 2.7595
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 92,
+       "mean_rmse": 2.715
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        21.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.7161
+      },
+      "Q4": {
+       "range": [
+        21.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.8668
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.8272
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 2.726
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0151
+       ],
+       "n": 75,
+       "mean_rmse": 2.7374
+      },
+      "Q4": {
+       "range": [
+        0.0151,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7642
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7599
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7436
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 2.7289
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8225
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6959
+       ],
+       "n": 75,
+       "mean_rmse": 2.7704
+      },
+      "Q2": {
+       "range": [
+        0.6959,
+        0.7244
+       ],
+       "n": 75,
+       "mean_rmse": 2.7048
+      },
+      "Q3": {
+       "range": [
+        0.7244,
+        0.8283
+       ],
+       "n": 75,
+       "mean_rmse": 2.7763
+      },
+      "Q4": {
+       "range": [
+        0.8283,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8033
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6
+       ],
+       "n": 75,
+       "mean_rmse": 2.7301
+      },
+      "Q2": {
+       "range": [
+        0.6,
+        0.6232
+       ],
+       "n": 75,
+       "mean_rmse": 2.7381
+      },
+      "Q3": {
+       "range": [
+        0.6232,
+        0.6579
+       ],
+       "n": 75,
+       "mean_rmse": 2.7229
+      },
+      "Q4": {
+       "range": [
+        0.6579,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8637
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 72.0,
+    "holdout": {
+     "holdout_rmse": 1.8822932958707213,
+     "retrain_s": 0.0497,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 2.5970787740095105
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.553919459655303,
+    "rmse_p10": 2.5864341579269245,
+    "rmse_median": 2.6417920107946244,
+    "train_s_median": 0.20759460050612688,
+    "train_s_mean": 0.38491032299896083,
+    "train_s_p90": 0.505505167655647,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.058605285142026044,
+     "num_leaves": 34,
+     "max_depth": 8,
+     "min_data_in_leaf": 38,
+     "lambda_l1": 5.7038226953370415e-05,
+     "lambda_l2": 0.43062014332660703,
+     "feature_fraction": 0.8426672185399388,
+     "bagging_fraction": 0.8505744092979057,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 20,
+     "mixture_balance_factor": 4,
+     "mixture_diversity_lambda": 0.1898155822829837,
+     "mixture_hard_m_step": false,
+     "mixture_expert_capacity_factor": 0.9109622642701073,
+     "mixture_expert_choice_boost": 22.894315475604305,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.05284487125989869,
+     "mixture_elbo_drop_threshold": 0.019144831260632912,
+     "mixture_elbo_plateau_threshold": 0.00014730055644550708,
+     "mixture_elbo_window": 16,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "num_leaves": 0.379,
+     "learning_rate": 0.2329,
+     "mixture_hard_m_step": 0.1287,
+     "mixture_diversity_lambda": 0.0775,
+     "max_depth": 0.0573,
+     "mixture_balance_factor": 0.0242,
+     "mixture_warmup_iters": 0.0217,
+     "min_data_in_leaf": 0.0217,
+     "feature_fraction": 0.0136,
+     "extra_trees": 0.0114,
+     "mixture_init": 0.0101,
+     "bagging_freq": 0.0071,
+     "bagging_fraction": 0.0054,
+     "mixture_r_smoothing": 0.0032,
+     "mixture_gate_type": 0.0026,
+     "mixture_e_step_mode": 0.0025,
+     "mixture_routing_mode": 0.0007,
+     "mixture_num_experts": 0.0003,
+     "mixture_refit_leaves": 0.0001,
+     "lambda_l2": 0.0001,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 26,
+        "mean": 2.9954,
+        "std": 0.9048,
+        "min": 2.6127
+       },
+       "none": {
+        "n": 256,
+        "mean": 2.8613,
+        "std": 0.9423,
+        "min": 2.5539
+       },
+       "leaf_reuse": {
+        "n": 18,
+        "mean": 3.0606,
+        "std": 0.5741,
+        "min": 2.6037
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 0.1341,
+       "p_value": 0.486408,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 279,
+        "mean": 2.8581,
+        "std": 0.9222,
+        "min": 2.5539
+       },
+       "token_choice": {
+        "n": 21,
+        "mean": 3.241,
+        "std": 0.856,
+        "min": 2.6758
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.3829,
+       "p_value": 0.066818,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 47,
+        "mean": 3.0882,
+        "std": 1.0097,
+        "min": 2.6127
+       },
+       "em": {
+        "n": 63,
+        "mean": 3.2673,
+        "std": 1.6144,
+        "min": 2.5864
+       },
+       "gate_only": {
+        "n": 190,
+        "mean": 2.7078,
+        "std": 0.372,
+        "min": 2.5539
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.3804,
+       "p_value": 0.01526,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 67,
+        "mean": 3.059,
+        "std": 1.3428,
+        "min": 2.5864
+       },
+       "tree_hierarchical": {
+        "n": 71,
+        "mean": 2.882,
+        "std": 0.7706,
+        "min": 2.5583
+       },
+       "random": {
+        "n": 21,
+        "mean": 2.9795,
+        "std": 0.8121,
+        "min": 2.5717
+       },
+       "uniform": {
+        "n": 141,
+        "mean": 2.7895,
+        "std": 0.7303,
+        "min": 2.5539
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0925,
+       "p_value": 0.405697,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 132,
+        "mean": 2.806,
+        "std": 0.4215,
+        "min": 2.5583
+       },
+       "none": {
+        "n": 115,
+        "mean": 2.8536,
+        "std": 0.8523,
+        "min": 2.5539
+       },
+       "markov": {
+        "n": 53,
+        "mean": 3.1492,
+        "std": 1.6478,
+        "min": 2.573
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.0476,
+       "p_value": 0.589329,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 24,
+        "mean": 3.8402,
+        "std": 1.2365,
+        "min": 2.8073
+       },
+       "False": {
+        "n": 276,
+        "mean": 2.8018,
+        "std": 0.8406,
+        "min": 2.5539
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.0384,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.8627,
+        "std": 0.9445,
+        "min": 2.5539
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.1958,
+        "std": 0.4273,
+        "min": 2.854
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3331,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 11,
+       "mean_rmse": 3.5484
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 289,
+       "mean_rmse": 2.8596
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.165
+       ],
+       "n": 75,
+       "mean_rmse": 2.8214
+      },
+      "Q2": {
+       "range": [
+        0.165,
+        0.1983
+       ],
+       "n": 75,
+       "mean_rmse": 2.6499
+      },
+      "Q3": {
+       "range": [
+        0.1983,
+        0.2349
+       ],
+       "n": 75,
+       "mean_rmse": 2.7191
+      },
+      "Q4": {
+       "range": [
+        0.2349,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.3492
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 67,
+       "mean_rmse": 3.0207
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        16.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.7764
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        20.0
+       ],
+       "n": 86,
+       "mean_rmse": 2.7868
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.9775
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 34,
+       "mean_rmse": 2.9763
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        7.0
+       ],
+       "n": 185,
+       "mean_rmse": 2.7883
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 3.0671
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0479
+       ],
+       "n": 75,
+       "mean_rmse": 3.1494
+      },
+      "Q2": {
+       "range": [
+        0.0479,
+        0.0572
+       ],
+       "n": 75,
+       "mean_rmse": 2.8086
+      },
+      "Q3": {
+       "range": [
+        0.0572,
+        0.0676
+       ],
+       "n": 75,
+       "mean_rmse": 2.6777
+      },
+      "Q4": {
+       "range": [
+        0.0676,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9039
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.7506
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        30.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.6884
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        58.25
+       ],
+       "n": 81,
+       "mean_rmse": 2.8862
+      },
+      "Q4": {
+       "range": [
+        58.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.2076
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.8504
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 58,
+       "mean_rmse": 2.825
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 179,
+       "mean_rmse": 2.9165
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.8904
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        44.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7282
+      },
+      "Q3": {
+       "range": [
+        44.0,
+        67.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.9542
+      },
+      "Q4": {
+       "range": [
+        67.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.9555
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 587.4,
+    "holdout": {
+     "holdout_rmse": 1.7283988119624654,
+     "retrain_s": 0.2795,
+     "predict_s": 0.0019,
+     "cv_rmse_of_winner": 2.553919459655303
+    }
+   }
+  },
+  "vix@s44": {
+   "dataset": "vix",
+   "seed": 44,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.6571905806562492,
+    "rmse_p10": 2.685984278605875,
+    "rmse_median": 2.733232498819883,
+    "train_s_median": 0.04336029160767793,
+    "train_s_mean": 0.047203722393761076,
+    "train_s_p90": 0.06983109876513481,
+    "best_params": {
+     "learning_rate": 0.045750809758378724,
+     "num_leaves": 68,
+     "max_depth": 5,
+     "min_data_in_leaf": 25,
+     "lambda_l1": 0.0004133519074111703,
+     "lambda_l2": 0.0004262548763200339,
+     "feature_fraction": 0.7079684834994466,
+     "bagging_fraction": 0.8971382833157585,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6519,
+     "learning_rate": 0.2611,
+     "max_depth": 0.0263,
+     "bagging_freq": 0.0167,
+     "num_leaves": 0.0138,
+     "bagging_fraction": 0.0111,
+     "extra_trees": 0.0097,
+     "feature_fraction": 0.0078,
+     "lambda_l2": 0.0011,
+     "lambda_l1": 0.0006
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7684,
+        "std": 0.1413,
+        "min": 2.6572
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.0293,
+        "std": 0.3142,
+        "min": 2.7179
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2609,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0429
+       ],
+       "n": 75,
+       "mean_rmse": 2.8491
+      },
+      "Q2": {
+       "range": [
+        0.0429,
+        0.064
+       ],
+       "n": 75,
+       "mean_rmse": 2.7598
+      },
+      "Q3": {
+       "range": [
+        0.064,
+        0.0859
+       ],
+       "n": 75,
+       "mean_rmse": 2.7368
+      },
+      "Q4": {
+       "range": [
+        0.0859,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7976
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        58.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.7942
+      },
+      "Q2": {
+       "range": [
+        58.0,
+        66.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7757
+      },
+      "Q3": {
+       "range": [
+        66.0,
+        74.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.7561
+      },
+      "Q4": {
+       "range": [
+        74.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.8183
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7874
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 49,
+       "mean_rmse": 2.8004
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        5.25
+       ],
+       "n": 107,
+       "mean_rmse": 2.7434
+      },
+      "Q4": {
+       "range": [
+        5.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8354
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.7875
+      },
+      "Q2": {
+       "range": [
+        18.75,
+        25.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7352
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        29.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.7481
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 88,
+       "mean_rmse": 2.8533
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7688
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0061
+       ],
+       "n": 75,
+       "mean_rmse": 2.8312
+      },
+      "Q3": {
+       "range": [
+        0.0061,
+        0.0448
+       ],
+       "n": 75,
+       "mean_rmse": 2.7583
+      },
+      "Q4": {
+       "range": [
+        0.0448,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7851
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.76
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7385
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7683
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8766
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7432
+       ],
+       "n": 75,
+       "mean_rmse": 2.8228
+      },
+      "Q2": {
+       "range": [
+        0.7432,
+        0.7862
+       ],
+       "n": 75,
+       "mean_rmse": 2.7617
+      },
+      "Q3": {
+       "range": [
+        0.7862,
+        0.8743
+       ],
+       "n": 75,
+       "mean_rmse": 2.7847
+      },
+      "Q4": {
+       "range": [
+        0.8743,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7742
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7763
+       ],
+       "n": 75,
+       "mean_rmse": 2.8646
+      },
+      "Q2": {
+       "range": [
+        0.7763,
+        0.8516
+       ],
+       "n": 75,
+       "mean_rmse": 2.7674
+      },
+      "Q3": {
+       "range": [
+        0.8516,
+        0.8933
+       ],
+       "n": 75,
+       "mean_rmse": 2.7518
+      },
+      "Q4": {
+       "range": [
+        0.8933,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7594
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 74.8,
+    "holdout": {
+     "holdout_rmse": 1.7348027059232993,
+     "retrain_s": 0.0602,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 2.6571905806562492
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4763809593546178,
+    "rmse_p10": 2.5094622440613756,
+    "rmse_median": 2.5708965155156243,
+    "train_s_median": 0.19629874769598243,
+    "train_s_mean": 0.40424329200511183,
+    "train_s_p90": 1.0519044198468328,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.04767544624415965,
+     "num_leaves": 97,
+     "max_depth": 11,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 1.9178187007488878,
+     "lambda_l2": 0.01650126377929323,
+     "feature_fraction": 0.9893022504632845,
+     "bagging_fraction": 0.899648321149274,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 48,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.022101585771543253,
+     "mixture_diversity_lambda": 0.19852342299042583,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 39,
+     "mixture_gate_learning_rate": 0.014010068397192038,
+     "mixture_gate_lambda_l2": 0.0032916822104736908,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_expert_capacity_factor": 1.2039660938383931,
+     "mixture_expert_choice_boost": 26.188363118867386,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.3057,
+     "lambda_l2": 0.2125,
+     "mixture_init": 0.1213,
+     "lambda_l1": 0.0531,
+     "bagging_freq": 0.0483,
+     "mixture_r_smoothing": 0.0388,
+     "mixture_warmup_iters": 0.0283,
+     "feature_fraction": 0.0278,
+     "num_leaves": 0.0274,
+     "min_data_in_leaf": 0.0248,
+     "max_depth": 0.0238,
+     "mixture_e_step_mode": 0.0234,
+     "mixture_hard_m_step": 0.0215,
+     "mixture_balance_factor": 0.0128,
+     "bagging_fraction": 0.0113,
+     "mixture_diversity_lambda": 0.0081,
+     "mixture_gate_type": 0.0046,
+     "mixture_refit_leaves": 0.0036,
+     "extra_trees": 0.0016,
+     "mixture_num_experts": 0.0009,
+     "mixture_routing_mode": 0.0005
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 116,
+        "mean": 2.7948,
+        "std": 0.7756,
+        "min": 2.4764
+       },
+       "none": {
+        "n": 156,
+        "mean": 2.9808,
+        "std": 1.5066,
+        "min": 2.491
+       },
+       "leaf_reuse": {
+        "n": 28,
+        "mean": 2.9821,
+        "std": 0.3557,
+        "min": 2.5693
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.186,
+       "p_value": 0.18813,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 31,
+        "mean": 3.1833,
+        "std": 1.1973,
+        "min": 2.5352
+       },
+       "expert_choice": {
+        "n": 269,
+        "mean": 2.8774,
+        "std": 1.193,
+        "min": 2.4764
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.3059,
+       "p_value": 0.192367,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 78,
+        "mean": 3.0676,
+        "std": 1.6068,
+        "min": 2.4764
+       },
+       "em": {
+        "n": 186,
+        "mean": 2.772,
+        "std": 0.9052,
+        "min": 2.491
+       },
+       "loss_only": {
+        "n": 36,
+        "mean": 3.2732,
+        "std": 1.3526,
+        "min": 2.5156
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.2956,
+       "p_value": 0.132385,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 244,
+        "mean": 2.7307,
+        "std": 0.9073,
+        "min": 2.4764
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 3.2093,
+        "std": 0.6778,
+        "min": 2.7208
+       },
+       "random": {
+        "n": 28,
+        "mean": 3.2839,
+        "std": 1.2193,
+        "min": 2.5316
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 4.9662,
+        "std": 2.7869,
+        "min": 2.7395
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.4786,
+       "p_value": 0.027477,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 160,
+        "mean": 2.9911,
+        "std": 1.5297,
+        "min": 2.491
+       },
+       "ema": {
+        "n": 28,
+        "mean": 3.0754,
+        "std": 0.8209,
+        "min": 2.5147
+       },
+       "markov": {
+        "n": 112,
+        "mean": 2.7501,
+        "std": 0.5338,
+        "min": 2.4764
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.241,
+       "p_value": 0.068221,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 36,
+        "mean": 3.4189,
+        "std": 1.0274,
+        "min": 2.622
+       },
+       "False": {
+        "n": 264,
+        "mean": 2.8395,
+        "std": 1.2017,
+        "min": 2.4764
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5794,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 3.2049,
+        "std": 0.6676,
+        "min": 2.7368
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.8867,
+        "std": 1.2248,
+        "min": 2.4764
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3182,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 20,
+       "mean_rmse": 2.928
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 280,
+       "mean_rmse": 2.9077
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0977
+       ],
+       "n": 75,
+       "mean_rmse": 3.0911
+      },
+      "Q2": {
+       "range": [
+        0.0977,
+        0.1471
+       ],
+       "n": 75,
+       "mean_rmse": 2.8717
+      },
+      "Q3": {
+       "range": [
+        0.1471,
+        0.1935
+       ],
+       "n": 75,
+       "mean_rmse": 2.7907
+      },
+      "Q4": {
+       "range": [
+        0.1935,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8825
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        36.75
+       ],
+       "n": 75,
+       "mean_rmse": 3.2059
+      },
+      "Q2": {
+       "range": [
+        36.75,
+        42.0
+       ],
+       "n": 70,
+       "mean_rmse": 3.0074
+      },
+      "Q3": {
+       "range": [
+        42.0,
+        47.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7036
+      },
+      "Q4": {
+       "range": [
+        47.0,
+        null
+       ],
+       "n": 86,
+       "mean_rmse": 2.7348
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 130,
+       "mean_rmse": 2.741
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 88,
+       "mean_rmse": 2.9937
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 3.0844
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0474
+       ],
+       "n": 75,
+       "mean_rmse": 3.1472
+      },
+      "Q2": {
+       "range": [
+        0.0474,
+        0.0847
+       ],
+       "n": 75,
+       "mean_rmse": 2.6381
+      },
+      "Q3": {
+       "range": [
+        0.0847,
+        0.2281
+       ],
+       "n": 75,
+       "mean_rmse": 3.0879
+      },
+      "Q4": {
+       "range": [
+        0.2281,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7629
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        80.0
+       ],
+       "n": 72,
+       "mean_rmse": 3.1835
+      },
+      "Q2": {
+       "range": [
+        80.0,
+        90.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.8463
+      },
+      "Q3": {
+       "range": [
+        90.0,
+        97.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7443
+      },
+      "Q4": {
+       "range": [
+        97.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 2.8723
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.8998
+      },
+      "Q2": {
+       "range": [
+        6.75,
+        9.0
+       ],
+       "n": 66,
+       "mean_rmse": 3.1751
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.9037
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 2.7082
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 41,
+       "mean_rmse": 2.8441
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 107,
+       "mean_rmse": 2.8499
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        15.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7422
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 3.156
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 617.0,
+    "holdout": {
+     "holdout_rmse": 2.101292550354496,
+     "retrain_s": 1.935,
+     "predict_s": 0.0019,
+     "cv_rmse_of_winner": 2.4763809593546178
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v080/ds_wine_quality_report.md
+++ b/bench_results/meth2_v080/ds_wine_quality_report.md
@@ -1,0 +1,492 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['wine_quality'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `5cec0a0bd5ab…`, package `/tmp/lgbm-moe-v080/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| wine_quality | naive-lightgbm | **0.61547** ± 0.01639 | 0.66867 | 0.0% | 0.61 |
+| wine_quality | moe | **0.61573** ± 0.01362 | 0.66666 | 0.0% | 2.68 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| wine_quality@s42 | naive-lightgbm | 0.6678 | 0.6775 | 0.407 | 584 |
+| wine_quality@s42 | moe | 0.6654 | 0.6812 | 1.745 | 2877 |
+| wine_quality@s43 | naive-lightgbm | 0.6630 | 0.6686 | 0.445 | 618 |
+| wine_quality@s43 | moe | 0.6585 | 0.6651 | 2.030 | 3275 |
+| wine_quality@s44 | naive-lightgbm | 0.6752 | 0.6836 | 0.261 | 352 |
+| wine_quality@s44 | moe | 0.6761 | 0.6882 | 1.582 | 2299 |
+
+
+
+---
+
+## wine_quality@s42  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.60747** (winner retrained in 0.62s, cv score of winner: 0.6678)
+- cv best RMSE: 0.6678, median: 0.6775, p10: 0.6709
+- train: median 0.407s/fold, mean 0.384s, p90 0.589s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.406 |
+| `extra_trees` | 0.304 |
+| `min_data_in_leaf` | 0.155 |
+| `feature_fraction` | 0.060 |
+| `bagging_fraction` | 0.027 |
+| `max_depth` | 0.027 |
+| `bagging_freq` | 0.017 |
+| `num_leaves` | 0.002 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.6799 | 0.0108 | 0.6678 |
+| True | 22 | 0.7226 | 0.0318 | 0.6907 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6896 | 0.6759 | 0.6794 | 0.6871 | **Q2** [0.0424, 0.0489] |
+| `num_leaves` | 0.6918 | 0.6845 | 0.6780 | 0.6778 | **Q4** [120.25, ∞) |
+| `max_depth` | 0.6997 | 0.6796 | — | 0.6782 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6774 | 0.6765 | 0.6788 | 0.6981 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 0.6817 | 0.6793 | 0.6787 | 0.6923 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.6775 | 0.6869 | 0.6872 | 0.6804 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.6831 | 0.6797 | 0.6814 | 0.6878 | **Q2** [0.623, 0.6574] |
+| `bagging_fraction` | 0.6905 | 0.6807 | 0.6772 | 0.6836 | **Q3** [0.8827, 0.9014] |
+
+#### E. Slice plot
+
+![wine_quality@s42/naive-lightgbm](slice_wine_quality@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.60151** (winner retrained in 3.85s, cv score of winner: 0.6654)
+- cv best RMSE: 0.6654, median: 0.6812, p10: 0.6698
+- train: median 1.745s/fold, mean 1.900s, p90 3.080s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.471 |
+| `lambda_l2` | 0.242 |
+| `bagging_fraction` | 0.123 |
+| `learning_rate` | 0.047 |
+| `feature_fraction` | 0.024 |
+| `extra_trees` | 0.021 |
+| `mixture_routing_mode` | 0.021 |
+| `mixture_gate_type` | 0.021 |
+| `mixture_diversity_lambda` | 0.012 |
+| `mixture_e_step_mode` | 0.006 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 220 | 0.7246 | 0.3894 | 0.6654 |
+| leaf_reuse | 61 | 0.8088 | 0.4331 | 0.6807 |
+| none | 19 | 0.8315 | 0.3322 | 0.6773 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 225 | 0.7075 | 0.1929 | 0.6654 |
+| token_choice | 75 | 0.8715 | 0.7070 | 0.6793 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 192 | 0.6910 | 0.0725 | 0.6654 |
+| gate_only | 73 | 0.8381 | 0.6762 | 0.6778 |
+| loss_only | 35 | 0.8773 | 0.5655 | 0.6671 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 181 | 0.7007 | 0.1548 | 0.6654 |
+| random | 57 | 0.7876 | 0.4161 | 0.6778 |
+| tree_hierarchical | 22 | 0.8105 | 0.3192 | 0.6716 |
+| uniform | 40 | 0.8751 | 0.8618 | 0.6749 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 219 | 0.7166 | 0.3665 | 0.6654 |
+| markov | 17 | 0.8173 | 0.3133 | 0.6772 |
+| none | 64 | 0.8394 | 0.4916 | 0.6793 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.7290 | 0.2703 | 0.6654 |
+| True | 20 | 1.0219 | 1.1252 | 0.6819 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 265 | 0.7243 | 0.2518 | 0.6654 |
+| True | 35 | 0.9315 | 0.9142 | 0.6908 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.7978 | 0.9018 | — | 0.7152 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.6949 | 0.8650 | 0.7316 | 0.7026 | **Q1** [None, 0.0542] |
+| `mixture_warmup_iters` | 0.7674 | 0.7498 | 0.6979 | 0.8025 | **Q3** [8.0, 12.0] |
+| `mixture_balance_factor` | 0.7826 | 0.8806 | — | 0.7003 | **Q4** [10.0, ∞) |
+| `learning_rate` | 0.7994 | 0.7987 | 0.6822 | 0.7137 | **Q3** [0.0858, 0.1055] |
+| `num_leaves` | 0.8830 | 0.7299 | 0.6849 | 0.6990 | **Q3** [110.0, 116.0] |
+| `max_depth` | 0.7715 | 0.6844 | — | 0.7660 | **Q2** [8.0, 9.0] |
+| `min_data_in_leaf` | 0.6827 | 0.7017 | 0.6889 | 0.9111 | **Q1** [None, 6.0] |
+
+#### E. Slice plot
+
+![wine_quality@s42/moe](slice_wine_quality@s42_moe.png)
+
+
+---
+
+## wine_quality@s43  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.63831** (winner retrained in 0.76s, cv score of winner: 0.6630)
+- cv best RMSE: 0.6630, median: 0.6686, p10: 0.6653
+- train: median 0.445s/fold, mean 0.407s, p90 0.623s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.422 |
+| `learning_rate` | 0.413 |
+| `min_data_in_leaf` | 0.079 |
+| `bagging_freq` | 0.036 |
+| `max_depth` | 0.018 |
+| `feature_fraction` | 0.013 |
+| `bagging_fraction` | 0.009 |
+| `num_leaves` | 0.006 |
+| `lambda_l1` | 0.002 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.6728 | 0.0112 | 0.6630 |
+| True | 21 | 0.7180 | 0.0213 | 0.6886 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6847 | 0.6711 | 0.6711 | 0.6770 | **Q2** [0.0516, 0.0598] |
+| `num_leaves` | 0.6877 | 0.6725 | 0.6726 | 0.6714 | **Q4** [123.0, ∞) |
+| `max_depth` | 0.6871 | — | 0.6741 | 0.6718 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6692 | 0.6715 | 0.6725 | 0.6894 | **Q1** [None, 6.0] |
+| `lambda_l1` | 0.6831 | 0.6735 | 0.6698 | 0.6776 | **Q3** [0.0733, 0.1665] |
+| `lambda_l2` | 0.6754 | 0.6693 | 0.6759 | 0.6834 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6737 | 0.6716 | 0.6720 | 0.6867 | **Q2** [0.5368, 0.5666] |
+| `bagging_fraction` | 0.6761 | 0.6727 | 0.6702 | 0.6851 | **Q3** [0.6535, 0.6781] |
+
+#### E. Slice plot
+
+![wine_quality@s43/naive-lightgbm](slice_wine_quality@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.63410** (winner retrained in 1.75s, cv score of winner: 0.6585)
+- cv best RMSE: 0.6585, median: 0.6651, p10: 0.6614
+- train: median 2.030s/fold, mean 2.166s, p90 3.098s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.191 |
+| `lambda_l2` | 0.089 |
+| `mixture_balance_factor` | 0.076 |
+| `feature_fraction` | 0.075 |
+| `bagging_freq` | 0.074 |
+| `num_leaves` | 0.072 |
+| `mixture_e_step_mode` | 0.059 |
+| `mixture_r_smoothing` | 0.040 |
+| `bagging_fraction` | 0.038 |
+| `min_data_in_leaf` | 0.038 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 184 | 0.7325 | 0.3607 | 0.6604 |
+| leaf_reuse | 102 | 0.7753 | 0.5394 | 0.6585 |
+| none | 14 | 1.1653 | 0.9351 | 0.6649 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 191 | 0.7651 | 0.4175 | 0.6604 |
+| token_choice | 109 | 0.7710 | 0.5668 | 0.6585 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 121 | 0.7249 | 0.3105 | 0.6585 |
+| gate_only | 117 | 0.7823 | 0.6366 | 0.6604 |
+| loss_only | 62 | 0.8214 | 0.3769 | 0.6618 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 222 | 0.7168 | 0.3431 | 0.6585 |
+| gmm | 50 | 0.7977 | 0.3599 | 0.6627 |
+| tree_hierarchical | 14 | 0.9286 | 0.4012 | 0.6644 |
+| random | 14 | 1.2976 | 1.4274 | 0.6625 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 266 | 0.7259 | 0.3370 | 0.6585 |
+| markov | 16 | 1.0867 | 1.1816 | 0.6628 |
+| none | 18 | 1.0941 | 0.8079 | 0.6645 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 276 | 0.7226 | 0.3148 | 0.6585 |
+| True | 24 | 1.2810 | 1.1914 | 0.6741 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.7668 | 0.4912 | 0.6585 |
+| True | 20 | 0.7731 | 0.1928 | 0.6922 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9648 | — | 0.7582 | 0.7638 | **Q3** [3.0, 4.0] |
+| `mixture_diversity_lambda` | 0.7064 | 0.7033 | 0.6959 | 0.9634 | **Q3** [0.0463, 0.1134] |
+| `mixture_warmup_iters` | 0.9696 | 0.6924 | 0.7426 | 0.7101 | **Q2** [37.0, 41.0] |
+| `mixture_balance_factor` | 0.8540 | 0.7686 | — | 0.7319 | **Q4** [5.0, ∞) |
+| `learning_rate` | 0.8116 | 0.6758 | 0.7286 | 0.8529 | **Q2** [0.0547, 0.0635] |
+| `num_leaves` | 0.9249 | 0.6775 | 0.7161 | 0.7434 | **Q2** [104.75, 113.0] |
+| `max_depth` | 0.9853 | 0.7345 | — | 0.7022 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6911 | 0.6941 | 0.7334 | 0.9308 | **Q1** [None, 6.0] |
+
+#### E. Slice plot
+
+![wine_quality@s43/moe](slice_wine_quality@s43_moe.png)
+
+
+---
+
+## wine_quality@s44  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.60061** (winner retrained in 0.44s, cv score of winner: 0.6752)
+- cv best RMSE: 0.6752, median: 0.6836, p10: 0.6790
+- train: median 0.261s/fold, mean 0.230s, p90 0.333s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.450 |
+| `learning_rate` | 0.192 |
+| `min_data_in_leaf` | 0.093 |
+| `bagging_fraction` | 0.072 |
+| `max_depth` | 0.071 |
+| `lambda_l2` | 0.033 |
+| `num_leaves` | 0.033 |
+| `bagging_freq` | 0.023 |
+| `feature_fraction` | 0.022 |
+| `lambda_l1` | 0.010 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 277 | 0.6869 | 0.0103 | 0.6752 |
+| True | 23 | 0.7177 | 0.0155 | 0.6983 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6919 | 0.6861 | 0.6853 | 0.6937 | **Q3** [0.0494, 0.0663] |
+| `num_leaves` | 0.6991 | 0.6865 | 0.6863 | 0.6856 | **Q4** [121.0, ∞) |
+| `max_depth` | 0.6980 | — | 0.6845 | 0.6934 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | — | 0.6835 | 0.6883 | 0.7004 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 0.6947 | 0.6862 | 0.6849 | 0.6913 | **Q3** [0.027, 0.0871] |
+| `lambda_l2` | 0.6903 | 0.6838 | 0.6869 | 0.6962 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6873 | 0.6854 | 0.6856 | 0.6989 | **Q2** [0.5384, 0.5618] |
+| `bagging_fraction` | 0.7004 | 0.6865 | 0.6836 | 0.6866 | **Q3** [0.9024, 0.9231] |
+
+#### E. Slice plot
+
+![wine_quality@s44/naive-lightgbm](slice_wine_quality@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.61159** (winner retrained in 2.44s, cv score of winner: 0.6761)
+- cv best RMSE: 0.6761, median: 0.6882, p10: 0.6788
+- train: median 1.582s/fold, mean 1.524s, p90 2.768s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.578 |
+| `lambda_l1` | 0.091 |
+| `num_leaves` | 0.064 |
+| `feature_fraction` | 0.051 |
+| `learning_rate` | 0.050 |
+| `bagging_fraction` | 0.036 |
+| `extra_trees` | 0.026 |
+| `mixture_balance_factor` | 0.021 |
+| `mixture_init` | 0.017 |
+| `mixture_warmup_iters` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 234 | 0.8029 | 0.5126 | 0.6761 |
+| gbdt | 40 | 0.9809 | 0.7424 | 0.6926 |
+| leaf_reuse | 26 | 1.1821 | 1.1228 | 0.6954 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 270 | 0.8362 | 0.5617 | 0.6761 |
+| token_choice | 30 | 1.0692 | 1.0596 | 0.6935 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 173 | 0.8048 | 0.5713 | 0.6761 |
+| loss_only | 38 | 0.9031 | 0.6772 | 0.6817 |
+| gate_only | 89 | 0.9472 | 0.7125 | 0.6778 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 150 | 0.7832 | 0.5027 | 0.6761 |
+| random | 90 | 0.8608 | 0.5720 | 0.6778 |
+| uniform | 46 | 0.9478 | 0.7159 | 0.6874 |
+| tree_hierarchical | 14 | 1.3785 | 1.3204 | 0.6822 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 233 | 0.8001 | 0.4703 | 0.6761 |
+| none | 16 | 0.9509 | 0.8024 | 0.7029 |
+| ema | 51 | 1.1023 | 1.0342 | 0.6926 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 273 | 0.8276 | 0.5651 | 0.6761 |
+| False | 27 | 1.1816 | 1.0554 | 0.6850 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.8424 | 0.6235 | 0.6761 |
+| True | 22 | 1.0759 | 0.7125 | 0.7026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 0.8595 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 1.0737 | 0.8117 | 0.7294 | 0.8232 | **Q3** [0.426, 0.4508] |
+| `mixture_warmup_iters` | 0.8646 | 0.9662 | 0.8149 | 0.7923 | **Q4** [43.0, ∞) |
+| `mixture_balance_factor` | 1.1061 | — | 0.8189 | 0.8174 | **Q4** [6.0, ∞) |
+| `learning_rate` | 0.8688 | 0.8084 | 0.9412 | 0.8196 | **Q2** [0.0713, 0.0858] |
+| `num_leaves` | 0.9926 | 0.8432 | 0.8403 | 0.7629 | **Q4** [120.0, ∞) |
+| `max_depth` | 1.0863 | 0.8232 | — | 0.7737 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.7693 | 0.8086 | 0.8491 | 1.0034 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![wine_quality@s44/moe](slice_wine_quality@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v080/ds_wine_quality_summary.json
+++ b/bench_results/meth2_v080/ds_wine_quality_summary.json
@@ -1,0 +1,2739 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "wine_quality"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/tmp/lgbm-moe-v080/python-package/lightgbm_moe",
+  "lib_sha256": "5cec0a0bd5ab1c6650981b9f069205235d851dd918a07d3af82f7f7537ac4dde",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "wine_quality": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6074681092037725,
+      "cv_best": 0.6678315805287544,
+      "crash_rate": 0.0,
+      "retrain_s": 0.6161
+     },
+     "43": {
+      "holdout_rmse": 0.6383110160230044,
+      "cv_best": 0.6630117003555592,
+      "crash_rate": 0.0,
+      "retrain_s": 0.7647
+     },
+     "44": {
+      "holdout_rmse": 0.6006148504583017,
+      "cv_best": 0.6751723908916849,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4376
+     }
+    },
+    "holdout_mean": 0.615465,
+    "holdout_std": 0.016395,
+    "cv_best_mean": 0.668672
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6015084927036235,
+      "cv_best": 0.6653815476548155,
+      "crash_rate": 0.0,
+      "retrain_s": 3.8504
+     },
+     "43": {
+      "holdout_rmse": 0.6340967130575034,
+      "cv_best": 0.6585190750359627,
+      "crash_rate": 0.0,
+      "retrain_s": 1.7488
+     },
+     "44": {
+      "holdout_rmse": 0.6115934104088393,
+      "cv_best": 0.6760950823938833,
+      "crash_rate": 0.0,
+      "retrain_s": 2.4428
+     }
+    },
+    "holdout_mean": 0.615733,
+    "holdout_std": 0.013622,
+    "cv_best_mean": 0.666665
+   }
+  }
+ },
+ "runs": {
+  "wine_quality@s42": {
+   "dataset": "wine_quality",
+   "seed": 42,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.814159292035399,
+    "std": 0.8812175760471399
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6678315805287544,
+    "rmse_p10": 0.6709041883958695,
+    "rmse_median": 0.6774949609121834,
+    "train_s_median": 0.40681845266371963,
+    "train_s_mean": 0.3839626444615423,
+    "train_s_p90": 0.5889215960353613,
+    "best_params": {
+     "learning_rate": 0.04561171136354861,
+     "num_leaves": 112,
+     "max_depth": 12,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 1.1006876169427215e-06,
+     "lambda_l2": 0.01627506790725957,
+     "feature_fraction": 0.6077025846821319,
+     "bagging_fraction": 0.8927049696094213,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.406,
+     "extra_trees": 0.3045,
+     "min_data_in_leaf": 0.1549,
+     "feature_fraction": 0.0596,
+     "bagging_fraction": 0.0274,
+     "max_depth": 0.0273,
+     "bagging_freq": 0.0173,
+     "num_leaves": 0.0016,
+     "lambda_l2": 0.0011,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.7226,
+        "std": 0.0318,
+        "min": 0.6907
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.6799,
+        "std": 0.0108,
+        "min": 0.6678
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0427,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0424
+       ],
+       "n": 75,
+       "mean_rmse": 0.6896
+      },
+      "Q2": {
+       "range": [
+        0.0424,
+        0.0489
+       ],
+       "n": 75,
+       "mean_rmse": 0.6759
+      },
+      "Q3": {
+       "range": [
+        0.0489,
+        0.06
+       ],
+       "n": 75,
+       "mean_rmse": 0.6794
+      },
+      "Q4": {
+       "range": [
+        0.06,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6871
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        79.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.6918
+      },
+      "Q2": {
+       "range": [
+        79.0,
+        111.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.6845
+      },
+      "Q3": {
+       "range": [
+        111.5,
+        120.25
+       ],
+       "n": 75,
+       "mean_rmse": 0.678
+      },
+      "Q4": {
+       "range": [
+        120.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6778
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.6997
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.6796
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 183,
+       "mean_rmse": 0.6782
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.6774
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6765
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6788
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.6981
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6817
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6793
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6787
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6923
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6775
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6869
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0133
+       ],
+       "n": 75,
+       "mean_rmse": 0.6872
+      },
+      "Q4": {
+       "range": [
+        0.0133,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6804
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.623
+       ],
+       "n": 75,
+       "mean_rmse": 0.6831
+      },
+      "Q2": {
+       "range": [
+        0.623,
+        0.6574
+       ],
+       "n": 75,
+       "mean_rmse": 0.6797
+      },
+      "Q3": {
+       "range": [
+        0.6574,
+        0.7561
+       ],
+       "n": 75,
+       "mean_rmse": 0.6814
+      },
+      "Q4": {
+       "range": [
+        0.7561,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6878
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8435
+       ],
+       "n": 75,
+       "mean_rmse": 0.6905
+      },
+      "Q2": {
+       "range": [
+        0.8435,
+        0.8827
+       ],
+       "n": 75,
+       "mean_rmse": 0.6807
+      },
+      "Q3": {
+       "range": [
+        0.8827,
+        0.9014
+       ],
+       "n": 75,
+       "mean_rmse": 0.6772
+      },
+      "Q4": {
+       "range": [
+        0.9014,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6836
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 584.0,
+    "holdout": {
+     "holdout_rmse": 0.6074681092037725,
+     "retrain_s": 0.6161,
+     "predict_s": 0.0025,
+     "cv_rmse_of_winner": 0.6678315805287544
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6653815476548155,
+    "rmse_p10": 0.6698337925550422,
+    "rmse_median": 0.6811843348850706,
+    "train_s_median": 1.745282945781946,
+    "train_s_mean": 1.9004636747489372,
+    "train_s_p90": 3.079594727680087,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.10157690413476499,
+     "num_leaves": 115,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.046654893020134e-07,
+     "lambda_l2": 0.04644190816935792,
+     "feature_fraction": 0.6501939156329917,
+     "bagging_fraction": 0.5356322185608697,
+     "bagging_freq": 7,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 7,
+     "mixture_balance_factor": 10,
+     "mixture_smoothing_lambda": 0.5353376585116068,
+     "mixture_diversity_lambda": 0.45332383340032095,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 22,
+     "mixture_gate_learning_rate": 0.011867631999197005,
+     "mixture_gate_lambda_l2": 0.012097406865608056,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 1.1737414308982894,
+     "mixture_expert_choice_boost": 15.492461017256375,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.29784618678132013,
+     "mixture_refit_every_n": 13,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.4715,
+     "lambda_l2": 0.2421,
+     "bagging_fraction": 0.1228,
+     "learning_rate": 0.0474,
+     "feature_fraction": 0.0236,
+     "extra_trees": 0.0213,
+     "mixture_routing_mode": 0.021,
+     "mixture_gate_type": 0.0205,
+     "mixture_diversity_lambda": 0.0118,
+     "mixture_e_step_mode": 0.0057,
+     "mixture_balance_factor": 0.0038,
+     "mixture_refit_leaves": 0.0018,
+     "mixture_init": 0.0016,
+     "max_depth": 0.0012,
+     "num_leaves": 0.0012,
+     "bagging_freq": 0.0008,
+     "mixture_r_smoothing": 0.0006,
+     "mixture_hard_m_step": 0.0004,
+     "min_data_in_leaf": 0.0004,
+     "mixture_warmup_iters": 0.0003,
+     "mixture_num_experts": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 61,
+        "mean": 0.8088,
+        "std": 0.4331,
+        "min": 0.6807
+       },
+       "none": {
+        "n": 19,
+        "mean": 0.8315,
+        "std": 0.3322,
+        "min": 0.6773
+       },
+       "gbdt": {
+        "n": 220,
+        "mean": 0.7246,
+        "std": 0.3894,
+        "min": 0.6654
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0842,
+       "p_value": 0.176782,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 75,
+        "mean": 0.8715,
+        "std": 0.707,
+        "min": 0.6793
+       },
+       "expert_choice": {
+        "n": 225,
+        "mean": 0.7075,
+        "std": 0.1929,
+        "min": 0.6654
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.164,
+       "p_value": 0.052222,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 35,
+        "mean": 0.8773,
+        "std": 0.5655,
+        "min": 0.6671
+       },
+       "gate_only": {
+        "n": 73,
+        "mean": 0.8381,
+        "std": 0.6762,
+        "min": 0.6778
+       },
+       "em": {
+        "n": 192,
+        "mean": 0.691,
+        "std": 0.0725,
+        "min": 0.6654
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.1471,
+       "p_value": 0.069626,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 57,
+        "mean": 0.7876,
+        "std": 0.4161,
+        "min": 0.6778
+       },
+       "gmm": {
+        "n": 181,
+        "mean": 0.7007,
+        "std": 0.1548,
+        "min": 0.6654
+       },
+       "tree_hierarchical": {
+        "n": 22,
+        "mean": 0.8105,
+        "std": 0.3192,
+        "min": 0.6716
+       },
+       "uniform": {
+        "n": 40,
+        "mean": 0.8751,
+        "std": 0.8618,
+        "min": 0.6749
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "random",
+       "delta_mean": 0.0869,
+       "p_value": 0.131062,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 219,
+        "mean": 0.7166,
+        "std": 0.3665,
+        "min": 0.6654
+       },
+       "markov": {
+        "n": 17,
+        "mean": 0.8173,
+        "std": 0.3133,
+        "min": 0.6772
+       },
+       "none": {
+        "n": 64,
+        "mean": 0.8394,
+        "std": 0.4916,
+        "min": 0.6793
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.1007,
+       "p_value": 0.23499,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 1.0219,
+        "std": 1.1252,
+        "min": 0.6819
+       },
+       "False": {
+        "n": 280,
+        "mean": 0.729,
+        "std": 0.2703,
+        "min": 0.6654
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2929,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 35,
+        "mean": 0.9315,
+        "std": 0.9142,
+        "min": 0.6908
+       },
+       "False": {
+        "n": 265,
+        "mean": 0.7243,
+        "std": 0.2518,
+        "min": 0.6654
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2072,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.7978
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 31,
+       "mean_rmse": 0.9018
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 218,
+       "mean_rmse": 0.7152
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0542
+       ],
+       "n": 75,
+       "mean_rmse": 0.6949
+      },
+      "Q2": {
+       "range": [
+        0.0542,
+        0.2419
+       ],
+       "n": 75,
+       "mean_rmse": 0.865
+      },
+      "Q3": {
+       "range": [
+        0.2419,
+        0.4667
+       ],
+       "n": 75,
+       "mean_rmse": 0.7316
+      },
+      "Q4": {
+       "range": [
+        0.4667,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.7026
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.7674
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 49,
+       "mean_rmse": 0.7498
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 109,
+       "mean_rmse": 0.6979
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.8025
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.7826
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.8806
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 185,
+       "mean_rmse": 0.7003
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0648
+       ],
+       "n": 75,
+       "mean_rmse": 0.7994
+      },
+      "Q2": {
+       "range": [
+        0.0648,
+        0.0858
+       ],
+       "n": 75,
+       "mean_rmse": 0.7987
+      },
+      "Q3": {
+       "range": [
+        0.0858,
+        0.1055
+       ],
+       "n": 75,
+       "mean_rmse": 0.6822
+      },
+      "Q4": {
+       "range": [
+        0.1055,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.7137
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        72.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.883
+      },
+      "Q2": {
+       "range": [
+        72.0,
+        110.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.7299
+      },
+      "Q3": {
+       "range": [
+        110.0,
+        116.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.6849
+      },
+      "Q4": {
+       "range": [
+        116.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.699
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.7715
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.6844
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 178,
+       "mean_rmse": 0.766
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.6827
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.7017
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        16.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6889
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.9111
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 2877.0,
+    "holdout": {
+     "holdout_rmse": 0.6015084927036235,
+     "retrain_s": 3.8504,
+     "predict_s": 0.016,
+     "cv_rmse_of_winner": 0.6653815476548155
+    }
+   }
+  },
+  "wine_quality@s43": {
+   "dataset": "wine_quality",
+   "seed": 43,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.824163139669103,
+    "std": 0.8714271981133532
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6630117003555592,
+    "rmse_p10": 0.6652916949856063,
+    "rmse_median": 0.6686034449229524,
+    "train_s_median": 0.44481988064944744,
+    "train_s_mean": 0.40660256770004827,
+    "train_s_p90": 0.6233668897673488,
+    "best_params": {
+     "learning_rate": 0.058292601472847656,
+     "num_leaves": 124,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.027838010330702843,
+     "lambda_l2": 1.6605084873834622e-05,
+     "feature_fraction": 0.5819151637052645,
+     "bagging_fraction": 0.6562093320646756,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4223,
+     "learning_rate": 0.413,
+     "min_data_in_leaf": 0.0794,
+     "bagging_freq": 0.0363,
+     "max_depth": 0.0185,
+     "feature_fraction": 0.0128,
+     "bagging_fraction": 0.0091,
+     "num_leaves": 0.0056,
+     "lambda_l1": 0.0021,
+     "lambda_l2": 0.0009
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.718,
+        "std": 0.0213,
+        "min": 0.6886
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.6728,
+        "std": 0.0112,
+        "min": 0.663
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0452,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0516
+       ],
+       "n": 75,
+       "mean_rmse": 0.6847
+      },
+      "Q2": {
+       "range": [
+        0.0516,
+        0.0598
+       ],
+       "n": 75,
+       "mean_rmse": 0.6711
+      },
+      "Q3": {
+       "range": [
+        0.0598,
+        0.0689
+       ],
+       "n": 75,
+       "mean_rmse": 0.6711
+      },
+      "Q4": {
+       "range": [
+        0.0689,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.677
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        98.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.6877
+      },
+      "Q2": {
+       "range": [
+        98.75,
+        116.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6725
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        123.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.6726
+      },
+      "Q4": {
+       "range": [
+        123.0,
+        null
+       ],
+       "n": 86,
+       "mean_rmse": 0.6714
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.6871
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.6741
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 147,
+       "mean_rmse": 0.6718
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.6692
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6715
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6725
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.6894
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0215
+       ],
+       "n": 75,
+       "mean_rmse": 0.6831
+      },
+      "Q2": {
+       "range": [
+        0.0215,
+        0.0733
+       ],
+       "n": 75,
+       "mean_rmse": 0.6735
+      },
+      "Q3": {
+       "range": [
+        0.0733,
+        0.1665
+       ],
+       "n": 75,
+       "mean_rmse": 0.6698
+      },
+      "Q4": {
+       "range": [
+        0.1665,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6776
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6754
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6693
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0018
+       ],
+       "n": 75,
+       "mean_rmse": 0.6759
+      },
+      "Q4": {
+       "range": [
+        0.0018,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6834
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5368
+       ],
+       "n": 75,
+       "mean_rmse": 0.6737
+      },
+      "Q2": {
+       "range": [
+        0.5368,
+        0.5666
+       ],
+       "n": 75,
+       "mean_rmse": 0.6716
+      },
+      "Q3": {
+       "range": [
+        0.5666,
+        0.5929
+       ],
+       "n": 75,
+       "mean_rmse": 0.672
+      },
+      "Q4": {
+       "range": [
+        0.5929,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6867
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6197
+       ],
+       "n": 75,
+       "mean_rmse": 0.6761
+      },
+      "Q2": {
+       "range": [
+        0.6197,
+        0.6535
+       ],
+       "n": 75,
+       "mean_rmse": 0.6727
+      },
+      "Q3": {
+       "range": [
+        0.6535,
+        0.6781
+       ],
+       "n": 75,
+       "mean_rmse": 0.6702
+      },
+      "Q4": {
+       "range": [
+        0.6781,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6851
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 618.3,
+    "holdout": {
+     "holdout_rmse": 0.6383110160230044,
+     "retrain_s": 0.7647,
+     "predict_s": 0.0027,
+     "cv_rmse_of_winner": 0.6630117003555592
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6585190750359627,
+    "rmse_p10": 0.6614234780521732,
+    "rmse_median": 0.6651333830011261,
+    "train_s_median": 2.0299491442739965,
+    "train_s_mean": 2.1656907765306532,
+    "train_s_p90": 3.0983865223824982,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.06559187265573739,
+     "num_leaves": 110,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 4.136071144025824e-05,
+     "lambda_l2": 2.6078653884037975e-07,
+     "feature_fraction": 0.5097899630322404,
+     "bagging_fraction": 0.596458933800273,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 37,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.8136084701067642,
+     "mixture_diversity_lambda": 0.040264198286883233,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 28,
+     "mixture_gate_learning_rate": 0.011822025058921343,
+     "mixture_gate_lambda_l2": 1.902266635230525,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 16,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "lambda_l1": 0.1907,
+     "lambda_l2": 0.0892,
+     "mixture_balance_factor": 0.0756,
+     "feature_fraction": 0.0752,
+     "bagging_freq": 0.0739,
+     "num_leaves": 0.072,
+     "mixture_e_step_mode": 0.0586,
+     "mixture_r_smoothing": 0.0403,
+     "bagging_fraction": 0.0384,
+     "min_data_in_leaf": 0.0379,
+     "learning_rate": 0.0372,
+     "mixture_init": 0.0365,
+     "mixture_diversity_lambda": 0.032,
+     "mixture_routing_mode": 0.0319,
+     "mixture_warmup_iters": 0.0317,
+     "mixture_gate_type": 0.0315,
+     "mixture_refit_leaves": 0.0272,
+     "mixture_num_experts": 0.0144,
+     "max_depth": 0.0034,
+     "extra_trees": 0.0013,
+     "mixture_hard_m_step": 0.001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 184,
+        "mean": 0.7325,
+        "std": 0.3607,
+        "min": 0.6604
+       },
+       "none": {
+        "n": 14,
+        "mean": 1.1653,
+        "std": 0.9351,
+        "min": 0.6649
+       },
+       "leaf_reuse": {
+        "n": 102,
+        "mean": 0.7753,
+        "std": 0.5394,
+        "min": 0.6585
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0428,
+       "p_value": 0.476299,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 191,
+        "mean": 0.7651,
+        "std": 0.4175,
+        "min": 0.6604
+       },
+       "token_choice": {
+        "n": 109,
+        "mean": 0.771,
+        "std": 0.5668,
+        "min": 0.6585
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0059,
+       "p_value": 0.925326,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 62,
+        "mean": 0.8214,
+        "std": 0.3769,
+        "min": 0.6618
+       },
+       "em": {
+        "n": 121,
+        "mean": 0.7249,
+        "std": 0.3105,
+        "min": 0.6585
+       },
+       "gate_only": {
+        "n": 117,
+        "mean": 0.7823,
+        "std": 0.6366,
+        "min": 0.6604
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0574,
+       "p_value": 0.382643,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 50,
+        "mean": 0.7977,
+        "std": 0.3599,
+        "min": 0.6627
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 0.9286,
+        "std": 0.4012,
+        "min": 0.6644
+       },
+       "random": {
+        "n": 14,
+        "mean": 1.2976,
+        "std": 1.4274,
+        "min": 0.6625
+       },
+       "uniform": {
+        "n": 222,
+        "mean": 0.7168,
+        "std": 0.3431,
+        "min": 0.6585
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "gmm",
+       "delta_mean": 0.0809,
+       "p_value": 0.1552,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 266,
+        "mean": 0.7259,
+        "std": 0.337,
+        "min": 0.6585
+       },
+       "none": {
+        "n": 18,
+        "mean": 1.0941,
+        "std": 0.8079,
+        "min": 0.6645
+       },
+       "markov": {
+        "n": 16,
+        "mean": 1.0867,
+        "std": 1.1816,
+        "min": 0.6628
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.3608,
+       "p_value": 0.256267,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 24,
+        "mean": 1.281,
+        "std": 1.1914,
+        "min": 0.6741
+       },
+       "False": {
+        "n": 276,
+        "mean": 0.7226,
+        "std": 0.3148,
+        "min": 0.6585
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5584,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 0.7668,
+        "std": 0.4912,
+        "min": 0.6585
+       },
+       "True": {
+        "n": 20,
+        "mean": 0.7731,
+        "std": 0.1928,
+        "min": 0.6922
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0063,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 11,
+       "mean_rmse": 0.9648
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 210,
+       "mean_rmse": 0.7582
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.7638
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0197
+       ],
+       "n": 75,
+       "mean_rmse": 0.7064
+      },
+      "Q2": {
+       "range": [
+        0.0197,
+        0.0463
+       ],
+       "n": 75,
+       "mean_rmse": 0.7033
+      },
+      "Q3": {
+       "range": [
+        0.0463,
+        0.1134
+       ],
+       "n": 75,
+       "mean_rmse": 0.6959
+      },
+      "Q4": {
+       "range": [
+        0.1134,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9634
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        37.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.9696
+      },
+      "Q2": {
+       "range": [
+        37.0,
+        41.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.6924
+      },
+      "Q3": {
+       "range": [
+        41.0,
+        44.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.7426
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 96,
+       "mean_rmse": 0.7101
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.854
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.7686
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 155,
+       "mean_rmse": 0.7319
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0547
+       ],
+       "n": 75,
+       "mean_rmse": 0.8116
+      },
+      "Q2": {
+       "range": [
+        0.0547,
+        0.0635
+       ],
+       "n": 75,
+       "mean_rmse": 0.6758
+      },
+      "Q3": {
+       "range": [
+        0.0635,
+        0.0777
+       ],
+       "n": 75,
+       "mean_rmse": 0.7286
+      },
+      "Q4": {
+       "range": [
+        0.0777,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8529
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        104.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.9249
+      },
+      "Q2": {
+       "range": [
+        104.75,
+        113.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.6775
+      },
+      "Q3": {
+       "range": [
+        113.0,
+        121.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.7161
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.7434
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.9853
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 52,
+       "mean_rmse": 0.7345
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 185,
+       "mean_rmse": 0.7022
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.6911
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.6941
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        16.0
+       ],
+       "n": 88,
+       "mean_rmse": 0.7334
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.9308
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 3274.9,
+    "holdout": {
+     "holdout_rmse": 0.6340967130575034,
+     "retrain_s": 1.7488,
+     "predict_s": 0.0186,
+     "cv_rmse_of_winner": 0.6585190750359627
+    }
+   }
+  },
+  "wine_quality@s44": {
+   "dataset": "wine_quality",
+   "seed": 44,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.82185455944594,
+    "std": 0.880623502625106
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6751723908916849,
+    "rmse_p10": 0.6789699648505451,
+    "rmse_median": 0.6836410835484472,
+    "train_s_median": 0.2606827476993203,
+    "train_s_mean": 0.23024267894526323,
+    "train_s_p90": 0.333184450417757,
+    "best_params": {
+     "learning_rate": 0.0587143485662275,
+     "num_leaves": 119,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.003573614893132869,
+     "lambda_l2": 0.0004758300725305213,
+     "feature_fraction": 0.550124632729228,
+     "bagging_fraction": 0.899924270649385,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4498,
+     "learning_rate": 0.1917,
+     "min_data_in_leaf": 0.0935,
+     "bagging_fraction": 0.0722,
+     "max_depth": 0.0712,
+     "lambda_l2": 0.0332,
+     "num_leaves": 0.0329,
+     "bagging_freq": 0.0232,
+     "feature_fraction": 0.0224,
+     "lambda_l1": 0.0098
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 277,
+        "mean": 0.6869,
+        "std": 0.0103,
+        "min": 0.6752
+       },
+       "True": {
+        "n": 23,
+        "mean": 0.7177,
+        "std": 0.0155,
+        "min": 0.6983
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0308,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0427
+       ],
+       "n": 75,
+       "mean_rmse": 0.6919
+      },
+      "Q2": {
+       "range": [
+        0.0427,
+        0.0494
+       ],
+       "n": 75,
+       "mean_rmse": 0.6861
+      },
+      "Q3": {
+       "range": [
+        0.0494,
+        0.0663
+       ],
+       "n": 75,
+       "mean_rmse": 0.6853
+      },
+      "Q4": {
+       "range": [
+        0.0663,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6937
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        110.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6991
+      },
+      "Q2": {
+       "range": [
+        110.0,
+        116.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.6865
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        121.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.6863
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.6856
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.698
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 167,
+       "mean_rmse": 0.6845
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.6934
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 145,
+       "mean_rmse": 0.6835
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6883
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.7004
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0057
+       ],
+       "n": 75,
+       "mean_rmse": 0.6947
+      },
+      "Q2": {
+       "range": [
+        0.0057,
+        0.027
+       ],
+       "n": 75,
+       "mean_rmse": 0.6862
+      },
+      "Q3": {
+       "range": [
+        0.027,
+        0.0871
+       ],
+       "n": 75,
+       "mean_rmse": 0.6849
+      },
+      "Q4": {
+       "range": [
+        0.0871,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6913
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6903
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6838
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.6869
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6962
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5384
+       ],
+       "n": 75,
+       "mean_rmse": 0.6873
+      },
+      "Q2": {
+       "range": [
+        0.5384,
+        0.5618
+       ],
+       "n": 75,
+       "mean_rmse": 0.6854
+      },
+      "Q3": {
+       "range": [
+        0.5618,
+        0.6006
+       ],
+       "n": 75,
+       "mean_rmse": 0.6856
+      },
+      "Q4": {
+       "range": [
+        0.6006,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6989
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8761
+       ],
+       "n": 75,
+       "mean_rmse": 0.7004
+      },
+      "Q2": {
+       "range": [
+        0.8761,
+        0.9024
+       ],
+       "n": 75,
+       "mean_rmse": 0.6865
+      },
+      "Q3": {
+       "range": [
+        0.9024,
+        0.9231
+       ],
+       "n": 75,
+       "mean_rmse": 0.6836
+      },
+      "Q4": {
+       "range": [
+        0.9231,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6866
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 352.5,
+    "holdout": {
+     "holdout_rmse": 0.6006148504583017,
+     "retrain_s": 0.4376,
+     "predict_s": 0.0025,
+     "cv_rmse_of_winner": 0.6751723908916849
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6760950823938833,
+    "rmse_p10": 0.67882933056352,
+    "rmse_median": 0.688235079021873,
+    "train_s_median": 1.5818313091993332,
+    "train_s_mean": 1.5236949710299572,
+    "train_s_p90": 2.767883487828077,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.06994659380646032,
+     "num_leaves": 110,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.0537515149645033e-05,
+     "lambda_l2": 0.17914004722512303,
+     "feature_fraction": 0.5358623200227534,
+     "bagging_fraction": 0.6601674193362713,
+     "bagging_freq": 0,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 44,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.7842434640869004,
+     "mixture_diversity_lambda": 0.434888425223704,
+     "mixture_hard_m_step": true,
+     "mixture_expert_capacity_factor": 1.03128368965763,
+     "mixture_expert_choice_boost": 29.495394687639152,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.46224617183117933,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "lambda_l2": 0.5783,
+     "lambda_l1": 0.0908,
+     "num_leaves": 0.0642,
+     "feature_fraction": 0.0512,
+     "learning_rate": 0.0495,
+     "bagging_fraction": 0.0364,
+     "extra_trees": 0.0258,
+     "mixture_balance_factor": 0.0211,
+     "mixture_init": 0.0168,
+     "mixture_warmup_iters": 0.0121,
+     "bagging_freq": 0.0114,
+     "mixture_gate_type": 0.0111,
+     "min_data_in_leaf": 0.0082,
+     "mixture_routing_mode": 0.008,
+     "mixture_diversity_lambda": 0.0056,
+     "mixture_hard_m_step": 0.0038,
+     "mixture_r_smoothing": 0.0021,
+     "mixture_refit_leaves": 0.0017,
+     "mixture_e_step_mode": 0.0014,
+     "mixture_num_experts": 0.0003,
+     "max_depth": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 40,
+        "mean": 0.9809,
+        "std": 0.7424,
+        "min": 0.6926
+       },
+       "none": {
+        "n": 234,
+        "mean": 0.8029,
+        "std": 0.5126,
+        "min": 0.6761
+       },
+       "leaf_reuse": {
+        "n": 26,
+        "mean": 1.1821,
+        "std": 1.1228,
+        "min": 0.6954
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 0.178,
+       "p_value": 0.156484,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 30,
+        "mean": 1.0692,
+        "std": 1.0596,
+        "min": 0.6935
+       },
+       "expert_choice": {
+        "n": 270,
+        "mean": 0.8362,
+        "std": 0.5617,
+        "min": 0.6761
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.233,
+       "p_value": 0.25226,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 89,
+        "mean": 0.9472,
+        "std": 0.7125,
+        "min": 0.6778
+       },
+       "em": {
+        "n": 173,
+        "mean": 0.8048,
+        "std": 0.5713,
+        "min": 0.6761
+       },
+       "loss_only": {
+        "n": 38,
+        "mean": 0.9031,
+        "std": 0.6772,
+        "min": 0.6817
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0983,
+       "p_value": 0.414738,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 46,
+        "mean": 0.9478,
+        "std": 0.7159,
+        "min": 0.6874
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 1.3785,
+        "std": 1.3204,
+        "min": 0.6822
+       },
+       "random": {
+        "n": 90,
+        "mean": 0.8608,
+        "std": 0.572,
+        "min": 0.6778
+       },
+       "gmm": {
+        "n": 150,
+        "mean": 0.7832,
+        "std": 0.5027,
+        "min": 0.6761
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "random",
+       "delta_mean": 0.0776,
+       "p_value": 0.291595,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 16,
+        "mean": 0.9509,
+        "std": 0.8024,
+        "min": 0.7029
+       },
+       "ema": {
+        "n": 51,
+        "mean": 1.1023,
+        "std": 1.0342,
+        "min": 0.6926
+       },
+       "markov": {
+        "n": 233,
+        "mean": 0.8001,
+        "std": 0.4703,
+        "min": 0.6761
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.1508,
+       "p_value": 0.481938,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 273,
+        "mean": 0.8276,
+        "std": 0.5651,
+        "min": 0.6761
+       },
+       "False": {
+        "n": 27,
+        "mean": 1.1816,
+        "std": 1.0554,
+        "min": 0.685
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.354,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 1.0759,
+        "std": 0.7125,
+        "min": 0.7026
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.8424,
+        "std": 0.6235,
+        "min": 0.6761
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2335,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 0.8595
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3288
+       ],
+       "n": 75,
+       "mean_rmse": 1.0737
+      },
+      "Q2": {
+       "range": [
+        0.3288,
+        0.426
+       ],
+       "n": 75,
+       "mean_rmse": 0.8117
+      },
+      "Q3": {
+       "range": [
+        0.426,
+        0.4508
+       ],
+       "n": 75,
+       "mean_rmse": 0.7294
+      },
+      "Q4": {
+       "range": [
+        0.4508,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8232
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8646
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        34.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.9662
+      },
+      "Q3": {
+       "range": [
+        34.0,
+        43.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.8149
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.7923
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 43,
+       "mean_rmse": 1.1061
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        6.0
+       ],
+       "n": 141,
+       "mean_rmse": 0.8189
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 116,
+       "mean_rmse": 0.8174
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0713
+       ],
+       "n": 75,
+       "mean_rmse": 0.8688
+      },
+      "Q2": {
+       "range": [
+        0.0713,
+        0.0858
+       ],
+       "n": 75,
+       "mean_rmse": 0.8084
+      },
+      "Q3": {
+       "range": [
+        0.0858,
+        0.1361
+       ],
+       "n": 75,
+       "mean_rmse": 0.9412
+      },
+      "Q4": {
+       "range": [
+        0.1361,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8196
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        105.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.9926
+      },
+      "Q2": {
+       "range": [
+        105.75,
+        114.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.8432
+      },
+      "Q3": {
+       "range": [
+        114.0,
+        120.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.8403
+      },
+      "Q4": {
+       "range": [
+        120.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.7629
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 73,
+       "mean_rmse": 1.0863
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 59,
+       "mean_rmse": 0.8232
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 168,
+       "mean_rmse": 0.7737
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.7693
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.8086
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        19.25
+       ],
+       "n": 86,
+       "mean_rmse": 0.8491
+      },
+      "Q4": {
+       "range": [
+        19.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 1.0034
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 2298.9,
+    "holdout": {
+     "holdout_rmse": 0.6115934104088393,
+     "retrain_s": 2.4428,
+     "predict_s": 0.0048,
+     "cv_rmse_of_winner": 0.6760950823938833
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_cpu_act_ensemble_report.md
+++ b/bench_results/meth2_v081/ds_cpu_act_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['cpu_act'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| cpu_act | naive-ensemble | **2.41869** ± 0.28385 | 2.41602 | 0.0% | 0.38 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| cpu_act@s42 | naive-ensemble | 2.4889 | 2.5477 | 0.435 | 702 |
+| cpu_act@s43 | naive-ensemble | 2.3073 | 2.3422 | 0.426 | 653 |
+| cpu_act@s44 | naive-ensemble | 2.4518 | 2.5092 | 0.308 | 482 |
+
+
+
+---
+
+## cpu_act@s42  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.17111** (winner retrained in 0.31s, cv score of winner: 2.4889)
+- cv best RMSE: 2.4889, median: 2.5477, p10: 2.5078
+- train: median 0.435s/fold, mean 0.465s, p90 0.669s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.521 |
+| `min_data_in_leaf` | 0.344 |
+| `extra_trees` | 0.072 |
+| `feature_fraction` | 0.019 |
+| `num_leaves` | 0.018 |
+| `n_models` | 0.018 |
+| `bagging_fraction` | 0.004 |
+| `max_depth` | 0.003 |
+| `bagging_freq` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7304 | 0.7005 | 2.4889 |
+| True | 20 | 4.3699 | 2.0869 | 3.0027 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.3423 | 2.6228 | 2.7259 | 2.6678 | **Q2** [0.1142, 0.1418] |
+| `num_leaves` | 2.6300 | 2.7092 | 2.7932 | 3.2001 | **Q1** [None, 18.0] |
+| `max_depth` | 3.1646 | 2.9631 | 2.7677 | 2.6904 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | — | 2.5932 | 2.7208 | 3.3845 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 3.0472 | 2.6804 | 2.6948 | 2.9363 | **Q2** [0.0003, 0.0009] |
+| `lambda_l2` | 3.2172 | 2.7150 | 2.7123 | 2.7144 | **Q3** [0.0196, 0.0608] |
+| `feature_fraction` | 2.8681 | 2.6691 | 2.6433 | 3.1783 | **Q3** [0.6534, 0.6944] |
+| `bagging_fraction` | 2.6581 | 2.8491 | 2.7085 | 3.1431 | **Q1** [None, 0.5274] |
+
+#### E. Slice plot
+
+![cpu_act@s42/naive-ensemble](slice_cpu_act@s42_naive-ensemble.png)
+
+
+---
+
+## cpu_act@s43  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.81612** (winner retrained in 0.46s, cv score of winner: 2.3073)
+- cv best RMSE: 2.3073, median: 2.3422, p10: 2.3200
+- train: median 0.426s/fold, mean 0.432s, p90 0.597s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.647 |
+| `learning_rate` | 0.245 |
+| `num_leaves` | 0.034 |
+| `extra_trees` | 0.024 |
+| `n_models` | 0.017 |
+| `bagging_fraction` | 0.010 |
+| `feature_fraction` | 0.010 |
+| `bagging_freq` | 0.007 |
+| `max_depth` | 0.005 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 2.4998 | 0.5775 | 2.3073 |
+| True | 22 | 4.0691 | 1.8553 | 2.6196 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.0647 | 2.3818 | 2.4427 | 2.5704 | **Q2** [0.1464, 0.1718] |
+| `num_leaves` | 2.5938 | 2.4571 | 2.4348 | 2.9509 | **Q3** [41.0, 47.0] |
+| `max_depth` | 2.8272 | — | 2.4980 | 2.7838 | **Q3** [5.0, 6.0] |
+| `min_data_in_leaf` | 2.3959 | 2.3641 | 2.4158 | 3.2625 | **Q2** [6.0, 8.0] |
+| `lambda_l1` | 2.4488 | 2.4472 | 2.7096 | 2.8539 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 2.6984 | 2.4899 | 2.5132 | 2.7581 | **Q2** [0.0, 0.0004] |
+| `feature_fraction` | 3.1242 | 2.4031 | 2.4788 | 2.4535 | **Q2** [0.9266, 0.9606] |
+| `bagging_fraction` | 3.0158 | 2.4907 | 2.4218 | 2.5313 | **Q3** [0.8868, 0.9196] |
+
+#### E. Slice plot
+
+![cpu_act@s43/naive-ensemble](slice_cpu_act@s43_naive-ensemble.png)
+
+
+---
+
+## cpu_act@s44  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.26882** (winner retrained in 0.36s, cv score of winner: 2.4518)
+- cv best RMSE: 2.4518, median: 2.5092, p10: 2.4700
+- train: median 0.308s/fold, mean 0.318s, p90 0.455s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.439 |
+| `min_data_in_leaf` | 0.352 |
+| `bagging_freq` | 0.086 |
+| `num_leaves` | 0.051 |
+| `extra_trees` | 0.026 |
+| `bagging_fraction` | 0.019 |
+| `feature_fraction` | 0.012 |
+| `max_depth` | 0.006 |
+| `lambda_l2` | 0.004 |
+| `n_models` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 265 | 2.7034 | 0.6832 | 2.4518 |
+| True | 35 | 3.6304 | 1.2635 | 2.8613 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.4669 | 2.6311 | 2.5181 | 2.6301 | **Q3** [0.2026, 0.2344] |
+| `num_leaves` | 2.6019 | 2.5750 | 2.7753 | 3.2725 | **Q2** [16.0, 21.0] |
+| `max_depth` | 3.3737 | 2.7165 | 2.6298 | 2.6565 | **Q3** [11.0, 12.0] |
+| `min_data_in_leaf` | — | 2.5512 | 2.5989 | 3.5000 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 3.2911 | 2.6336 | 2.7083 | 2.6131 | **Q4** [1.3908, ∞) |
+| `lambda_l2` | 2.9047 | 2.7957 | 2.7870 | 2.7589 | **Q4** [0.0954, ∞) |
+| `feature_fraction` | 2.7702 | 2.7246 | 2.8473 | 2.9041 | **Q2** [0.6905, 0.7326] |
+| `bagging_fraction` | 2.7722 | 2.6339 | 2.6351 | 3.2050 | **Q2** [0.7154, 0.7443] |
+
+#### E. Slice plot
+
+![cpu_act@s44/naive-ensemble](slice_cpu_act@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v081/ds_cpu_act_ensemble_summary.json
+++ b/bench_results/meth2_v081/ds_cpu_act_ensemble_summary.json
@@ -1,0 +1,1169 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "cpu_act"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "cpu_act": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.1711093742397867,
+      "cv_best": 2.4889363218100486,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3089
+     },
+     "43": {
+      "holdout_rmse": 2.8161245771803296,
+      "cv_best": 2.307282493869447,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4597
+     },
+     "44": {
+      "holdout_rmse": 2.2688229536151376,
+      "cv_best": 2.4518369742987334,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3586
+     }
+    },
+    "holdout_mean": 2.418686,
+    "holdout_std": 0.283849,
+    "cv_best_mean": 2.416019
+   }
+  }
+ },
+ "runs": {
+  "cpu_act@s42": {
+   "dataset": "cpu_act",
+   "seed": 42,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 83.92462618248398,
+    "std": 18.493954695764945
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4889363218100486,
+    "rmse_p10": 2.507758109397158,
+    "rmse_median": 2.5476550597160186,
+    "train_s_median": 0.4347722278907895,
+    "train_s_mean": 0.4650754499658943,
+    "train_s_p90": 0.6685124038532377,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.2065603603719714,
+     "num_leaves": 14,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0018856062706660913,
+     "lambda_l2": 0.0024442915675220315,
+     "feature_fraction": 0.6551346699251709,
+     "bagging_fraction": 0.8081626931526306,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5207,
+     "min_data_in_leaf": 0.3436,
+     "extra_trees": 0.0723,
+     "feature_fraction": 0.019,
+     "num_leaves": 0.0179,
+     "n_models": 0.0176,
+     "bagging_fraction": 0.0045,
+     "max_depth": 0.0029,
+     "bagging_freq": 0.0013,
+     "lambda_l1": 0.0002,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7304,
+        "std": 0.7005,
+        "min": 2.4889
+       },
+       "True": {
+        "n": 20,
+        "mean": 4.3699,
+        "std": 2.0869,
+        "min": 3.0027
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.6395,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1142
+       ],
+       "n": 75,
+       "mean_rmse": 3.3423
+      },
+      "Q2": {
+       "range": [
+        0.1142,
+        0.1418
+       ],
+       "n": 75,
+       "mean_rmse": 2.6228
+      },
+      "Q3": {
+       "range": [
+        0.1418,
+        0.1712
+       ],
+       "n": 75,
+       "mean_rmse": 2.7259
+      },
+      "Q4": {
+       "range": [
+        0.1712,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6678
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.63
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        23.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7092
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        38.5
+       ],
+       "n": 88,
+       "mean_rmse": 2.7932
+      },
+      "Q4": {
+       "range": [
+        38.5,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.2001
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 53,
+       "mean_rmse": 3.1646
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 42,
+       "mean_rmse": 2.9631
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 106,
+       "mean_rmse": 2.7677
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 99,
+       "mean_rmse": 2.6904
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 147,
+       "mean_rmse": 2.5932
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.7208
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 3.3845
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 3.0472
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0009
+       ],
+       "n": 75,
+       "mean_rmse": 2.6804
+      },
+      "Q3": {
+       "range": [
+        0.0009,
+        0.0043
+       ],
+       "n": 75,
+       "mean_rmse": 2.6948
+      },
+      "Q4": {
+       "range": [
+        0.0043,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9363
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0048
+       ],
+       "n": 75,
+       "mean_rmse": 3.2172
+      },
+      "Q2": {
+       "range": [
+        0.0048,
+        0.0196
+       ],
+       "n": 75,
+       "mean_rmse": 2.715
+      },
+      "Q3": {
+       "range": [
+        0.0196,
+        0.0608
+       ],
+       "n": 75,
+       "mean_rmse": 2.7123
+      },
+      "Q4": {
+       "range": [
+        0.0608,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7144
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6338
+       ],
+       "n": 75,
+       "mean_rmse": 2.8681
+      },
+      "Q2": {
+       "range": [
+        0.6338,
+        0.6534
+       ],
+       "n": 75,
+       "mean_rmse": 2.6691
+      },
+      "Q3": {
+       "range": [
+        0.6534,
+        0.6944
+       ],
+       "n": 75,
+       "mean_rmse": 2.6433
+      },
+      "Q4": {
+       "range": [
+        0.6944,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.1783
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5274
+       ],
+       "n": 75,
+       "mean_rmse": 2.6581
+      },
+      "Q2": {
+       "range": [
+        0.5274,
+        0.5477
+       ],
+       "n": 75,
+       "mean_rmse": 2.8491
+      },
+      "Q3": {
+       "range": [
+        0.5477,
+        0.6571
+       ],
+       "n": 75,
+       "mean_rmse": 2.7085
+      },
+      "Q4": {
+       "range": [
+        0.6571,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.1431
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 702.2,
+    "holdout": {
+     "holdout_rmse": 2.1711093742397867,
+     "retrain_s": 0.3089,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.4889363218100486
+    }
+   }
+  },
+  "cpu_act@s43": {
+   "dataset": "cpu_act",
+   "seed": 43,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.04531583765639,
+    "std": 18.208031997815638
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.307282493869447,
+    "rmse_p10": 2.320010654048009,
+    "rmse_median": 2.34219909432686,
+    "train_s_median": 0.42557090558111665,
+    "train_s_mean": 0.4322421912414332,
+    "train_s_p90": 0.5969568053260448,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.2669279386694621,
+     "num_leaves": 24,
+     "max_depth": 6,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0014682557728019799,
+     "lambda_l2": 0.05756351597757317,
+     "feature_fraction": 0.8948285025960593,
+     "bagging_fraction": 0.8259423866954796,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.647,
+     "learning_rate": 0.2451,
+     "num_leaves": 0.0344,
+     "extra_trees": 0.0236,
+     "n_models": 0.0165,
+     "bagging_fraction": 0.0104,
+     "feature_fraction": 0.0098,
+     "bagging_freq": 0.0074,
+     "max_depth": 0.0049,
+     "lambda_l2": 0.0006,
+     "lambda_l1": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 2.4998,
+        "std": 0.5775,
+        "min": 2.3073
+       },
+       "True": {
+        "n": 22,
+        "mean": 4.0691,
+        "std": 1.8553,
+        "min": 2.6196
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.5693,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1464
+       ],
+       "n": 75,
+       "mean_rmse": 3.0647
+      },
+      "Q2": {
+       "range": [
+        0.1464,
+        0.1718
+       ],
+       "n": 75,
+       "mean_rmse": 2.3818
+      },
+      "Q3": {
+       "range": [
+        0.1718,
+        0.2033
+       ],
+       "n": 75,
+       "mean_rmse": 2.4427
+      },
+      "Q4": {
+       "range": [
+        0.2033,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.5704
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.5938
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        41.0
+       ],
+       "n": 67,
+       "mean_rmse": 2.4571
+      },
+      "Q3": {
+       "range": [
+        41.0,
+        47.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.4348
+      },
+      "Q4": {
+       "range": [
+        47.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.9509
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 31,
+       "mean_rmse": 2.8272
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 182,
+       "mean_rmse": 2.498
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 2.7838
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.3959
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 2.3641
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 91,
+       "mean_rmse": 2.4158
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 3.2625
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.4488
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.4472
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 2.7096
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8539
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6984
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 2.4899
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.004
+       ],
+       "n": 75,
+       "mean_rmse": 2.5132
+      },
+      "Q4": {
+       "range": [
+        0.004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7581
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9266
+       ],
+       "n": 75,
+       "mean_rmse": 3.1242
+      },
+      "Q2": {
+       "range": [
+        0.9266,
+        0.9606
+       ],
+       "n": 75,
+       "mean_rmse": 2.4031
+      },
+      "Q3": {
+       "range": [
+        0.9606,
+        0.9792
+       ],
+       "n": 75,
+       "mean_rmse": 2.4788
+      },
+      "Q4": {
+       "range": [
+        0.9792,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.4535
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8527
+       ],
+       "n": 75,
+       "mean_rmse": 3.0158
+      },
+      "Q2": {
+       "range": [
+        0.8527,
+        0.8868
+       ],
+       "n": 75,
+       "mean_rmse": 2.4907
+      },
+      "Q3": {
+       "range": [
+        0.8868,
+        0.9196
+       ],
+       "n": 75,
+       "mean_rmse": 2.4218
+      },
+      "Q4": {
+       "range": [
+        0.9196,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.5313
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 653.1,
+    "holdout": {
+     "holdout_rmse": 2.8161245771803296,
+     "retrain_s": 0.4597,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.307282493869447
+    }
+   }
+  },
+  "cpu_act@s44": {
+   "dataset": "cpu_act",
+   "seed": 44,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.05965822398535,
+    "std": 18.44113958458848
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4518369742987334,
+    "rmse_p10": 2.469971441533434,
+    "rmse_median": 2.509207272293965,
+    "train_s_median": 0.3077383372932673,
+    "train_s_mean": 0.3180702139387528,
+    "train_s_p90": 0.4554103063419462,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.2348424332394314,
+     "num_leaves": 17,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.10034879307541866,
+     "lambda_l2": 0.00777132719071447,
+     "feature_fraction": 0.6809753291566247,
+     "bagging_fraction": 0.7452228055815161,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.4394,
+     "min_data_in_leaf": 0.3522,
+     "bagging_freq": 0.086,
+     "num_leaves": 0.0505,
+     "extra_trees": 0.0265,
+     "bagging_fraction": 0.0186,
+     "feature_fraction": 0.0124,
+     "max_depth": 0.0061,
+     "lambda_l2": 0.0039,
+     "n_models": 0.0027,
+     "lambda_l1": 0.0016
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 35,
+        "mean": 3.6304,
+        "std": 1.2635,
+        "min": 2.8613
+       },
+       "False": {
+        "n": 265,
+        "mean": 2.7034,
+        "std": 0.6832,
+        "min": 2.4518
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.927,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1375
+       ],
+       "n": 75,
+       "mean_rmse": 3.4669
+      },
+      "Q2": {
+       "range": [
+        0.1375,
+        0.2026
+       ],
+       "n": 75,
+       "mean_rmse": 2.6311
+      },
+      "Q3": {
+       "range": [
+        0.2026,
+        0.2344
+       ],
+       "n": 75,
+       "mean_rmse": 2.5181
+      },
+      "Q4": {
+       "range": [
+        0.2344,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6301
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.6019
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        21.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.575
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        47.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.7753
+      },
+      "Q4": {
+       "range": [
+        47.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.2725
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 3.3737
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.7165
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 65,
+       "mean_rmse": 2.6298
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 110,
+       "mean_rmse": 2.6565
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 136,
+       "mean_rmse": 2.5512
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        14.0
+       ],
+       "n": 86,
+       "mean_rmse": 2.5989
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 3.5
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0211
+       ],
+       "n": 75,
+       "mean_rmse": 3.2911
+      },
+      "Q2": {
+       "range": [
+        0.0211,
+        0.269
+       ],
+       "n": 75,
+       "mean_rmse": 2.6336
+      },
+      "Q3": {
+       "range": [
+        0.269,
+        1.3908
+       ],
+       "n": 75,
+       "mean_rmse": 2.7083
+      },
+      "Q4": {
+       "range": [
+        1.3908,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6131
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 2.9047
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0049
+       ],
+       "n": 75,
+       "mean_rmse": 2.7957
+      },
+      "Q3": {
+       "range": [
+        0.0049,
+        0.0954
+       ],
+       "n": 75,
+       "mean_rmse": 2.787
+      },
+      "Q4": {
+       "range": [
+        0.0954,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7589
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6905
+       ],
+       "n": 75,
+       "mean_rmse": 2.7702
+      },
+      "Q2": {
+       "range": [
+        0.6905,
+        0.7326
+       ],
+       "n": 75,
+       "mean_rmse": 2.7246
+      },
+      "Q3": {
+       "range": [
+        0.7326,
+        0.8705
+       ],
+       "n": 75,
+       "mean_rmse": 2.8473
+      },
+      "Q4": {
+       "range": [
+        0.8705,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9041
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7154
+       ],
+       "n": 75,
+       "mean_rmse": 2.7722
+      },
+      "Q2": {
+       "range": [
+        0.7154,
+        0.7443
+       ],
+       "n": 75,
+       "mean_rmse": 2.6339
+      },
+      "Q3": {
+       "range": [
+        0.7443,
+        0.7803
+       ],
+       "n": 75,
+       "mean_rmse": 2.6351
+      },
+      "Q4": {
+       "range": [
+        0.7803,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.205
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 481.6,
+    "holdout": {
+     "holdout_rmse": 2.2688229536151376,
+     "retrain_s": 0.3586,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.4518369742987334
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_cpu_act_report.md
+++ b/bench_results/meth2_v081/ds_cpu_act_report.md
@@ -1,0 +1,501 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['cpu_act'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| cpu_act | naive-lightgbm | **2.51321** ± 0.31795 | 2.45180 | 0.0% | 0.22 |
+| cpu_act | moe | **2.42513** ± 0.28908 | 2.40656 | 0.0% | 2.28 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| cpu_act@s42 | naive-lightgbm | 2.5168 | 2.5887 | 0.161 | 264 |
+| cpu_act@s42 | moe | 2.4623 | 2.6068 | 0.906 | 1824 |
+| cpu_act@s43 | naive-lightgbm | 2.3606 | 2.4179 | 0.210 | 326 |
+| cpu_act@s43 | moe | 2.3140 | 2.4026 | 0.790 | 1257 |
+| cpu_act@s44 | naive-lightgbm | 2.4780 | 2.5416 | 0.165 | 258 |
+| cpu_act@s44 | moe | 2.4434 | 2.5061 | 2.418 | 3314 |
+
+
+
+---
+
+## cpu_act@s42  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.30096** (winner retrained in 0.13s, cv score of winner: 2.5168)
+- cv best RMSE: 2.5168, median: 2.5887, p10: 2.5383
+- train: median 0.161s/fold, mean 0.171s, p90 0.222s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.541 |
+| `min_data_in_leaf` | 0.225 |
+| `extra_trees` | 0.131 |
+| `feature_fraction` | 0.063 |
+| `max_depth` | 0.016 |
+| `num_leaves` | 0.013 |
+| `bagging_freq` | 0.005 |
+| `bagging_fraction` | 0.004 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 2.7237 | 0.5702 | 2.5168 |
+| True | 22 | 5.1620 | 2.8843 | 2.9974 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.5242 | 2.5987 | 2.6638 | 2.8232 | **Q2** [0.0878, 0.1015] |
+| `num_leaves` | 2.7932 | 2.6426 | 2.7366 | 3.4317 | **Q2** [17.0, 22.0] |
+| `max_depth` | 3.5982 | 2.7181 | — | 2.6996 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.8011 | 2.5874 | 2.6193 | 3.6265 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 3.1783 | 3.0481 | 2.5990 | 2.7845 | **Q3** [0.101, 0.2619] |
+| `lambda_l2` | 2.7125 | 2.6434 | 2.9249 | 3.3292 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 3.3781 | 2.7630 | 2.6453 | 2.8235 | **Q3** [0.86, 0.8808] |
+| `bagging_fraction` | 2.8270 | 2.6803 | 3.2550 | 2.8477 | **Q2** [0.5773, 0.6504] |
+
+#### E. Slice plot
+
+![cpu_act@s42/naive-lightgbm](slice_cpu_act@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.23920** (winner retrained in 2.64s, cv score of winner: 2.4623)
+- cv best RMSE: 2.4623, median: 2.6068, p10: 2.4914
+- train: median 0.906s/fold, mean 1.198s, p90 2.208s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.515 |
+| `extra_trees` | 0.135 |
+| `mixture_diversity_lambda` | 0.121 |
+| `min_data_in_leaf` | 0.072 |
+| `bagging_fraction` | 0.047 |
+| `lambda_l2` | 0.039 |
+| `bagging_freq` | 0.020 |
+| `mixture_warmup_iters` | 0.012 |
+| `mixture_balance_factor` | 0.010 |
+| `feature_fraction` | 0.007 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 244 | 3.3111 | 3.4651 | 2.4623 |
+| gbdt | 30 | 4.9927 | 6.1027 | 2.5034 |
+| none | 26 | 5.4331 | 5.2738 | 2.5866 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 245 | 3.4384 | 3.8126 | 2.4623 |
+| token_choice | 55 | 4.6642 | 4.8731 | 2.5857 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 170 | 3.4655 | 3.8109 | 2.4623 |
+| gate_only | 89 | 3.8502 | 4.6786 | 2.5653 |
+| loss_only | 41 | 4.0769 | 3.4958 | 2.4695 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 222 | 3.2678 | 3.7413 | 2.4623 |
+| tree_hierarchical | 40 | 4.0216 | 3.0899 | 2.6258 |
+| random | 16 | 4.6633 | 4.1256 | 2.7618 |
+| gmm | 22 | 6.2741 | 6.6315 | 3.1499 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 220 | 3.3916 | 3.8205 | 2.4623 |
+| markov | 63 | 4.0205 | 3.7580 | 2.5857 |
+| none | 17 | 5.8528 | 6.5449 | 2.5945 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 240 | 3.4968 | 3.9023 | 2.4623 |
+| True | 60 | 4.3285 | 4.5588 | 2.5857 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 265 | 3.2792 | 3.3358 | 2.4623 |
+| True | 35 | 6.5701 | 6.8687 | 3.0286 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 4.1098 | — | 3.3485 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 4.3804 | 2.7317 | 3.4674 | 4.0732 | **Q2** [0.1238, 0.1661] |
+| `mixture_warmup_iters` | 3.5492 | 3.5419 | 4.1139 | 3.4743 | **Q4** [41.0, ∞) |
+| `mixture_balance_factor` | — | 3.2420 | 3.6335 | 4.1217 | **Q2** [2.0, 3.0] |
+| `learning_rate` | 6.0818 | 2.7104 | 2.7357 | 3.1248 | **Q2** [0.1558, 0.1887] |
+| `num_leaves` | 3.8267 | 4.0646 | 3.6768 | 3.0865 | **Q4** [92.25, ∞) |
+| `max_depth` | 3.6810 | 3.1338 | — | 3.7775 | **Q2** [5.0, 6.0] |
+| `min_data_in_leaf` | 3.5808 | 2.9696 | 2.7862 | 5.5393 | **Q3** [11.0, 19.0] |
+
+#### E. Slice plot
+
+![cpu_act@s42/moe](slice_cpu_act@s42_moe.png)
+
+
+---
+
+## cpu_act@s43  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.96263** (winner retrained in 0.35s, cv score of winner: 2.3606)
+- cv best RMSE: 2.3606, median: 2.4179, p10: 2.3767
+- train: median 0.210s/fold, mean 0.212s, p90 0.290s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.545 |
+| `learning_rate` | 0.327 |
+| `extra_trees` | 0.047 |
+| `num_leaves` | 0.030 |
+| `bagging_fraction` | 0.025 |
+| `feature_fraction` | 0.017 |
+| `bagging_freq` | 0.004 |
+| `max_depth` | 0.003 |
+| `lambda_l1` | 0.002 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.6156 | 0.7424 | 2.3606 |
+| True | 21 | 3.9526 | 1.4165 | 2.8650 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.0578 | 2.5427 | 2.6238 | 2.6125 | **Q2** [0.0635, 0.0793] |
+| `num_leaves` | 2.6429 | 2.5224 | 2.5676 | 3.0855 | **Q2** [20.0, 26.0] |
+| `max_depth` | 3.0309 | 2.5906 | 2.5758 | 2.6500 | **Q3** [10.0, 11.0] |
+| `min_data_in_leaf` | 2.4133 | 2.5333 | 2.4333 | 3.4038 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.5531 | 2.6273 | 2.9238 | 2.7327 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.7548 | 2.5349 | 2.6795 | 2.8676 | **Q2** [0.0001, 0.009] |
+| `feature_fraction` | 2.8955 | 2.6856 | 2.7271 | 2.5286 | **Q4** [0.9543, ∞) |
+| `bagging_fraction` | 2.7772 | 2.7105 | 2.6495 | 2.6996 | **Q3** [0.7722, 0.8744] |
+
+#### E. Slice plot
+
+![cpu_act@s43/naive-lightgbm](slice_cpu_act@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.83340** (winner retrained in 1.05s, cv score of winner: 2.3140)
+- cv best RMSE: 2.3140, median: 2.4026, p10: 2.3413
+- train: median 0.790s/fold, mean 0.824s, p90 1.181s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.468 |
+| `learning_rate` | 0.261 |
+| `mixture_hard_m_step` | 0.228 |
+| `mixture_diversity_lambda` | 0.008 |
+| `num_leaves` | 0.008 |
+| `mixture_refit_leaves` | 0.006 |
+| `bagging_freq` | 0.005 |
+| `mixture_e_step_mode` | 0.004 |
+| `bagging_fraction` | 0.004 |
+| `mixture_init` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 266 | 3.1136 | 3.0107 | 2.3140 |
+| gbdt | 18 | 4.0626 | 2.1326 | 2.3721 |
+| none | 16 | 15.4928 | 13.0750 | 4.7629 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 280 | 3.6877 | 4.9211 | 2.3140 |
+| expert_choice | 20 | 5.8327 | 5.8111 | 2.5741 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 265 | 3.4971 | 4.6327 | 2.3140 |
+| em | 17 | 6.2459 | 7.4159 | 2.5857 |
+| loss_only | 18 | 6.4621 | 6.0853 | 2.5913 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 231 | 3.5989 | 4.8006 | 2.3140 |
+| uniform | 38 | 3.7280 | 2.8564 | 2.3278 |
+| tree_hierarchical | 16 | 5.2546 | 6.4304 | 2.4897 |
+| random | 15 | 6.1423 | 8.6471 | 2.4511 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 79 | 3.5600 | 2.7358 | 2.3140 |
+| none | 206 | 3.9046 | 5.7009 | 2.3206 |
+| ema | 15 | 4.2423 | 4.0513 | 2.3676 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 274 | 3.5558 | 3.9941 | 2.3140 |
+| False | 26 | 6.7286 | 10.6191 | 2.3278 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 3.7673 | 5.1621 | 2.3140 |
+| True | 22 | 4.6324 | 2.3235 | 2.8686 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 3.8307 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 3.3907 | 2.9584 | 3.8226 | 5.1513 | **Q2** [0.152, 0.1788] |
+| `mixture_warmup_iters` | 4.0415 | 3.2335 | 3.9730 | 4.0709 | **Q2** [24.75, 28.5] |
+| `mixture_balance_factor` | 5.8107 | 3.3543 | — | 3.3847 | **Q2** [5.0, 6.0] |
+| `learning_rate` | 5.6853 | 3.3653 | 2.7831 | 3.4892 | **Q3** [0.116, 0.1365] |
+| `num_leaves` | 3.5355 | 3.6885 | 3.3865 | 4.7285 | **Q3** [32.0, 40.25] |
+| `max_depth` | 3.9140 | — | — | 3.8049 | **Q4** [8.0, ∞) |
+| `min_data_in_leaf` | 2.7071 | 3.3078 | 3.8189 | 5.2091 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![cpu_act@s43/moe](slice_cpu_act@s43_moe.png)
+
+
+---
+
+## cpu_act@s44  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.27606** (winner retrained in 0.17s, cv score of winner: 2.4780)
+- cv best RMSE: 2.4780, median: 2.5416, p10: 2.5063
+- train: median 0.165s/fold, mean 0.167s, p90 0.220s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.525 |
+| `learning_rate` | 0.251 |
+| `extra_trees` | 0.116 |
+| `feature_fraction` | 0.052 |
+| `num_leaves` | 0.030 |
+| `bagging_freq` | 0.008 |
+| `max_depth` | 0.008 |
+| `bagging_fraction` | 0.007 |
+| `lambda_l2` | 0.003 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7136 | 0.6089 | 2.4780 |
+| True | 20 | 3.8921 | 1.1427 | 2.8796 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.1451 | 2.5864 | 2.6362 | 2.8009 | **Q2** [0.0864, 0.0971] |
+| `num_leaves` | 2.6861 | 2.6349 | 2.6778 | 3.1672 | **Q2** [19.0, 23.0] |
+| `max_depth` | 2.9955 | 2.8130 | — | 2.7386 | **Q4** [7.0, ∞) |
+| `min_data_in_leaf` | 2.5623 | 2.5740 | 2.5874 | 3.4190 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.6384 | 3.0447 | 2.6391 | 2.8463 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.6267 | 2.8511 | 2.6385 | 3.0522 | **Q1** [None, 0.0] |
+| `feature_fraction` | 3.2942 | 2.6950 | 2.5976 | 2.5817 | **Q4** [0.9903, ∞) |
+| `bagging_fraction` | 3.1352 | 2.7428 | 2.6153 | 2.6753 | **Q3** [0.9574, 0.9762] |
+
+#### E. Slice plot
+
+![cpu_act@s44/naive-lightgbm](slice_cpu_act@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.20279** (winner retrained in 3.13s, cv score of winner: 2.4434)
+- cv best RMSE: 2.4434, median: 2.5061, p10: 2.4615
+- train: median 2.418s/fold, mean 2.187s, p90 2.894s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.424 |
+| `mixture_init` | 0.241 |
+| `min_data_in_leaf` | 0.067 |
+| `feature_fraction` | 0.064 |
+| `bagging_fraction` | 0.062 |
+| `max_depth` | 0.040 |
+| `num_leaves` | 0.023 |
+| `mixture_e_step_mode` | 0.021 |
+| `mixture_gate_type` | 0.017 |
+| `bagging_freq` | 0.010 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_init` | **uniform** | 2.9670 (n=244) | tree_hierarchical | Δ +0.7020 | p=2.60e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 239 | 3.2016 | 3.3744 | 2.4434 |
+| gbdt | 34 | 5.2745 | 7.9049 | 2.4466 |
+| none | 27 | 7.3371 | 10.4888 | 2.4777 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 216 | 3.3970 | 3.9114 | 2.4434 |
+| token_choice | 84 | 4.8672 | 7.6207 | 2.4466 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 145 | 3.2747 | 3.2065 | 2.4465 |
+| loss_only | 120 | 3.7675 | 5.6128 | 2.4434 |
+| gate_only | 35 | 6.1620 | 8.9553 | 2.4733 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 244 | 2.9670 | 2.8978 | 2.4434 |
+| tree_hierarchical | 25 | 3.6690 | 0.6571 | 2.7851 |
+| random | 15 | 7.5860 | 8.0410 | 2.6231 |
+| gmm | 16 | 13.3211 | 14.6819 | 3.0624 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 170 | 3.1766 | 2.8735 | 2.4465 |
+| ema | 101 | 4.0842 | 5.9329 | 2.4434 |
+| none | 29 | 6.5543 | 10.2732 | 2.5073 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 264 | 3.4606 | 4.5371 | 2.4434 |
+| True | 36 | 6.3616 | 8.5186 | 2.6902 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 264 | 3.5380 | 4.7516 | 2.4434 |
+| True | 36 | 5.7940 | 7.8028 | 3.0339 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 6.4299 | — | — | 3.2970 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 5.5338 | 3.9483 | 2.8018 | 2.9509 | **Q3** [0.4261, 0.4588] |
+| `mixture_warmup_iters` | 6.4075 | 3.4812 | 2.8855 | 2.8087 | **Q4** [49.0, ∞) |
+| `mixture_balance_factor` | 6.6520 | 3.4831 | — | 2.9893 | **Q4** [8.0, ∞) |
+| `learning_rate` | 6.8362 | 2.7500 | 2.7029 | 2.9456 | **Q3** [0.1815, 0.2191] |
+| `num_leaves` | 4.5199 | 3.1052 | 3.6820 | 3.9498 | **Q2** [48.0, 62.0] |
+| `max_depth` | 6.6434 | 3.4673 | — | 2.9945 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 3.9329 | 2.7633 | 2.7539 | 6.0361 | **Q3** [9.0, 14.25] |
+
+#### E. Slice plot
+
+![cpu_act@s44/moe](slice_cpu_act@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| cpu_act@s44 | `mixture_init` | **uniform** | +0.7020 | 2.60e-03 |

--- a/bench_results/meth2_v081/ds_cpu_act_summary.json
+++ b/bench_results/meth2_v081/ds_cpu_act_summary.json
@@ -1,0 +1,2739 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "cpu_act"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "cpu_act": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.300955382422753,
+      "cv_best": 2.5167682181190614,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1297
+     },
+     "43": {
+      "holdout_rmse": 2.9626315579993556,
+      "cv_best": 2.3605952907213994,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3502
+     },
+     "44": {
+      "holdout_rmse": 2.276056326993748,
+      "cv_best": 2.478020653643999,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1657
+     }
+    },
+    "holdout_mean": 2.513214,
+    "holdout_std": 0.317948,
+    "cv_best_mean": 2.451795
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.239201018803847,
+      "cv_best": 2.4623198136480258,
+      "crash_rate": 0.0,
+      "retrain_s": 2.6385
+     },
+     "43": {
+      "holdout_rmse": 2.833403411824488,
+      "cv_best": 2.3139895693935095,
+      "crash_rate": 0.0,
+      "retrain_s": 1.054
+     },
+     "44": {
+      "holdout_rmse": 2.202788999892926,
+      "cv_best": 2.4433695511704054,
+      "crash_rate": 0.0,
+      "retrain_s": 3.135
+     }
+    },
+    "holdout_mean": 2.425131,
+    "holdout_std": 0.289075,
+    "cv_best_mean": 2.40656
+   }
+  }
+ },
+ "runs": {
+  "cpu_act@s42": {
+   "dataset": "cpu_act",
+   "seed": 42,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 83.92462618248398,
+    "std": 18.493954695764945
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.5167682181190614,
+    "rmse_p10": 2.5382797920027733,
+    "rmse_median": 2.5886531381388105,
+    "train_s_median": 0.16095291469246148,
+    "train_s_mean": 0.17066441046198208,
+    "train_s_p90": 0.2222297197207809,
+    "best_params": {
+     "learning_rate": 0.09264509243568801,
+     "num_leaves": 16,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.03330432130542346,
+     "lambda_l2": 4.271764835509462e-08,
+     "feature_fraction": 0.8683160857189651,
+     "bagging_fraction": 0.5918727988243391,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5413,
+     "min_data_in_leaf": 0.225,
+     "extra_trees": 0.1314,
+     "feature_fraction": 0.0626,
+     "max_depth": 0.0163,
+     "num_leaves": 0.0127,
+     "bagging_freq": 0.0048,
+     "bagging_fraction": 0.0043,
+     "lambda_l1": 0.0014,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 5.162,
+        "std": 2.8843,
+        "min": 2.9974
+       },
+       "False": {
+        "n": 278,
+        "mean": 2.7237,
+        "std": 0.5702,
+        "min": 2.5168
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.4383,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0878
+       ],
+       "n": 75,
+       "mean_rmse": 3.5242
+      },
+      "Q2": {
+       "range": [
+        0.0878,
+        0.1015
+       ],
+       "n": 75,
+       "mean_rmse": 2.5987
+      },
+      "Q3": {
+       "range": [
+        0.1015,
+        0.1365
+       ],
+       "n": 75,
+       "mean_rmse": 2.6638
+      },
+      "Q4": {
+       "range": [
+        0.1365,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8232
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.7932
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        22.0
+       ],
+       "n": 81,
+       "mean_rmse": 2.6426
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        27.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7366
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.4317
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 67,
+       "mean_rmse": 3.5982
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 36,
+       "mean_rmse": 2.7181
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 197,
+       "mean_rmse": 2.6996
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 56,
+       "mean_rmse": 2.8011
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.5874
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.6193
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.6265
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0022
+       ],
+       "n": 75,
+       "mean_rmse": 3.1783
+      },
+      "Q2": {
+       "range": [
+        0.0022,
+        0.101
+       ],
+       "n": 75,
+       "mean_rmse": 3.0481
+      },
+      "Q3": {
+       "range": [
+        0.101,
+        0.2619
+       ],
+       "n": 75,
+       "mean_rmse": 2.599
+      },
+      "Q4": {
+       "range": [
+        0.2619,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7845
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7125
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6434
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.9249
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.3292
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8159
+       ],
+       "n": 75,
+       "mean_rmse": 3.3781
+      },
+      "Q2": {
+       "range": [
+        0.8159,
+        0.86
+       ],
+       "n": 75,
+       "mean_rmse": 2.763
+      },
+      "Q3": {
+       "range": [
+        0.86,
+        0.8808
+       ],
+       "n": 75,
+       "mean_rmse": 2.6453
+      },
+      "Q4": {
+       "range": [
+        0.8808,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8235
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5773
+       ],
+       "n": 75,
+       "mean_rmse": 2.827
+      },
+      "Q2": {
+       "range": [
+        0.5773,
+        0.6504
+       ],
+       "n": 75,
+       "mean_rmse": 2.6803
+      },
+      "Q3": {
+       "range": [
+        0.6504,
+        0.9249
+       ],
+       "n": 75,
+       "mean_rmse": 3.255
+      },
+      "Q4": {
+       "range": [
+        0.9249,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8477
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 263.5,
+    "holdout": {
+     "holdout_rmse": 2.300955382422753,
+     "retrain_s": 0.1297,
+     "predict_s": 0.0014,
+     "cv_rmse_of_winner": 2.5167682181190614
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4623198136480258,
+    "rmse_p10": 2.4914015617691225,
+    "rmse_median": 2.606848933786858,
+    "train_s_median": 0.9058226812630892,
+    "train_s_mean": 1.198446154847741,
+    "train_s_p90": 2.2080355353653434,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.19297862402485097,
+     "num_leaves": 90,
+     "max_depth": 7,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 0.7816832248964914,
+     "lambda_l2": 2.1268596943503277e-08,
+     "feature_fraction": 0.7775291735877441,
+     "bagging_fraction": 0.8669159574694225,
+     "bagging_freq": 7,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 8,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.8158628055798206,
+     "mixture_diversity_lambda": 0.13731644662053016,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 49,
+     "mixture_gate_learning_rate": 0.019245609021396368,
+     "mixture_gate_lambda_l2": 0.00791291500495135,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_retrain_interval": 29,
+     "mixture_expert_capacity_factor": 1.3495072366786747,
+     "mixture_expert_choice_boost": 25.772350968720446,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.2030981993874068,
+     "mixture_refit_every_n": 29,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5148,
+     "extra_trees": 0.1346,
+     "mixture_diversity_lambda": 0.1215,
+     "min_data_in_leaf": 0.0716,
+     "bagging_fraction": 0.0474,
+     "lambda_l2": 0.0392,
+     "bagging_freq": 0.0201,
+     "mixture_warmup_iters": 0.0119,
+     "mixture_balance_factor": 0.0097,
+     "feature_fraction": 0.0074,
+     "mixture_gate_type": 0.0062,
+     "mixture_init": 0.0047,
+     "mixture_e_step_mode": 0.0028,
+     "num_leaves": 0.002,
+     "max_depth": 0.0018,
+     "mixture_hard_m_step": 0.0017,
+     "mixture_r_smoothing": 0.0008,
+     "mixture_num_experts": 0.0008,
+     "lambda_l1": 0.0006,
+     "mixture_routing_mode": 0.0004,
+     "mixture_refit_leaves": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 244,
+        "mean": 3.3111,
+        "std": 3.4651,
+        "min": 2.4623
+       },
+       "none": {
+        "n": 26,
+        "mean": 5.4331,
+        "std": 5.2738,
+        "min": 2.5866
+       },
+       "gbdt": {
+        "n": 30,
+        "mean": 4.9927,
+        "std": 6.1027,
+        "min": 2.5034
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 1.6816,
+       "p_value": 0.155323,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 55,
+        "mean": 4.6642,
+        "std": 4.8731,
+        "min": 2.5857
+       },
+       "expert_choice": {
+        "n": 245,
+        "mean": 3.4384,
+        "std": 3.8126,
+        "min": 2.4623
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 1.2258,
+       "p_value": 0.08725,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 41,
+        "mean": 4.0769,
+        "std": 3.4958,
+        "min": 2.4695
+       },
+       "gate_only": {
+        "n": 89,
+        "mean": 3.8502,
+        "std": 4.6786,
+        "min": 2.5653
+       },
+       "em": {
+        "n": 170,
+        "mean": 3.4655,
+        "std": 3.8109,
+        "min": 2.4623
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.3847,
+       "p_value": 0.507116,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 16,
+        "mean": 4.6633,
+        "std": 4.1256,
+        "min": 2.7618
+       },
+       "gmm": {
+        "n": 22,
+        "mean": 6.2741,
+        "std": 6.6315,
+        "min": 3.1499
+       },
+       "tree_hierarchical": {
+        "n": 40,
+        "mean": 4.0216,
+        "std": 3.0899,
+        "min": 2.6258
+       },
+       "uniform": {
+        "n": 222,
+        "mean": 3.2678,
+        "std": 3.7413,
+        "min": 2.4623
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.7538,
+       "p_value": 0.179478,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 220,
+        "mean": 3.3916,
+        "std": 3.8205,
+        "min": 2.4623
+       },
+       "markov": {
+        "n": 63,
+        "mean": 4.0205,
+        "std": 3.758,
+        "min": 2.5857
+       },
+       "none": {
+        "n": 17,
+        "mean": 5.8528,
+        "std": 6.5449,
+        "min": 2.5945
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.6289,
+       "p_value": 0.249202,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 60,
+        "mean": 4.3285,
+        "std": 4.5588,
+        "min": 2.5857
+       },
+       "False": {
+        "n": 240,
+        "mean": 3.4968,
+        "std": 3.9023,
+        "min": 2.4623
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.8317,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 35,
+        "mean": 6.5701,
+        "std": 6.8687,
+        "min": 3.0286
+       },
+       "False": {
+        "n": 265,
+        "mean": 3.2792,
+        "std": 3.3358,
+        "min": 2.4623
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 3.2909,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        4.0
+       ],
+       "n": 124,
+       "mean_rmse": 4.1098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 176,
+       "mean_rmse": 3.3485
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1238
+       ],
+       "n": 75,
+       "mean_rmse": 4.3804
+      },
+      "Q2": {
+       "range": [
+        0.1238,
+        0.1661
+       ],
+       "n": 75,
+       "mean_rmse": 2.7317
+      },
+      "Q3": {
+       "range": [
+        0.1661,
+        0.2374
+       ],
+       "n": 75,
+       "mean_rmse": 3.4674
+      },
+      "Q4": {
+       "range": [
+        0.2374,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 4.0732
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 73,
+       "mean_rmse": 3.5492
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        31.0
+       ],
+       "n": 76,
+       "mean_rmse": 3.5419
+      },
+      "Q3": {
+       "range": [
+        31.0,
+        41.0
+       ],
+       "n": 72,
+       "mean_rmse": 4.1139
+      },
+      "Q4": {
+       "range": [
+        41.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 3.4743
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 92,
+       "mean_rmse": 3.242
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 116,
+       "mean_rmse": 3.6335
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 92,
+       "mean_rmse": 4.1217
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1558
+       ],
+       "n": 75,
+       "mean_rmse": 6.0818
+      },
+      "Q2": {
+       "range": [
+        0.1558,
+        0.1887
+       ],
+       "n": 75,
+       "mean_rmse": 2.7104
+      },
+      "Q3": {
+       "range": [
+        0.1887,
+        0.2184
+       ],
+       "n": 75,
+       "mean_rmse": 2.7357
+      },
+      "Q4": {
+       "range": [
+        0.2184,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.1248
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        59.0
+       ],
+       "n": 74,
+       "mean_rmse": 3.8267
+      },
+      "Q2": {
+       "range": [
+        59.0,
+        82.0
+       ],
+       "n": 75,
+       "mean_rmse": 4.0646
+      },
+      "Q3": {
+       "range": [
+        82.0,
+        92.25
+       ],
+       "n": 76,
+       "mean_rmse": 3.6768
+      },
+      "Q4": {
+       "range": [
+        92.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.0865
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 62,
+       "mean_rmse": 3.681
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 44,
+       "mean_rmse": 3.1338
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 194,
+       "mean_rmse": 3.7775
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 44,
+       "mean_rmse": 3.5808
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 103,
+       "mean_rmse": 2.9696
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        19.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.7862
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 5.5393
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1824.0,
+    "holdout": {
+     "holdout_rmse": 2.239201018803847,
+     "retrain_s": 2.6385,
+     "predict_s": 0.0265,
+     "cv_rmse_of_winner": 2.4623198136480258
+    }
+   }
+  },
+  "cpu_act@s43": {
+   "dataset": "cpu_act",
+   "seed": 43,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.04531583765639,
+    "std": 18.208031997815638
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.3605952907213994,
+    "rmse_p10": 2.3766976806914064,
+    "rmse_median": 2.4179002246630907,
+    "train_s_median": 0.2101670065894723,
+    "train_s_mean": 0.21161382510885599,
+    "train_s_p90": 0.2895390359684825,
+    "best_params": {
+     "learning_rate": 0.061448868291719326,
+     "num_leaves": 29,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 3.556881073599275e-07,
+     "lambda_l2": 0.016652932385200474,
+     "feature_fraction": 0.9571427521547401,
+     "bagging_fraction": 0.7709482037567025,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5451,
+     "learning_rate": 0.3273,
+     "extra_trees": 0.0467,
+     "num_leaves": 0.0302,
+     "bagging_fraction": 0.0251,
+     "feature_fraction": 0.0165,
+     "bagging_freq": 0.0041,
+     "max_depth": 0.0029,
+     "lambda_l1": 0.002,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 3.9526,
+        "std": 1.4165,
+        "min": 2.865
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.6156,
+        "std": 0.7424,
+        "min": 2.3606
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.337,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0635
+       ],
+       "n": 75,
+       "mean_rmse": 3.0578
+      },
+      "Q2": {
+       "range": [
+        0.0635,
+        0.0793
+       ],
+       "n": 75,
+       "mean_rmse": 2.5427
+      },
+      "Q3": {
+       "range": [
+        0.0793,
+        0.1074
+       ],
+       "n": 75,
+       "mean_rmse": 2.6238
+      },
+      "Q4": {
+       "range": [
+        0.1074,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6125
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.6429
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        26.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.5224
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        32.0
+       ],
+       "n": 85,
+       "mean_rmse": 2.5676
+      },
+      "Q4": {
+       "range": [
+        32.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 3.0855
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 3.0309
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 51,
+       "mean_rmse": 2.5906
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 38,
+       "mean_rmse": 2.5758
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 149,
+       "mean_rmse": 2.65
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.4133
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.5333
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.4333
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 3.4038
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.5531
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6273
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.3735
+       ],
+       "n": 75,
+       "mean_rmse": 2.9238
+      },
+      "Q4": {
+       "range": [
+        0.3735,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7327
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 2.7548
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.009
+       ],
+       "n": 75,
+       "mean_rmse": 2.5349
+      },
+      "Q3": {
+       "range": [
+        0.009,
+        0.0305
+       ],
+       "n": 75,
+       "mean_rmse": 2.6795
+      },
+      "Q4": {
+       "range": [
+        0.0305,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8676
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8157
+       ],
+       "n": 75,
+       "mean_rmse": 2.8955
+      },
+      "Q2": {
+       "range": [
+        0.8157,
+        0.9004
+       ],
+       "n": 75,
+       "mean_rmse": 2.6856
+      },
+      "Q3": {
+       "range": [
+        0.9004,
+        0.9543
+       ],
+       "n": 75,
+       "mean_rmse": 2.7271
+      },
+      "Q4": {
+       "range": [
+        0.9543,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.5286
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7364
+       ],
+       "n": 75,
+       "mean_rmse": 2.7772
+      },
+      "Q2": {
+       "range": [
+        0.7364,
+        0.7722
+       ],
+       "n": 75,
+       "mean_rmse": 2.7105
+      },
+      "Q3": {
+       "range": [
+        0.7722,
+        0.8744
+       ],
+       "n": 75,
+       "mean_rmse": 2.6495
+      },
+      "Q4": {
+       "range": [
+        0.8744,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6996
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 325.5,
+    "holdout": {
+     "holdout_rmse": 2.9626315579993556,
+     "retrain_s": 0.3502,
+     "predict_s": 0.002,
+     "cv_rmse_of_winner": 2.3605952907213994
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.3139895693935095,
+    "rmse_p10": 2.341314615863275,
+    "rmse_median": 2.402611292067171,
+    "train_s_median": 0.7901946669444442,
+    "train_s_mean": 0.8236448438428343,
+    "train_s_p90": 1.181370136104525,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.1293225016080443,
+     "num_leaves": 31,
+     "max_depth": 7,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 2.401288363777746e-08,
+     "lambda_l2": 1.2623760975605327,
+     "feature_fraction": 0.9058306011656458,
+     "bagging_fraction": 0.8368545164090064,
+     "bagging_freq": 6,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 27,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.386762132189783,
+     "mixture_diversity_lambda": 0.2008731344809785,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 26,
+     "mixture_gate_learning_rate": 0.047902506287640687,
+     "mixture_gate_lambda_l2": 0.5387797731247357,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 11,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.058084461836113495,
+     "mixture_refit_every_n": 6,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.4678,
+     "learning_rate": 0.2607,
+     "mixture_hard_m_step": 0.2283,
+     "mixture_diversity_lambda": 0.0081,
+     "num_leaves": 0.0076,
+     "mixture_refit_leaves": 0.0065,
+     "bagging_freq": 0.0049,
+     "mixture_e_step_mode": 0.0042,
+     "bagging_fraction": 0.0037,
+     "mixture_init": 0.0025,
+     "lambda_l2": 0.0017,
+     "max_depth": 0.001,
+     "min_data_in_leaf": 0.0007,
+     "mixture_warmup_iters": 0.0007,
+     "feature_fraction": 0.0007,
+     "extra_trees": 0.0004,
+     "mixture_r_smoothing": 0.0002,
+     "mixture_balance_factor": 0.0001,
+     "mixture_routing_mode": 0.0001,
+     "mixture_num_experts": 0.0,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 18,
+        "mean": 4.0626,
+        "std": 2.1326,
+        "min": 2.3721
+       },
+       "none": {
+        "n": 16,
+        "mean": 15.4928,
+        "std": 13.075,
+        "min": 4.7629
+       },
+       "leaf_reuse": {
+        "n": 266,
+        "mean": 3.1136,
+        "std": 3.0107,
+        "min": 2.314
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.949,
+       "p_value": 0.098295,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 20,
+        "mean": 5.8327,
+        "std": 5.8111,
+        "min": 2.5741
+       },
+       "token_choice": {
+        "n": 280,
+        "mean": 3.6877,
+        "std": 4.9211,
+        "min": 2.314
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 2.145,
+       "p_value": 0.131191,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 18,
+        "mean": 6.4621,
+        "std": 6.0853,
+        "min": 2.5913
+       },
+       "em": {
+        "n": 17,
+        "mean": 6.2459,
+        "std": 7.4159,
+        "min": 2.5857
+       },
+       "gate_only": {
+        "n": 265,
+        "mean": 3.4971,
+        "std": 4.6327,
+        "min": 2.314
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 2.7488,
+       "p_value": 0.161299,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 231,
+        "mean": 3.5989,
+        "std": 4.8006,
+        "min": 2.314
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 5.2546,
+        "std": 6.4304,
+        "min": 2.4897
+       },
+       "random": {
+        "n": 15,
+        "mean": 6.1423,
+        "std": 8.6471,
+        "min": 2.4511
+       },
+       "uniform": {
+        "n": 38,
+        "mean": 3.728,
+        "std": 2.8564,
+        "min": 2.3278
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "uniform",
+       "delta_mean": 0.1291,
+       "p_value": 0.820252,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 15,
+        "mean": 4.2423,
+        "std": 4.0513,
+        "min": 2.3676
+       },
+       "none": {
+        "n": 206,
+        "mean": 3.9046,
+        "std": 5.7009,
+        "min": 2.3206
+       },
+       "markov": {
+        "n": 79,
+        "mean": 3.56,
+        "std": 2.7358,
+        "min": 2.314
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.3446,
+       "p_value": 0.495106,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 274,
+        "mean": 3.5558,
+        "std": 3.9941,
+        "min": 2.314
+       },
+       "False": {
+        "n": 26,
+        "mean": 6.7286,
+        "std": 10.6191,
+        "min": 2.3278
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 3.1728,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 3.7673,
+        "std": 5.1621,
+        "min": 2.314
+       },
+       "True": {
+        "n": 22,
+        "mean": 4.6324,
+        "std": 2.3235,
+        "min": 2.8686
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.8651,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 3.8307
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.152
+       ],
+       "n": 75,
+       "mean_rmse": 3.3907
+      },
+      "Q2": {
+       "range": [
+        0.152,
+        0.1788
+       ],
+       "n": 75,
+       "mean_rmse": 2.9584
+      },
+      "Q3": {
+       "range": [
+        0.1788,
+        0.2743
+       ],
+       "n": 75,
+       "mean_rmse": 3.8226
+      },
+      "Q4": {
+       "range": [
+        0.2743,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.1513
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        24.75
+       ],
+       "n": 75,
+       "mean_rmse": 4.0415
+      },
+      "Q2": {
+       "range": [
+        24.75,
+        28.5
+       ],
+       "n": 75,
+       "mean_rmse": 3.2335
+      },
+      "Q3": {
+       "range": [
+        28.5,
+        32.0
+       ],
+       "n": 72,
+       "mean_rmse": 3.973
+      },
+      "Q4": {
+       "range": [
+        32.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 4.0709
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 56,
+       "mean_rmse": 5.8107
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 67,
+       "mean_rmse": 3.3543
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 177,
+       "mean_rmse": 3.3847
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0995
+       ],
+       "n": 75,
+       "mean_rmse": 5.6853
+      },
+      "Q2": {
+       "range": [
+        0.0995,
+        0.116
+       ],
+       "n": 75,
+       "mean_rmse": 3.3653
+      },
+      "Q3": {
+       "range": [
+        0.116,
+        0.1365
+       ],
+       "n": 75,
+       "mean_rmse": 2.7831
+      },
+      "Q4": {
+       "range": [
+        0.1365,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.4892
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        27.0
+       ],
+       "n": 71,
+       "mean_rmse": 3.5355
+      },
+      "Q2": {
+       "range": [
+        27.0,
+        32.0
+       ],
+       "n": 73,
+       "mean_rmse": 3.6885
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        40.25
+       ],
+       "n": 81,
+       "mean_rmse": 3.3865
+      },
+      "Q4": {
+       "range": [
+        40.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 4.7285
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 3.914
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 229,
+       "mean_rmse": 3.8049
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 51,
+       "mean_rmse": 2.7071
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 97,
+       "mean_rmse": 3.3078
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        20.0
+       ],
+       "n": 73,
+       "mean_rmse": 3.8189
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 5.2091
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 1257.0,
+    "holdout": {
+     "holdout_rmse": 2.833403411824488,
+     "retrain_s": 1.054,
+     "predict_s": 0.0072,
+     "cv_rmse_of_winner": 2.3139895693935095
+    }
+   }
+  },
+  "cpu_act@s44": {
+   "dataset": "cpu_act",
+   "seed": 44,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.05965822398535,
+    "std": 18.44113958458848
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.478020653643999,
+    "rmse_p10": 2.5062736680386064,
+    "rmse_median": 2.541616785532076,
+    "train_s_median": 0.16456200275570154,
+    "train_s_mean": 0.16656606199343998,
+    "train_s_p90": 0.2195247074961663,
+    "best_params": {
+     "learning_rate": 0.09794167184693416,
+     "num_leaves": 20,
+     "max_depth": 7,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.009843483454644992,
+     "lambda_l2": 0.0014078509805729065,
+     "feature_fraction": 0.9992950848593232,
+     "bagging_fraction": 0.9641084492758434,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5246,
+     "learning_rate": 0.2508,
+     "extra_trees": 0.1155,
+     "feature_fraction": 0.0522,
+     "num_leaves": 0.0296,
+     "bagging_freq": 0.0083,
+     "max_depth": 0.0076,
+     "bagging_fraction": 0.0071,
+     "lambda_l2": 0.0031,
+     "lambda_l1": 0.0013
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7136,
+        "std": 0.6089,
+        "min": 2.478
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.8921,
+        "std": 1.1427,
+        "min": 2.8796
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.1785,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0864
+       ],
+       "n": 75,
+       "mean_rmse": 3.1451
+      },
+      "Q2": {
+       "range": [
+        0.0864,
+        0.0971
+       ],
+       "n": 75,
+       "mean_rmse": 2.5864
+      },
+      "Q3": {
+       "range": [
+        0.0971,
+        0.1132
+       ],
+       "n": 75,
+       "mean_rmse": 2.6362
+      },
+      "Q4": {
+       "range": [
+        0.1132,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8009
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.6861
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        23.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.6349
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        37.25
+       ],
+       "n": 82,
+       "mean_rmse": 2.6778
+      },
+      "Q4": {
+       "range": [
+        37.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.1672
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 53,
+       "mean_rmse": 2.9955
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 33,
+       "mean_rmse": 2.813
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 214,
+       "mean_rmse": 2.7386
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.5623
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 2.574
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 90,
+       "mean_rmse": 2.5874
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.419
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6384
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0022
+       ],
+       "n": 75,
+       "mean_rmse": 3.0447
+      },
+      "Q3": {
+       "range": [
+        0.0022,
+        0.0123
+       ],
+       "n": 75,
+       "mean_rmse": 2.6391
+      },
+      "Q4": {
+       "range": [
+        0.0123,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8463
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.6267
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0005
+       ],
+       "n": 75,
+       "mean_rmse": 2.8511
+      },
+      "Q3": {
+       "range": [
+        0.0005,
+        0.0035
+       ],
+       "n": 75,
+       "mean_rmse": 2.6385
+      },
+      "Q4": {
+       "range": [
+        0.0035,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.0522
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9465
+       ],
+       "n": 75,
+       "mean_rmse": 3.2942
+      },
+      "Q2": {
+       "range": [
+        0.9465,
+        0.9787
+       ],
+       "n": 75,
+       "mean_rmse": 2.695
+      },
+      "Q3": {
+       "range": [
+        0.9787,
+        0.9903
+       ],
+       "n": 75,
+       "mean_rmse": 2.5976
+      },
+      "Q4": {
+       "range": [
+        0.9903,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.5817
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9328
+       ],
+       "n": 75,
+       "mean_rmse": 3.1352
+      },
+      "Q2": {
+       "range": [
+        0.9328,
+        0.9574
+       ],
+       "n": 75,
+       "mean_rmse": 2.7428
+      },
+      "Q3": {
+       "range": [
+        0.9574,
+        0.9762
+       ],
+       "n": 75,
+       "mean_rmse": 2.6153
+      },
+      "Q4": {
+       "range": [
+        0.9762,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.6753
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 257.7,
+    "holdout": {
+     "holdout_rmse": 2.276056326993748,
+     "retrain_s": 0.1657,
+     "predict_s": 0.0017,
+     "cv_rmse_of_winner": 2.478020653643999
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4433695511704054,
+    "rmse_p10": 2.461544135445148,
+    "rmse_median": 2.50612933944156,
+    "train_s_median": 2.418336860463023,
+    "train_s_mean": 2.1865895151396595,
+    "train_s_p90": 2.8941619873419406,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.1974024480403841,
+     "num_leaves": 52,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.987362170914045e-08,
+     "lambda_l2": 0.6640901025551658,
+     "feature_fraction": 0.8431982786910301,
+     "bagging_fraction": 0.6868582794193463,
+     "bagging_freq": 3,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 50,
+     "mixture_balance_factor": 8,
+     "mixture_smoothing_lambda": 0.3679102373012826,
+     "mixture_diversity_lambda": 0.44344437910949475,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 5,
+     "mixture_gate_num_leaves": 11,
+     "mixture_gate_learning_rate": 0.33686956476234187,
+     "mixture_gate_lambda_l2": 0.0011374494212100703,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 30,
+     "mixture_expert_capacity_factor": 1.341837615014339,
+     "mixture_expert_choice_boost": 17.42603642500684,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.4237,
+     "mixture_init": 0.2409,
+     "min_data_in_leaf": 0.0672,
+     "feature_fraction": 0.0641,
+     "bagging_fraction": 0.062,
+     "max_depth": 0.0401,
+     "num_leaves": 0.0233,
+     "mixture_e_step_mode": 0.021,
+     "mixture_gate_type": 0.0171,
+     "bagging_freq": 0.0103,
+     "mixture_diversity_lambda": 0.0096,
+     "mixture_r_smoothing": 0.0093,
+     "mixture_warmup_iters": 0.0044,
+     "mixture_balance_factor": 0.003,
+     "mixture_num_experts": 0.0013,
+     "mixture_hard_m_step": 0.001,
+     "lambda_l2": 0.0009,
+     "extra_trees": 0.0005,
+     "mixture_routing_mode": 0.0002,
+     "lambda_l1": 0.0002,
+     "mixture_refit_leaves": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 34,
+        "mean": 5.2745,
+        "std": 7.9049,
+        "min": 2.4466
+       },
+       "none": {
+        "n": 27,
+        "mean": 7.3371,
+        "std": 10.4888,
+        "min": 2.4777
+       },
+       "leaf_reuse": {
+        "n": 239,
+        "mean": 3.2016,
+        "std": 3.3744,
+        "min": 2.4434
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 2.0729,
+       "p_value": 0.145862,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 84,
+        "mean": 4.8672,
+        "std": 7.6207,
+        "min": 2.4466
+       },
+       "expert_choice": {
+        "n": 216,
+        "mean": 3.397,
+        "std": 3.9114,
+        "min": 2.4434
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 1.4702,
+       "p_value": 0.097142,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 35,
+        "mean": 6.162,
+        "std": 8.9553,
+        "min": 2.4733
+       },
+       "em": {
+        "n": 145,
+        "mean": 3.2747,
+        "std": 3.2065,
+        "min": 2.4465
+       },
+       "loss_only": {
+        "n": 120,
+        "mean": 3.7675,
+        "std": 5.6128,
+        "min": 2.4434
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.4928,
+       "p_value": 0.396444,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 244,
+        "mean": 2.967,
+        "std": 2.8978,
+        "min": 2.4434
+       },
+       "tree_hierarchical": {
+        "n": 25,
+        "mean": 3.669,
+        "std": 0.6571,
+        "min": 2.7851
+       },
+       "random": {
+        "n": 15,
+        "mean": 7.586,
+        "std": 8.041,
+        "min": 2.6231
+       },
+       "gmm": {
+        "n": 16,
+        "mean": 13.3211,
+        "std": 14.6819,
+        "min": 3.0624
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.702,
+       "p_value": 0.002604,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 29,
+        "mean": 6.5543,
+        "std": 10.2732,
+        "min": 2.5073
+       },
+       "ema": {
+        "n": 101,
+        "mean": 4.0842,
+        "std": 5.9329,
+        "min": 2.4434
+       },
+       "markov": {
+        "n": 170,
+        "mean": 3.1766,
+        "std": 2.8735,
+        "min": 2.4465
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.9076,
+       "p_value": 0.154148,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 36,
+        "mean": 6.3616,
+        "std": 8.5186,
+        "min": 2.6902
+       },
+       "False": {
+        "n": 264,
+        "mean": 3.4606,
+        "std": 4.5371,
+        "min": 2.4434
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.901,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 36,
+        "mean": 5.794,
+        "std": 7.8028,
+        "min": 3.0339
+       },
+       "False": {
+        "n": 264,
+        "mean": 3.538,
+        "std": 4.7516,
+        "min": 2.4434
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.256,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 49,
+       "mean_rmse": 6.4299
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 251,
+       "mean_rmse": 3.297
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1933
+       ],
+       "n": 75,
+       "mean_rmse": 5.5338
+      },
+      "Q2": {
+       "range": [
+        0.1933,
+        0.4261
+       ],
+       "n": 75,
+       "mean_rmse": 3.9483
+      },
+      "Q3": {
+       "range": [
+        0.4261,
+        0.4588
+       ],
+       "n": 75,
+       "mean_rmse": 2.8018
+      },
+      "Q4": {
+       "range": [
+        0.4588,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9509
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        42.0
+       ],
+       "n": 69,
+       "mean_rmse": 6.4075
+      },
+      "Q2": {
+       "range": [
+        42.0,
+        47.0
+       ],
+       "n": 70,
+       "mean_rmse": 3.4812
+      },
+      "Q3": {
+       "range": [
+        47.0,
+        49.0
+       ],
+       "n": 60,
+       "mean_rmse": 2.8855
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 101,
+       "mean_rmse": 2.8087
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 57,
+       "mean_rmse": 6.652
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 75,
+       "mean_rmse": 3.4831
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 168,
+       "mean_rmse": 2.9893
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.145
+       ],
+       "n": 75,
+       "mean_rmse": 6.8362
+      },
+      "Q2": {
+       "range": [
+        0.145,
+        0.1815
+       ],
+       "n": 75,
+       "mean_rmse": 2.75
+      },
+      "Q3": {
+       "range": [
+        0.1815,
+        0.2191
+       ],
+       "n": 75,
+       "mean_rmse": 2.7029
+      },
+      "Q4": {
+       "range": [
+        0.2191,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9456
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        48.0
+       ],
+       "n": 71,
+       "mean_rmse": 4.5199
+      },
+      "Q2": {
+       "range": [
+        48.0,
+        62.0
+       ],
+       "n": 73,
+       "mean_rmse": 3.1052
+      },
+      "Q3": {
+       "range": [
+        62.0,
+        78.0
+       ],
+       "n": 79,
+       "mean_rmse": 3.682
+      },
+      "Q4": {
+       "range": [
+        78.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 3.9498
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 58,
+       "mean_rmse": 6.6434
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 69,
+       "mean_rmse": 3.4673
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 173,
+       "mean_rmse": 2.9945
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 59,
+       "mean_rmse": 3.9329
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.7633
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.25
+       ],
+       "n": 90,
+       "mean_rmse": 2.7539
+      },
+      "Q4": {
+       "range": [
+        14.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0361
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 3313.7,
+    "holdout": {
+     "holdout_rmse": 2.202788999892926,
+     "retrain_s": 3.135,
+     "predict_s": 0.03,
+     "cv_rmse_of_winner": 2.4433695511704054
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_elevators_ensemble_report.md
+++ b/bench_results/meth2_v081/ds_elevators_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['elevators'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| elevators | naive-ensemble | **0.00230** ± 0.00009 | 0.00252 | 0.0% | 0.28 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| elevators@s42 | naive-ensemble | 0.0026 | 0.0026 | 0.206 | 388 |
+| elevators@s43 | naive-ensemble | 0.0025 | 0.0026 | 0.264 | 518 |
+| elevators@s44 | naive-ensemble | 0.0025 | 0.0026 | 0.283 | 444 |
+
+
+
+---
+
+## elevators@s42  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.00242** (winner retrained in 0.24s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0026, p10: 0.0026
+- train: median 0.206s/fold, mean 0.256s, p90 0.395s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.639 |
+| `learning_rate` | 0.139 |
+| `extra_trees` | 0.060 |
+| `feature_fraction` | 0.041 |
+| `min_data_in_leaf` | 0.035 |
+| `max_depth` | 0.023 |
+| `bagging_fraction` | 0.022 |
+| `n_models` | 0.019 |
+| `bagging_freq` | 0.015 |
+| `lambda_l2` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.0028 | 0.0005 | 0.0026 |
+| True | 22 | 0.0034 | 0.0008 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0032 | 0.0027 | 0.0027 | 0.0026 | **Q4** [0.2822, ∞) |
+| `num_leaves` | 0.0028 | 0.0027 | 0.0030 | 0.0028 | **Q2** [33.0, 54.0] |
+| `max_depth` | 0.0028 | — | 0.0027 | 0.0030 | **Q3** [4.0, 5.0] |
+| `min_data_in_leaf` | 0.0027 | 0.0027 | 0.0027 | 0.0031 | **Q1** [None, 12.0] |
+| `lambda_l1` | 0.0028 | 0.0027 | 0.0028 | 0.0030 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 0.0027 | 0.0028 | 0.0028 | 0.0029 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0029 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.9137, 0.9504] |
+| `bagging_fraction` | 0.0030 | 0.0028 | 0.0027 | 0.0027 | **Q3** [0.9136, 0.9337] |
+
+#### E. Slice plot
+
+![elevators@s42/naive-ensemble](slice_elevators@s42_naive-ensemble.png)
+
+
+---
+
+## elevators@s43  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.00223** (winner retrained in 0.29s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0026, p10: 0.0026
+- train: median 0.264s/fold, mean 0.342s, p90 0.643s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.390 |
+| `bagging_freq` | 0.262 |
+| `learning_rate` | 0.088 |
+| `num_leaves` | 0.055 |
+| `n_models` | 0.050 |
+| `feature_fraction` | 0.040 |
+| `bagging_fraction` | 0.038 |
+| `min_data_in_leaf` | 0.037 |
+| `max_depth` | 0.026 |
+| `extra_trees` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.0027 | 0.0005 | 0.0025 |
+| True | 22 | 0.0035 | 0.0009 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0032 | 0.0027 | 0.0027 | 0.0026 | **Q4** [0.2642, ∞) |
+| `num_leaves` | 0.0027 | 0.0027 | 0.0028 | 0.0031 | **Q1** [None, 12.0] |
+| `max_depth` | 0.0031 | — | — | 0.0027 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 0.0028 | 0.0026 | 0.0027 | 0.0031 | **Q2** [7.0, 10.0] |
+| `lambda_l1` | 0.0027 | 0.0027 | 0.0026 | 0.0032 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.0029 | 0.0028 | 0.0027 | 0.0028 | **Q3** [0.0001, 0.0004] |
+| `feature_fraction` | 0.0031 | 0.0028 | 0.0026 | 0.0027 | **Q3** [0.9516, 0.9744] |
+| `bagging_fraction` | 0.0029 | 0.0027 | 0.0027 | 0.0029 | **Q2** [0.7346, 0.7667] |
+
+#### E. Slice plot
+
+![elevators@s43/naive-ensemble](slice_elevators@s43_naive-ensemble.png)
+
+
+---
+
+## elevators@s44  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.00225** (winner retrained in 0.31s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0026, p10: 0.0025
+- train: median 0.283s/fold, mean 0.293s, p90 0.398s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.505 |
+| `learning_rate` | 0.334 |
+| `bagging_fraction` | 0.072 |
+| `num_leaves` | 0.040 |
+| `min_data_in_leaf` | 0.018 |
+| `extra_trees` | 0.014 |
+| `max_depth` | 0.006 |
+| `n_models` | 0.006 |
+| `feature_fraction` | 0.002 |
+| `bagging_freq` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.0027 | 0.0005 | 0.0025 |
+| True | 20 | 0.0035 | 0.0008 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0032 | 0.0027 | 0.0026 | 0.0026 | **Q3** [0.255, 0.2789] |
+| `num_leaves` | 0.0026 | 0.0026 | 0.0028 | 0.0030 | **Q1** [None, 12.0] |
+| `max_depth` | 0.0029 | 0.0028 | 0.0027 | 0.0027 | **Q3** [7.0, 9.0] |
+| `min_data_in_leaf` | 0.0026 | 0.0027 | 0.0028 | 0.0029 | **Q1** [None, 7.0] |
+| `lambda_l1` | 0.0027 | 0.0026 | 0.0026 | 0.0031 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 0.0029 | 0.0028 | 0.0027 | 0.0026 | **Q4** [1.8467, ∞) |
+| `feature_fraction` | 0.0030 | 0.0026 | 0.0027 | 0.0027 | **Q2** [0.873, 0.9218] |
+| `bagging_fraction` | 0.0028 | 0.0027 | 0.0027 | 0.0028 | **Q2** [0.7538, 0.7975] |
+
+#### E. Slice plot
+
+![elevators@s44/naive-ensemble](slice_elevators@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v081/ds_elevators_ensemble_summary.json
+++ b/bench_results/meth2_v081/ds_elevators_ensemble_summary.json
@@ -1,0 +1,1169 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "elevators"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "elevators": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.002424896767206646,
+      "cv_best": 0.0025541422644813115,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2449
+     },
+     "43": {
+      "holdout_rmse": 0.0022343354669783233,
+      "cv_best": 0.00253645628626813,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2873
+     },
+     "44": {
+      "holdout_rmse": 0.0022463994461221744,
+      "cv_best": 0.0024825053282565702,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3113
+     }
+    },
+    "holdout_mean": 0.002302,
+    "holdout_std": 8.7e-05,
+    "cv_best_mean": 0.002524
+   }
+  }
+ },
+ "runs": {
+  "elevators@s42": {
+   "dataset": "elevators",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021624375,
+    "std": 0.006717125937435966
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0025541422644813115,
+    "rmse_p10": 0.002583129497433085,
+    "rmse_median": 0.002623797033200657,
+    "train_s_median": 0.20608004797250032,
+    "train_s_mean": 0.25586212806900344,
+    "train_s_p90": 0.3945261971279986,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.2988004227428443,
+     "num_leaves": 29,
+     "max_depth": 4,
+     "min_data_in_leaf": 12,
+     "lambda_l1": 0.0002641729841783152,
+     "lambda_l2": 8.313189149964025e-08,
+     "feature_fraction": 0.9901893616530495,
+     "bagging_fraction": 0.9107627919092857,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6389,
+     "learning_rate": 0.1388,
+     "extra_trees": 0.0598,
+     "feature_fraction": 0.0408,
+     "min_data_in_leaf": 0.0355,
+     "max_depth": 0.0232,
+     "bagging_fraction": 0.0223,
+     "n_models": 0.0193,
+     "bagging_freq": 0.0148,
+     "lambda_l2": 0.0039,
+     "num_leaves": 0.0027
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 0.0028,
+        "std": 0.0005,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 22,
+        "mean": 0.0034,
+        "std": 0.0008,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2166
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.2166,
+        0.2636
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2636,
+        0.2822
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.2822,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        33.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        33.0,
+        54.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        54.0,
+        114.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        114.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 23,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 183,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 94,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 58,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        21.25
+       ],
+       "n": 92,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        21.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0014
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0014,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9137
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.9137,
+        0.9504
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9504,
+        0.9764
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9764,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8526
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.8526,
+        0.9136
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9136,
+        0.9337
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9337,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 388.2,
+    "holdout": {
+     "holdout_rmse": 0.002424896767206646,
+     "retrain_s": 0.2449,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.0025541422644813115
+    }
+   }
+  },
+  "elevators@s43": {
+   "dataset": "elevators",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021558875,
+    "std": 0.0066420654720030425
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00253645628626813,
+    "rmse_p10": 0.0025605030752783335,
+    "rmse_median": 0.002602787982644326,
+    "train_s_median": 0.26385057419538493,
+    "train_s_mean": 0.3422855409123004,
+    "train_s_p90": 0.6425776388123633,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.2776850487638199,
+     "num_leaves": 14,
+     "max_depth": 11,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 1.2284838169208216e-07,
+     "lambda_l2": 4.844759993004295e-05,
+     "feature_fraction": 0.9503231386051336,
+     "bagging_fraction": 0.7821992535527313,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.3902,
+     "bagging_freq": 0.2624,
+     "learning_rate": 0.0882,
+     "num_leaves": 0.055,
+     "n_models": 0.05,
+     "feature_fraction": 0.0397,
+     "bagging_fraction": 0.0384,
+     "min_data_in_leaf": 0.0375,
+     "max_depth": 0.0264,
+     "extra_trees": 0.012,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 0.0027,
+        "std": 0.0005,
+        "min": 0.0025
+       },
+       "True": {
+        "n": 22,
+        "mean": 0.0035,
+        "std": 0.0009,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0008,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1799
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.1799,
+        0.2311
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2311,
+        0.2642
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.2642,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        27.25
+       ],
+       "n": 86,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        27.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0031
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 226,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 44,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 91,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        21.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        21.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8769
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.8769,
+        0.9516
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9516,
+        0.9744
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.9744,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7346
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.7346,
+        0.7667
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.7667,
+        0.7908
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.7908,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 518.0,
+    "holdout": {
+     "holdout_rmse": 0.0022343354669783233,
+     "retrain_s": 0.2873,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.00253645628626813
+    }
+   }
+  },
+  "elevators@s44": {
+   "dataset": "elevators",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021623500000000004,
+    "std": 0.006704326793198554
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0024825053282565702,
+    "rmse_p10": 0.0025083705973803316,
+    "rmse_median": 0.002563014770299081,
+    "train_s_median": 0.2826290065422654,
+    "train_s_mean": 0.2930867779441178,
+    "train_s_p90": 0.3981689078360796,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.29805729456197294,
+     "num_leaves": 10,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 3.5605030293585113e-07,
+     "lambda_l2": 1.7570751528202748,
+     "feature_fraction": 0.9020181624691609,
+     "bagging_fraction": 0.7675800390942373,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.5047,
+     "learning_rate": 0.3343,
+     "bagging_fraction": 0.0718,
+     "num_leaves": 0.0398,
+     "min_data_in_leaf": 0.0182,
+     "extra_trees": 0.0142,
+     "max_depth": 0.006,
+     "n_models": 0.0059,
+     "feature_fraction": 0.0023,
+     "bagging_freq": 0.0018,
+     "lambda_l2": 0.001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 0.0035,
+        "std": 0.0008,
+        "min": 0.0026
+       },
+       "False": {
+        "n": 280,
+        "mean": 0.0027,
+        "std": 0.0005,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0008,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2101
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.2101,
+        0.255
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.255,
+        0.2789
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.2789,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0026
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        18.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        46.25
+       ],
+       "n": 84,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        46.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 50,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 55,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 119,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.0026
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 92,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        19.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0307
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0307,
+        1.8467
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        1.8467,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.873
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.873,
+        0.9218
+       ],
+       "n": 75,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        0.9218,
+        0.9586
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9586,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7538
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.7538,
+        0.7975
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.7975,
+        0.8438
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.8438,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 444.3,
+    "holdout": {
+     "holdout_rmse": 0.0022463994461221744,
+     "retrain_s": 0.3113,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.0024825053282565702
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_elevators_report.md
+++ b/bench_results/meth2_v081/ds_elevators_report.md
@@ -1,0 +1,492 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['elevators'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| elevators | naive-lightgbm | **0.00238** ± 0.00005 | 0.00264 | 0.0% | 0.23 |
+| elevators | moe | **0.00230** ± 0.00010 | 0.00251 | 0.0% | 2.04 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| elevators@s42 | naive-lightgbm | 0.0026 | 0.0027 | 0.124 | 206 |
+| elevators@s42 | moe | 0.0025 | 0.0026 | 1.690 | 2307 |
+| elevators@s43 | naive-lightgbm | 0.0027 | 0.0027 | 0.149 | 244 |
+| elevators@s43 | moe | 0.0026 | 0.0028 | 0.763 | 1337 |
+| elevators@s44 | naive-lightgbm | 0.0026 | 0.0027 | 0.227 | 342 |
+| elevators@s44 | moe | 0.0025 | 0.0026 | 2.152 | 3529 |
+
+
+
+---
+
+## elevators@s42  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00245** (winner retrained in 0.14s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0027
+- train: median 0.124s/fold, mean 0.132s, p90 0.181s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.733 |
+| `learning_rate` | 0.188 |
+| `extra_trees` | 0.032 |
+| `bagging_freq` | 0.019 |
+| `feature_fraction` | 0.017 |
+| `num_leaves` | 0.004 |
+| `bagging_fraction` | 0.003 |
+| `max_depth` | 0.002 |
+| `min_data_in_leaf` | 0.002 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.0028 | 0.0004 | 0.0026 |
+| True | 22 | 0.0036 | 0.0009 | 0.0028 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0033 | 0.0027 | 0.0027 | 0.0028 | **Q2** [0.1755, 0.2043] |
+| `num_leaves` | 0.0029 | 0.0027 | 0.0028 | 0.0031 | **Q2** [14.0, 18.0] |
+| `max_depth` | 0.0031 | — | — | 0.0028 | **Q4** [6.0, ∞) |
+| `min_data_in_leaf` | 0.0028 | 0.0028 | 0.0029 | 0.0031 | **Q1** [None, 11.0] |
+| `lambda_l1` | 0.0029 | 0.0029 | 0.0028 | 0.0030 | **Q3** [0.0003, 0.0015] |
+| `lambda_l2` | 0.0031 | 0.0028 | 0.0028 | 0.0029 | **Q2** [0.0001, 0.0003] |
+| `feature_fraction` | 0.0031 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.9043, 0.9313] |
+| `bagging_fraction` | 0.0031 | 0.0028 | 0.0028 | 0.0029 | **Q2** [0.9313, 0.9559] |
+
+#### E. Slice plot
+
+![elevators@s42/naive-lightgbm](slice_elevators@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00232** (winner retrained in 2.20s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0026, p10: 0.0025
+- train: median 1.690s/fold, mean 1.512s, p90 2.060s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.346 |
+| `mixture_diversity_lambda` | 0.154 |
+| `mixture_r_smoothing` | 0.097 |
+| `lambda_l1` | 0.076 |
+| `num_leaves` | 0.058 |
+| `max_depth` | 0.053 |
+| `mixture_warmup_iters` | 0.049 |
+| `mixture_e_step_mode` | 0.028 |
+| `mixture_init` | 0.027 |
+| `mixture_gate_type` | 0.027 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 255 | 0.0038 | 0.0055 | 0.0025 |
+| gbdt | 24 | 0.0046 | 0.0030 | 0.0028 |
+| none | 21 | 0.0446 | 0.1652 | 0.0031 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 40 | 0.0058 | 0.0062 | 0.0028 |
+| token_choice | 260 | 0.0068 | 0.0485 | 0.0025 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 32 | 0.0042 | 0.0028 | 0.0028 |
+| gate_only | 247 | 0.0067 | 0.0496 | 0.0025 |
+| em | 21 | 0.0106 | 0.0155 | 0.0031 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 237 | 0.0034 | 0.0037 | 0.0025 |
+| random | 33 | 0.0039 | 0.0022 | 0.0025 |
+| gmm | 15 | 0.0103 | 0.0178 | 0.0029 |
+| tree_hierarchical | 15 | 0.0615 | 0.1928 | 0.0038 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 90 | 0.0037 | 0.0036 | 0.0025 |
+| none | 36 | 0.0047 | 0.0037 | 0.0026 |
+| ema | 174 | 0.0087 | 0.0592 | 0.0025 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 57 | 0.0053 | 0.0055 | 0.0027 |
+| True | 243 | 0.0070 | 0.0502 | 0.0025 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 35 | 0.0055 | 0.0046 | 0.0030 |
+| False | 265 | 0.0069 | 0.0481 | 0.0025 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0060 | — | 0.0094 | 0.0030 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0052 | 0.0031 | 0.0132 | 0.0052 | **Q2** [0.3096, 0.3476] |
+| `mixture_warmup_iters` | 0.0039 | 0.0031 | 0.0049 | 0.0141 | **Q2** [12.0, 14.5] |
+| `mixture_balance_factor` | 0.0044 | 0.0153 | — | 0.0032 | **Q4** [10.0, ∞) |
+| `learning_rate` | 0.0060 | 0.0044 | 0.0032 | 0.0132 | **Q3** [0.2608, 0.2821] |
+| `num_leaves` | 0.0151 | 0.0049 | 0.0032 | 0.0040 | **Q3** [86.0, 101.0] |
+| `max_depth` | 0.0037 | — | 0.0079 | 0.0052 | **Q1** [None, 5.0] |
+| `min_data_in_leaf` | 0.0029 | 0.0037 | 0.0034 | 0.0163 | **Q1** [None, 9.0] |
+
+#### E. Slice plot
+
+![elevators@s42/moe](slice_elevators@s42_moe.png)
+
+
+---
+
+## elevators@s43  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00236** (winner retrained in 0.15s, cv score of winner: 0.0027)
+- cv best RMSE: 0.0027, median: 0.0027, p10: 0.0027
+- train: median 0.149s/fold, mean 0.157s, p90 0.230s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.610 |
+| `learning_rate` | 0.147 |
+| `feature_fraction` | 0.056 |
+| `num_leaves` | 0.055 |
+| `min_data_in_leaf` | 0.043 |
+| `max_depth` | 0.039 |
+| `extra_trees` | 0.030 |
+| `bagging_fraction` | 0.015 |
+| `lambda_l2` | 0.004 |
+| `bagging_freq` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.0028 | 0.0005 | 0.0027 |
+| True | 21 | 0.0037 | 0.0007 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0033 | 0.0027 | 0.0028 | 0.0027 | **Q2** [0.1548, 0.1835] |
+| `num_leaves` | 0.0028 | 0.0028 | 0.0029 | 0.0031 | **Q1** [None, 17.0] |
+| `max_depth` | 0.0034 | 0.0029 | — | 0.0029 | **Q2** [5.0, 8.0] |
+| `min_data_in_leaf` | 0.0028 | 0.0028 | 0.0027 | 0.0032 | **Q3** [20.5, 24.0] |
+| `lambda_l1` | 0.0029 | 0.0028 | 0.0028 | 0.0031 | **Q2** [0.0, 0.0004] |
+| `lambda_l2` | 0.0029 | 0.0029 | 0.0029 | 0.0030 | **Q1** [None, 0.0001] |
+| `feature_fraction` | 0.0032 | 0.0029 | 0.0028 | 0.0027 | **Q4** [0.9712, ∞) |
+| `bagging_fraction` | 0.0031 | 0.0029 | 0.0029 | 0.0028 | **Q4** [0.9656, ∞) |
+
+#### E. Slice plot
+
+![elevators@s43/naive-lightgbm](slice_elevators@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00240** (winner retrained in 0.54s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0028, p10: 0.0026
+- train: median 0.763s/fold, mean 0.874s, p90 1.305s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.224 |
+| `mixture_hard_m_step` | 0.185 |
+| `mixture_balance_factor` | 0.170 |
+| `max_depth` | 0.083 |
+| `learning_rate` | 0.081 |
+| `mixture_routing_mode` | 0.060 |
+| `bagging_freq` | 0.056 |
+| `bagging_fraction` | 0.040 |
+| `num_leaves` | 0.034 |
+| `mixture_gate_type` | 0.023 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 268 | 0.0038 | 0.0097 | 0.0026 |
+| none | 16 | 0.0062 | 0.0046 | 0.0032 |
+| leaf_reuse | 16 | 0.0078 | 0.0063 | 0.0028 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 40 | 0.0041 | 0.0022 | 0.0028 |
+| token_choice | 260 | 0.0042 | 0.0100 | 0.0026 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 117 | 0.0037 | 0.0025 | 0.0027 |
+| em | 168 | 0.0043 | 0.0122 | 0.0026 |
+| gate_only | 15 | 0.0072 | 0.0056 | 0.0028 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 29 | 0.0041 | 0.0033 | 0.0027 |
+| tree_hierarchical | 233 | 0.0041 | 0.0104 | 0.0026 |
+| uniform | 24 | 0.0042 | 0.0033 | 0.0028 |
+| random | 14 | 0.0061 | 0.0068 | 0.0026 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 24 | 0.0040 | 0.0021 | 0.0028 |
+| markov | 253 | 0.0041 | 0.0101 | 0.0026 |
+| none | 23 | 0.0049 | 0.0041 | 0.0027 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 281 | 0.0034 | 0.0025 | 0.0026 |
+| False | 19 | 0.0150 | 0.0341 | 0.0027 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 172 | 0.0039 | 0.0033 | 0.0027 |
+| True | 128 | 0.0045 | 0.0138 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 0.0042 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 0.0035 | 0.0054 | 0.0037 | 0.0042 | **Q1** [None, 0.1484] |
+| `mixture_warmup_iters` | 0.0034 | 0.0049 | 0.0045 | 0.0038 | **Q1** [None, 12.0] |
+| `mixture_balance_factor` | 0.0066 | 0.0043 | — | 0.0032 | **Q4** [10.0, ∞) |
+| `learning_rate` | 0.0052 | 0.0034 | 0.0031 | 0.0050 | **Q3** [0.2295, 0.2635] |
+| `num_leaves` | 0.0031 | 0.0039 | 0.0061 | 0.0035 | **Q1** [None, 15.0] |
+| `max_depth` | 0.0085 | 0.0034 | 0.0034 | 0.0044 | **Q2** [4.0, 7.0] |
+| `min_data_in_leaf` | 0.0061 | 0.0034 | 0.0032 | 0.0043 | **Q3** [20.0, 24.25] |
+
+#### E. Slice plot
+
+![elevators@s43/moe](slice_elevators@s43_moe.png)
+
+
+---
+
+## elevators@s44  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00234** (winner retrained in 0.41s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0027
+- train: median 0.227s/fold, mean 0.222s, p90 0.323s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.631 |
+| `feature_fraction` | 0.092 |
+| `learning_rate` | 0.090 |
+| `bagging_fraction` | 0.051 |
+| `bagging_freq` | 0.050 |
+| `max_depth` | 0.038 |
+| `num_leaves` | 0.027 |
+| `min_data_in_leaf` | 0.016 |
+| `extra_trees` | 0.002 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.0028 | 0.0005 | 0.0026 |
+| True | 21 | 0.0035 | 0.0008 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0032 | 0.0027 | 0.0027 | 0.0029 | **Q2** [0.1153, 0.1319] |
+| `num_leaves` | 0.0031 | 0.0029 | 0.0028 | 0.0027 | **Q4** [124.0, ∞) |
+| `max_depth` | 0.0031 | 0.0028 | 0.0028 | 0.0028 | **Q2** [6.0, 7.0] |
+| `min_data_in_leaf` | 0.0029 | 0.0027 | 0.0028 | 0.0031 | **Q2** [15.0, 19.0] |
+| `lambda_l1` | 0.0030 | 0.0027 | 0.0028 | 0.0031 | **Q2** [0.0, 0.0002] |
+| `lambda_l2` | 0.0028 | 0.0028 | 0.0028 | 0.0030 | **Q1** [None, 0.0003] |
+| `feature_fraction` | 0.0032 | 0.0028 | 0.0028 | 0.0027 | **Q4** [0.9776, ∞) |
+| `bagging_fraction` | 0.0031 | 0.0029 | 0.0027 | 0.0027 | **Q3** [0.9628, 0.9815] |
+
+#### E. Slice plot
+
+![elevators@s44/naive-lightgbm](slice_elevators@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00217** (winner retrained in 3.39s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0026, p10: 0.0025
+- train: median 2.152s/fold, mean 2.322s, p90 4.357s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.675 |
+| `lambda_l2` | 0.087 |
+| `extra_trees` | 0.062 |
+| `mixture_diversity_lambda` | 0.043 |
+| `mixture_r_smoothing` | 0.030 |
+| `mixture_gate_type` | 0.016 |
+| `mixture_init` | 0.016 |
+| `num_leaves` | 0.015 |
+| `mixture_warmup_iters` | 0.015 |
+| `mixture_refit_leaves` | 0.014 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 239 | 0.0029 | 0.0020 | 0.0025 |
+| gbdt | 45 | 0.0040 | 0.0032 | 0.0026 |
+| none | 16 | 0.0055 | 0.0039 | 0.0029 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 280 | 0.0030 | 0.0018 | 0.0025 |
+| expert_choice | 20 | 0.0060 | 0.0059 | 0.0027 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 267 | 0.0030 | 0.0019 | 0.0025 |
+| loss_only | 16 | 0.0051 | 0.0041 | 0.0027 |
+| em | 17 | 0.0054 | 0.0047 | 0.0028 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 166 | 0.0029 | 0.0018 | 0.0025 |
+| random | 82 | 0.0030 | 0.0011 | 0.0025 |
+| tree_hierarchical | 40 | 0.0045 | 0.0044 | 0.0026 |
+| gmm | 12 | 0.0050 | 0.0046 | 0.0026 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 211 | 0.0031 | 0.0024 | 0.0025 |
+| none | 38 | 0.0035 | 0.0028 | 0.0025 |
+| ema | 51 | 0.0038 | 0.0020 | 0.0026 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0031 | 0.0023 | 0.0025 |
+| False | 21 | 0.0044 | 0.0036 | 0.0026 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 259 | 0.0031 | 0.0022 | 0.0025 |
+| True | 41 | 0.0042 | 0.0032 | 0.0027 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 0.0033 | 0.0046 | 0.0029 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0028 | 0.0029 | 0.0035 | 0.0036 | **Q1** [None, 0.0284] |
+| `mixture_warmup_iters` | 0.0028 | 0.0033 | 0.0030 | 0.0038 | **Q1** [None, 8.0] |
+| `mixture_balance_factor` | 0.0042 | 0.0033 | — | 0.0030 | **Q4** [9.0, ∞) |
+| `learning_rate` | 0.0041 | 0.0027 | 0.0029 | 0.0032 | **Q2** [0.1764, 0.2192] |
+| `num_leaves` | 0.0043 | 0.0027 | 0.0030 | 0.0029 | **Q2** [90.75, 99.5] |
+| `max_depth` | 0.0038 | 0.0032 | — | 0.0030 | **Q4** [8.0, ∞) |
+| `min_data_in_leaf` | 0.0035 | 0.0028 | 0.0029 | 0.0036 | **Q2** [17.0, 21.0] |
+
+#### E. Slice plot
+
+![elevators@s44/moe](slice_elevators@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v081/ds_elevators_summary.json
+++ b/bench_results/meth2_v081/ds_elevators_summary.json
@@ -1,0 +1,2754 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "elevators"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "elevators": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.0024475993016704815,
+      "cv_best": 0.0026330350603668623,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1413
+     },
+     "43": {
+      "holdout_rmse": 0.002364735983277477,
+      "cv_best": 0.0026565633378986203,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1509
+     },
+     "44": {
+      "holdout_rmse": 0.002340609908281478,
+      "cv_best": 0.0026358550583388644,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4052
+     }
+    },
+    "holdout_mean": 0.002384,
+    "holdout_std": 4.6e-05,
+    "cv_best_mean": 0.002642
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.0023241778146174735,
+      "cv_best": 0.0025000529921979124,
+      "crash_rate": 0.0,
+      "retrain_s": 2.1984
+     },
+     "43": {
+      "holdout_rmse": 0.0023991562110086957,
+      "cv_best": 0.0025576636460751165,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5411
+     },
+     "44": {
+      "holdout_rmse": 0.002171370007508384,
+      "cv_best": 0.0024760414773106016,
+      "crash_rate": 0.0,
+      "retrain_s": 3.3872
+     }
+    },
+    "holdout_mean": 0.002298,
+    "holdout_std": 9.5e-05,
+    "cv_best_mean": 0.002511
+   }
+  }
+ },
+ "runs": {
+  "elevators@s42": {
+   "dataset": "elevators",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021624375,
+    "std": 0.006717125937435966
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0026330350603668623,
+    "rmse_p10": 0.0026671229525594723,
+    "rmse_median": 0.0027124111761814007,
+    "train_s_median": 0.12353714220225812,
+    "train_s_mean": 0.13247178429240983,
+    "train_s_p90": 0.1805029317364097,
+    "best_params": {
+     "learning_rate": 0.23778434791157024,
+     "num_leaves": 15,
+     "max_depth": 6,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 0.00034200225716518373,
+     "lambda_l2": 0.00011876407186465006,
+     "feature_fraction": 0.9097243991797953,
+     "bagging_fraction": 0.9406735868207391,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.7333,
+     "learning_rate": 0.1882,
+     "extra_trees": 0.0317,
+     "bagging_freq": 0.0187,
+     "feature_fraction": 0.0172,
+     "num_leaves": 0.0043,
+     "bagging_fraction": 0.0026,
+     "max_depth": 0.002,
+     "min_data_in_leaf": 0.0019,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.0036,
+        "std": 0.0009,
+        "min": 0.0028
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.0028,
+        "std": 0.0004,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0008,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1755
+       ],
+       "n": 75,
+       "mean_rmse": 0.0033
+      },
+      "Q2": {
+       "range": [
+        0.1755,
+        0.2043
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2043,
+        0.2322
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.2322,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        41.25
+       ],
+       "n": 85,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        41.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0031
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 235,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        14.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        18.25
+       ],
+       "n": 86,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        18.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0015
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0015,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0011
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0011,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9043
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9043,
+        0.9313
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9313,
+        0.9528
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9528,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9313
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9313,
+        0.9559
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9559,
+        0.9726
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9726,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 206.5,
+    "holdout": {
+     "holdout_rmse": 0.0024475993016704815,
+     "retrain_s": 0.1413,
+     "predict_s": 0.0016,
+     "cv_rmse_of_winner": 0.0026330350603668623
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0025000529921979124,
+    "rmse_p10": 0.00252140028129443,
+    "rmse_median": 0.002598127489676398,
+    "train_s_median": 1.6902885785326363,
+    "train_s_mean": 1.5121814063924053,
+    "train_s_p90": 2.0598265841975807,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.29979764858922164,
+     "num_leaves": 98,
+     "max_depth": 5,
+     "min_data_in_leaf": 12,
+     "lambda_l1": 1.4043554341973093e-05,
+     "lambda_l2": 0.08131865554109383,
+     "feature_fraction": 0.9835273729636904,
+     "bagging_fraction": 0.6606625269173885,
+     "bagging_freq": 7,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 11,
+     "mixture_balance_factor": 10,
+     "mixture_smoothing_lambda": 0.3552162179734322,
+     "mixture_diversity_lambda": 0.3464858267394596,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 26,
+     "mixture_gate_learning_rate": 0.43599131278015907,
+     "mixture_gate_lambda_l2": 0.5324416218104209,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_retrain_interval": 6,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.3457,
+     "mixture_diversity_lambda": 0.1541,
+     "mixture_r_smoothing": 0.097,
+     "lambda_l1": 0.0761,
+     "num_leaves": 0.0578,
+     "max_depth": 0.0535,
+     "mixture_warmup_iters": 0.0485,
+     "mixture_e_step_mode": 0.0279,
+     "mixture_init": 0.0274,
+     "mixture_gate_type": 0.0272,
+     "min_data_in_leaf": 0.0259,
+     "lambda_l2": 0.0186,
+     "mixture_hard_m_step": 0.0162,
+     "feature_fraction": 0.0131,
+     "mixture_routing_mode": 0.0063,
+     "bagging_freq": 0.0021,
+     "bagging_fraction": 0.0009,
+     "extra_trees": 0.0006,
+     "mixture_num_experts": 0.0005,
+     "mixture_balance_factor": 0.0003,
+     "mixture_refit_leaves": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 255,
+        "mean": 0.0038,
+        "std": 0.0055,
+        "min": 0.0025
+       },
+       "none": {
+        "n": 21,
+        "mean": 0.0446,
+        "std": 0.1652,
+        "min": 0.0031
+       },
+       "gbdt": {
+        "n": 24,
+        "mean": 0.0046,
+        "std": 0.003,
+        "min": 0.0028
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0008,
+       "p_value": 0.257877,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 260,
+        "mean": 0.0068,
+        "std": 0.0485,
+        "min": 0.0025
+       },
+       "expert_choice": {
+        "n": 40,
+        "mean": 0.0058,
+        "std": 0.0062,
+        "min": 0.0028
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.001,
+       "p_value": 0.751611,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 32,
+        "mean": 0.0042,
+        "std": 0.0028,
+        "min": 0.0028
+       },
+       "gate_only": {
+        "n": 247,
+        "mean": 0.0067,
+        "std": 0.0496,
+        "min": 0.0025
+       },
+       "em": {
+        "n": 21,
+        "mean": 0.0106,
+        "std": 0.0155,
+        "min": 0.0031
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0025,
+       "p_value": 0.447735,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 33,
+        "mean": 0.0039,
+        "std": 0.0022,
+        "min": 0.0025
+       },
+       "gmm": {
+        "n": 15,
+        "mean": 0.0103,
+        "std": 0.0178,
+        "min": 0.0029
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 0.0615,
+        "std": 0.1928,
+        "min": 0.0038
+       },
+       "uniform": {
+        "n": 237,
+        "mean": 0.0034,
+        "std": 0.0037,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0005,
+       "p_value": 0.29261,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 174,
+        "mean": 0.0087,
+        "std": 0.0592,
+        "min": 0.0025
+       },
+       "markov": {
+        "n": 90,
+        "mean": 0.0037,
+        "std": 0.0036,
+        "min": 0.0025
+       },
+       "none": {
+        "n": 36,
+        "mean": 0.0047,
+        "std": 0.0037,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.001,
+       "p_value": 0.197685,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 243,
+        "mean": 0.007,
+        "std": 0.0502,
+        "min": 0.0025
+       },
+       "False": {
+        "n": 57,
+        "mean": 0.0053,
+        "std": 0.0055,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0017,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 35,
+        "mean": 0.0055,
+        "std": 0.0046,
+        "min": 0.003
+       },
+       "False": {
+        "n": 265,
+        "mean": 0.0069,
+        "std": 0.0481,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0014,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 14,
+       "mean_rmse": 0.006
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 166,
+       "mean_rmse": 0.0094
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 120,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3096
+       ],
+       "n": 75,
+       "mean_rmse": 0.0052
+      },
+      "Q2": {
+       "range": [
+        0.3096,
+        0.3476
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q3": {
+       "range": [
+        0.3476,
+        0.3936
+       ],
+       "n": 75,
+       "mean_rmse": 0.0132
+      },
+      "Q4": {
+       "range": [
+        0.3936,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0052
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0039
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        14.5
+       ],
+       "n": 79,
+       "mean_rmse": 0.0031
+      },
+      "Q3": {
+       "range": [
+        14.5,
+        26.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0049
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0141
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 55,
+       "mean_rmse": 0.0044
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.0153
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 164,
+       "mean_rmse": 0.0032
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.207
+       ],
+       "n": 75,
+       "mean_rmse": 0.006
+      },
+      "Q2": {
+       "range": [
+        0.207,
+        0.2608
+       ],
+       "n": 75,
+       "mean_rmse": 0.0044
+      },
+      "Q3": {
+       "range": [
+        0.2608,
+        0.2821
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        0.2821,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0132
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0151
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        86.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0049
+      },
+      "Q3": {
+       "range": [
+        86.0,
+        101.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        101.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.004
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 33,
+       "mean_rmse": 0.0037
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        9.0
+       ],
+       "n": 186,
+       "mean_rmse": 0.0079
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0052
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        12.5
+       ],
+       "n": 79,
+       "mean_rmse": 0.0037
+      },
+      "Q3": {
+       "range": [
+        12.5,
+        23.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0034
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0163
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 2307.4,
+    "holdout": {
+     "holdout_rmse": 0.0023241778146174735,
+     "retrain_s": 2.1984,
+     "predict_s": 0.0347,
+     "cv_rmse_of_winner": 0.0025000529921979124
+    }
+   }
+  },
+  "elevators@s43": {
+   "dataset": "elevators",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021558875,
+    "std": 0.0066420654720030425
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0026565633378986203,
+    "rmse_p10": 0.002680527752898886,
+    "rmse_median": 0.002715646736400354,
+    "train_s_median": 0.14913474675267935,
+    "train_s_mean": 0.1574584124510487,
+    "train_s_p90": 0.23005078606307516,
+    "best_params": {
+     "learning_rate": 0.22904905338999487,
+     "num_leaves": 13,
+     "max_depth": 9,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 0.0006508740691517306,
+     "lambda_l2": 2.9956687016156434e-07,
+     "feature_fraction": 0.9381780782007021,
+     "bagging_fraction": 0.913244587365999,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6099,
+     "learning_rate": 0.1466,
+     "feature_fraction": 0.0558,
+     "num_leaves": 0.0551,
+     "min_data_in_leaf": 0.0428,
+     "max_depth": 0.0387,
+     "extra_trees": 0.0299,
+     "bagging_fraction": 0.015,
+     "lambda_l2": 0.004,
+     "bagging_freq": 0.0022
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.0037,
+        "std": 0.0007,
+        "min": 0.0029
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.0028,
+        "std": 0.0005,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0009,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1548
+       ],
+       "n": 75,
+       "mean_rmse": 0.0033
+      },
+      "Q2": {
+       "range": [
+        0.1548,
+        0.1835
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.1835,
+        0.2143
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.2143,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        30.0
+       ],
+       "n": 82,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        49.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 22,
+       "mean_rmse": 0.0034
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 159,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        20.5
+       ],
+       "n": 82,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        20.5,
+        24.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 0.0032
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0015
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0015,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0911
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.0911,
+        0.4249
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        0.4249,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8619
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.8619,
+        0.9452
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.9452,
+        0.9712
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9712,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9085
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9085,
+        0.9387
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.9387,
+        0.9656
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        0.9656,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 244.4,
+    "holdout": {
+     "holdout_rmse": 0.002364735983277477,
+     "retrain_s": 0.1509,
+     "predict_s": 0.0016,
+     "cv_rmse_of_winner": 0.0026565633378986203
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0025576636460751165,
+    "rmse_p10": 0.002647477943524162,
+    "rmse_median": 0.002765700990147193,
+    "train_s_median": 0.7626893671229482,
+    "train_s_mean": 0.8743999050756295,
+    "train_s_p90": 1.3053157975524665,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.2632995931820673,
+     "num_leaves": 63,
+     "max_depth": 4,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 2.2783218772508002e-05,
+     "lambda_l2": 8.168381099105191e-05,
+     "feature_fraction": 0.9099536640180815,
+     "bagging_fraction": 0.5711253731426821,
+     "bagging_freq": 0,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 16,
+     "mixture_balance_factor": 3,
+     "mixture_smoothing_lambda": 0.42249704432581964,
+     "mixture_diversity_lambda": 0.20905904876195297,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 47,
+     "mixture_gate_learning_rate": 0.3700298324218646,
+     "mixture_gate_lambda_l2": 0.051991927848732855,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "lambda_l1": 0.2241,
+     "mixture_hard_m_step": 0.185,
+     "mixture_balance_factor": 0.1698,
+     "max_depth": 0.0832,
+     "learning_rate": 0.0814,
+     "mixture_routing_mode": 0.0604,
+     "bagging_freq": 0.0556,
+     "bagging_fraction": 0.0397,
+     "num_leaves": 0.0336,
+     "mixture_gate_type": 0.0233,
+     "mixture_diversity_lambda": 0.0146,
+     "min_data_in_leaf": 0.0112,
+     "mixture_init": 0.0063,
+     "mixture_e_step_mode": 0.0062,
+     "mixture_num_experts": 0.0018,
+     "feature_fraction": 0.0014,
+     "mixture_warmup_iters": 0.0012,
+     "mixture_r_smoothing": 0.0008,
+     "mixture_refit_leaves": 0.0006,
+     "lambda_l2": 0.0,
+     "extra_trees": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 268,
+        "mean": 0.0038,
+        "std": 0.0097,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0062,
+        "std": 0.0046,
+        "min": 0.0032
+       },
+       "leaf_reuse": {
+        "n": 16,
+        "mean": 0.0078,
+        "std": 0.0063,
+        "min": 0.0028
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0024,
+       "p_value": 0.090021,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 40,
+        "mean": 0.0041,
+        "std": 0.0022,
+        "min": 0.0028
+       },
+       "token_choice": {
+        "n": 260,
+        "mean": 0.0042,
+        "std": 0.01,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0001,
+       "p_value": 0.892923,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 117,
+        "mean": 0.0037,
+        "std": 0.0025,
+        "min": 0.0027
+       },
+       "em": {
+        "n": 168,
+        "mean": 0.0043,
+        "std": 0.0122,
+        "min": 0.0026
+       },
+       "gate_only": {
+        "n": 15,
+        "mean": 0.0072,
+        "std": 0.0056,
+        "min": 0.0028
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0006,
+       "p_value": 0.524983,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 29,
+        "mean": 0.0041,
+        "std": 0.0033,
+        "min": 0.0027
+       },
+       "tree_hierarchical": {
+        "n": 233,
+        "mean": 0.0041,
+        "std": 0.0104,
+        "min": 0.0026
+       },
+       "random": {
+        "n": 14,
+        "mean": 0.0061,
+        "std": 0.0068,
+        "min": 0.0026
+       },
+       "uniform": {
+        "n": 24,
+        "mean": 0.0042,
+        "std": 0.0033,
+        "min": 0.0028
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.969959,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 24,
+        "mean": 0.004,
+        "std": 0.0021,
+        "min": 0.0028
+       },
+       "none": {
+        "n": 23,
+        "mean": 0.0049,
+        "std": 0.0041,
+        "min": 0.0027
+       },
+       "markov": {
+        "n": 253,
+        "mean": 0.0041,
+        "std": 0.0101,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0001,
+       "p_value": 0.91295,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 281,
+        "mean": 0.0034,
+        "std": 0.0025,
+        "min": 0.0026
+       },
+       "False": {
+        "n": 19,
+        "mean": 0.015,
+        "std": 0.0341,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0116,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 172,
+        "mean": 0.0039,
+        "std": 0.0033,
+        "min": 0.0027
+       },
+       "True": {
+        "n": 128,
+        "mean": 0.0045,
+        "std": 0.0138,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 0.0042
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1484
+       ],
+       "n": 75,
+       "mean_rmse": 0.0035
+      },
+      "Q2": {
+       "range": [
+        0.1484,
+        0.2251
+       ],
+       "n": 75,
+       "mean_rmse": 0.0054
+      },
+      "Q3": {
+       "range": [
+        0.2251,
+        0.4388
+       ],
+       "n": 75,
+       "mean_rmse": 0.0037
+      },
+      "Q4": {
+       "range": [
+        0.4388,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0042
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.0034
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        18.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.0049
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        44.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0045
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0038
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0066
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        10.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0043
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 172,
+       "mean_rmse": 0.0032
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1704
+       ],
+       "n": 75,
+       "mean_rmse": 0.0052
+      },
+      "Q2": {
+       "range": [
+        0.1704,
+        0.2295
+       ],
+       "n": 75,
+       "mean_rmse": 0.0034
+      },
+      "Q3": {
+       "range": [
+        0.2295,
+        0.2635
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q4": {
+       "range": [
+        0.2635,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.005
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        35.5
+       ],
+       "n": 78,
+       "mean_rmse": 0.0039
+      },
+      "Q3": {
+       "range": [
+        35.5,
+        71.25
+       ],
+       "n": 75,
+       "mean_rmse": 0.0061
+      },
+      "Q4": {
+       "range": [
+        71.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0035
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 28,
+       "mean_rmse": 0.0085
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        7.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.0034
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0034
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.0044
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0061
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        20.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.0034
+      },
+      "Q3": {
+       "range": [
+        20.0,
+        24.25
+       ],
+       "n": 76,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        24.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0043
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1336.8,
+    "holdout": {
+     "holdout_rmse": 0.0023991562110086957,
+     "retrain_s": 0.5411,
+     "predict_s": 0.0089,
+     "cv_rmse_of_winner": 0.0025576636460751165
+    }
+   }
+  },
+  "elevators@s44": {
+   "dataset": "elevators",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021623500000000004,
+    "std": 0.006704326793198554
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0026358550583388644,
+    "rmse_p10": 0.002654763558637113,
+    "rmse_median": 0.002696921483605334,
+    "train_s_median": 0.22692839801311493,
+    "train_s_mean": 0.22227021957188847,
+    "train_s_p90": 0.3226113372668625,
+    "best_params": {
+     "learning_rate": 0.11710211476394085,
+     "num_leaves": 123,
+     "max_depth": 8,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 2.7563434176324515e-05,
+     "lambda_l2": 0.00028475448024112987,
+     "feature_fraction": 0.9924300268336325,
+     "bagging_fraction": 0.9732175073815882,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6315,
+     "feature_fraction": 0.0916,
+     "learning_rate": 0.0899,
+     "bagging_fraction": 0.0515,
+     "bagging_freq": 0.0502,
+     "max_depth": 0.0382,
+     "num_leaves": 0.0268,
+     "min_data_in_leaf": 0.0161,
+     "extra_trees": 0.0021,
+     "lambda_l2": 0.002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 279,
+        "mean": 0.0028,
+        "std": 0.0005,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 21,
+        "mean": 0.0035,
+        "std": 0.0008,
+        "min": 0.0029
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0007,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1153
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.1153,
+        0.1319
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.1319,
+        0.1556
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.1556,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        103.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        103.0,
+        119.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        119.0,
+        124.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 52,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 50,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 123,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        19.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        24.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0002,
+        0.0019
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0019,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0023
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0023,
+        0.0397
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0397,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8263
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "Q2": {
+       "range": [
+        0.8263,
+        0.9341
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9341,
+        0.9776
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9776,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9027
+       ],
+       "n": 75,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9027,
+        0.9628
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.9628,
+        0.9815
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9815,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 342.2,
+    "holdout": {
+     "holdout_rmse": 0.002340609908281478,
+     "retrain_s": 0.4052,
+     "predict_s": 0.0028,
+     "cv_rmse_of_winner": 0.0026358550583388644
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.0024760414773106016,
+    "rmse_p10": 0.002508692385147114,
+    "rmse_median": 0.002583121825605163,
+    "train_s_median": 2.152326114475727,
+    "train_s_mean": 2.322113054645558,
+    "train_s_p90": 4.3573971516639,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.28425624004410405,
+     "num_leaves": 100,
+     "max_depth": 8,
+     "min_data_in_leaf": 16,
+     "lambda_l1": 3.249888817641549e-07,
+     "lambda_l2": 1.418422352950057e-08,
+     "feature_fraction": 0.9137059222972593,
+     "bagging_fraction": 0.995769754659169,
+     "bagging_freq": 0,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 9,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.6567018324462699,
+     "mixture_diversity_lambda": 0.46758368733072336,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 10,
+     "mixture_gate_num_leaves": 35,
+     "mixture_gate_learning_rate": 0.04690965437393534,
+     "mixture_gate_lambda_l2": 0.33364356567693804,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 8,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.4020173569082328,
+     "mixture_refit_every_n": 13,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 5,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "lambda_l1": 0.6751,
+     "lambda_l2": 0.0873,
+     "extra_trees": 0.0617,
+     "mixture_diversity_lambda": 0.0434,
+     "mixture_r_smoothing": 0.0299,
+     "mixture_gate_type": 0.016,
+     "mixture_init": 0.0158,
+     "num_leaves": 0.0153,
+     "mixture_warmup_iters": 0.0153,
+     "mixture_refit_leaves": 0.0138,
+     "min_data_in_leaf": 0.0115,
+     "bagging_freq": 0.0114,
+     "mixture_hard_m_step": 0.0019,
+     "learning_rate": 0.0004,
+     "mixture_balance_factor": 0.0003,
+     "max_depth": 0.0003,
+     "mixture_routing_mode": 0.0003,
+     "bagging_fraction": 0.0003,
+     "mixture_e_step_mode": 0.0001,
+     "feature_fraction": 0.0,
+     "mixture_num_experts": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 45,
+        "mean": 0.004,
+        "std": 0.0032,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0055,
+        "std": 0.0039,
+        "min": 0.0029
+       },
+       "leaf_reuse": {
+        "n": 239,
+        "mean": 0.0029,
+        "std": 0.002,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0011,
+       "p_value": 0.039668,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 280,
+        "mean": 0.003,
+        "std": 0.0018,
+        "min": 0.0025
+       },
+       "expert_choice": {
+        "n": 20,
+        "mean": 0.006,
+        "std": 0.0059,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.003,
+       "p_value": 0.039765,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 267,
+        "mean": 0.003,
+        "std": 0.0019,
+        "min": 0.0025
+       },
+       "em": {
+        "n": 17,
+        "mean": 0.0054,
+        "std": 0.0047,
+        "min": 0.0028
+       },
+       "loss_only": {
+        "n": 16,
+        "mean": 0.0051,
+        "std": 0.0041,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0021,
+       "p_value": 0.06644,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 166,
+        "mean": 0.0029,
+        "std": 0.0018,
+        "min": 0.0025
+       },
+       "tree_hierarchical": {
+        "n": 40,
+        "mean": 0.0045,
+        "std": 0.0044,
+        "min": 0.0026
+       },
+       "random": {
+        "n": 82,
+        "mean": 0.003,
+        "std": 0.0011,
+        "min": 0.0025
+       },
+       "gmm": {
+        "n": 12,
+        "mean": 0.005,
+        "std": 0.0046,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0001,
+       "p_value": 0.836282,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 38,
+        "mean": 0.0035,
+        "std": 0.0028,
+        "min": 0.0025
+       },
+       "ema": {
+        "n": 51,
+        "mean": 0.0038,
+        "std": 0.002,
+        "min": 0.0026
+       },
+       "markov": {
+        "n": 211,
+        "mean": 0.0031,
+        "std": 0.0024,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.0004,
+       "p_value": 0.418824,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0031,
+        "std": 0.0023,
+        "min": 0.0025
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0044,
+        "std": 0.0036,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0013,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 41,
+        "mean": 0.0042,
+        "std": 0.0032,
+        "min": 0.0027
+       },
+       "False": {
+        "n": 259,
+        "mean": 0.0031,
+        "std": 0.0022,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0011,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 129,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 22,
+       "mean_rmse": 0.0046
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 149,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0284
+       ],
+       "n": 75,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0284,
+        0.0802
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        0.0802,
+        0.1898
+       ],
+       "n": 75,
+       "mean_rmse": 0.0035
+      },
+      "Q4": {
+       "range": [
+        0.1898,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0036
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        17.25
+       ],
+       "n": 84,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        17.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0038
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 42,
+       "mean_rmse": 0.0042
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 90,
+       "mean_rmse": 0.0033
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 168,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1764
+       ],
+       "n": 75,
+       "mean_rmse": 0.0041
+      },
+      "Q2": {
+       "range": [
+        0.1764,
+        0.2192
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2192,
+        0.2633
+       ],
+       "n": 75,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        0.2633,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0032
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        90.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0043
+      },
+      "Q2": {
+       "range": [
+        90.75,
+        99.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        99.5,
+        110.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        110.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0038
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 34,
+       "mean_rmse": 0.0032
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 205,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0035
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        21.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        24.25
+       ],
+       "n": 85,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        24.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0036
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 3529.4,
+    "holdout": {
+     "holdout_rmse": 0.002171370007508384,
+     "retrain_s": 3.3872,
+     "predict_s": 0.0576,
+     "cv_rmse_of_winner": 0.0024760414773106016
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_fred_gdp_report.md
+++ b/bench_results/meth2_v081/ds_fred_gdp_report.md
@@ -1,0 +1,674 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['fred_gdp'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `0cf3634c544c`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| fred_gdp | naive-lightgbm | **1.52767** ± 0.01959 | 0.80518 | 0.0% | 0.02 |
+| fred_gdp | naive-ensemble | **1.54257** ± 0.00696 | 0.80904 | 0.0% | 0.06 |
+| fred_gdp | moe | **1.48863** ± 0.01429 | 0.81671 | 0.0% | 0.95 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| fred_gdp@s42 | naive-lightgbm | 0.8046 | 0.8281 | 0.013 | 25 |
+| fred_gdp@s42 | naive-ensemble | 0.8127 | 0.8286 | 0.041 | 67 |
+| fred_gdp@s42 | moe | 0.8247 | 0.9069 | 0.150 | 282 |
+| fred_gdp@s43 | naive-lightgbm | 0.7992 | 0.8220 | 0.016 | 30 |
+| fred_gdp@s43 | naive-ensemble | 0.8044 | 0.8233 | 0.025 | 47 |
+| fred_gdp@s43 | moe | 0.8110 | 0.8575 | 0.129 | 218 |
+| fred_gdp@s44 | naive-lightgbm | 0.8117 | 0.8302 | 0.015 | 30 |
+| fred_gdp@s44 | naive-ensemble | 0.8101 | 0.8252 | 0.028 | 50 |
+| fred_gdp@s44 | moe | 0.8144 | 0.8929 | 0.120 | 987 |
+
+
+
+---
+
+## fred_gdp@s42  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.50612** (winner retrained in 0.02s, cv score of winner: 0.8046)
+- cv best RMSE: 0.8046, median: 0.8281, p10: 0.8113
+- train: median 0.013s/fold, mean 0.013s, p90 0.017s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.868 |
+| `learning_rate` | 0.041 |
+| `max_depth` | 0.022 |
+| `feature_fraction` | 0.017 |
+| `bagging_fraction` | 0.017 |
+| `bagging_freq` | 0.016 |
+| `extra_trees` | 0.010 |
+| `num_leaves` | 0.008 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.8276 | 0.0146 | 0.8046 |
+| True | 22 | 0.8415 | 0.0103 | 0.8237 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8370 | 0.8285 | 0.8227 | 0.8264 | **Q3** [0.2513, 0.2747] |
+| `num_leaves` | 0.8229 | 0.8247 | 0.8300 | 0.8367 | **Q1** [None, 12.0] |
+| `max_depth` | 0.8319 | 0.8270 | 0.8239 | 0.8327 | **Q3** [7.0, 8.0] |
+| `min_data_in_leaf` | 0.8392 | 0.8207 | 0.8220 | 0.8337 | **Q2** [20.0, 23.0] |
+| `lambda_l1` | 0.8320 | 0.8254 | 0.8293 | 0.8279 | **Q2** [0.0, 0.0001] |
+| `lambda_l2` | 0.8262 | 0.8260 | 0.8294 | 0.8330 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.8354 | 0.8244 | 0.8248 | 0.8301 | **Q2** [0.8639, 0.892] |
+| `bagging_fraction` | 0.8319 | 0.8227 | 0.8258 | 0.8343 | **Q2** [0.7971, 0.8357] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/naive-lightgbm](slice_fred_gdp@s42_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.55155** (winner retrained in 0.08s, cv score of winner: 0.8127)
+- cv best RMSE: 0.8127, median: 0.8286, p10: 0.8164
+- train: median 0.041s/fold, mean 0.041s, p90 0.052s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.904 |
+| `num_leaves` | 0.027 |
+| `bagging_fraction` | 0.023 |
+| `bagging_freq` | 0.020 |
+| `extra_trees` | 0.008 |
+| `learning_rate` | 0.005 |
+| `max_depth` | 0.004 |
+| `feature_fraction` | 0.004 |
+| `lambda_l2` | 0.004 |
+| `n_models` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.8284 | 0.0114 | 0.8127 |
+| True | 21 | 0.8417 | 0.0145 | 0.8194 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8336 | 0.8293 | 0.8236 | 0.8309 | **Q3** [0.1523, 0.188] |
+| `num_leaves` | 0.8360 | 0.8348 | 0.8256 | 0.8215 | **Q4** [125.0, ∞) |
+| `max_depth` | 0.8344 | 0.8354 | 0.8338 | 0.8232 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 0.8355 | 0.8253 | 0.8231 | 0.8340 | **Q3** [24.0, 28.0] |
+| `lambda_l1` | 0.8325 | 0.8353 | 0.8252 | 0.8243 | **Q4** [0.0286, ∞) |
+| `lambda_l2` | 0.8344 | 0.8308 | 0.8223 | 0.8298 | **Q3** [0.07, 0.386] |
+| `feature_fraction` | 0.8344 | 0.8309 | 0.8248 | 0.8274 | **Q3** [0.8997, 0.9372] |
+| `bagging_fraction` | 0.8364 | 0.8335 | 0.8226 | 0.8249 | **Q3** [0.8828, 0.949] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/naive-ensemble](slice_fred_gdp@s42_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 1.48024** (winner retrained in 0.37s, cv score of winner: 0.8247)
+- cv best RMSE: 0.8247, median: 0.9069, p10: 0.8512
+- train: median 0.150s/fold, mean 0.179s, p90 0.256s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.922 |
+| `lambda_l1` | 0.022 |
+| `mixture_warmup_iters` | 0.015 |
+| `mixture_balance_factor` | 0.010 |
+| `mixture_r_smoothing` | 0.005 |
+| `mixture_init` | 0.005 |
+| `mixture_diversity_lambda` | 0.003 |
+| `mixture_hard_m_step` | 0.003 |
+| `bagging_freq` | 0.002 |
+| `extra_trees` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 207 | 0.9094 | 0.0644 | 0.8391 |
+| none | 71 | 0.9238 | 0.0747 | 0.8247 |
+| gbdt | 22 | 0.9539 | 0.0743 | 0.8596 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 253 | 0.9124 | 0.0699 | 0.8247 |
+| expert_choice | 47 | 0.9356 | 0.0592 | 0.8509 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 227 | 0.9083 | 0.0689 | 0.8247 |
+| em | 42 | 0.9298 | 0.0536 | 0.8509 |
+| loss_only | 31 | 0.9544 | 0.0706 | 0.8558 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 208 | 0.9058 | 0.0608 | 0.8391 |
+| gmm | 45 | 0.9197 | 0.0762 | 0.8247 |
+| random | 30 | 0.9431 | 0.0742 | 0.8596 |
+| tree_hierarchical | 17 | 0.9842 | 0.0773 | 0.8633 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 150 | 0.9079 | 0.0657 | 0.8247 |
+| none | 131 | 0.9162 | 0.0618 | 0.8399 |
+| ema | 19 | 0.9795 | 0.0992 | 0.8555 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 197 | 0.9094 | 0.0695 | 0.8391 |
+| False | 103 | 0.9288 | 0.0657 | 0.8247 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 263 | 0.9070 | 0.0639 | 0.8247 |
+| False | 37 | 0.9806 | 0.0678 | 0.8945 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9731 | — | — | 0.9129 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 0.9455 | 0.9038 | 0.9111 | 0.9039 | **Q2** [0.3032, 0.3921] |
+| `mixture_warmup_iters` | 0.9316 | 0.8985 | 0.9177 | 0.9184 | **Q2** [26.0, 28.5] |
+| `mixture_balance_factor` | 0.9202 | — | 0.8969 | 0.9393 | **Q3** [5.0, 6.0] |
+| `learning_rate` | 0.9325 | 0.8995 | 0.9025 | 0.9298 | **Q2** [0.0718, 0.0894] |
+| `num_leaves` | 0.9118 | 0.9357 | 0.9036 | 0.9126 | **Q3** [95.0, 111.0] |
+| `max_depth` | 0.9240 | 0.9167 | 0.9007 | 0.9267 | **Q3** [7.0, 8.0] |
+| `min_data_in_leaf` | 0.8848 | 0.8697 | 0.9137 | 0.9865 | **Q2** [9.0, 11.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/moe](slice_fred_gdp@s42_moe.png)
+
+
+---
+
+## fred_gdp@s43  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.55352** (winner retrained in 0.03s, cv score of winner: 0.7992)
+- cv best RMSE: 0.7992, median: 0.8220, p10: 0.8085
+- train: median 0.016s/fold, mean 0.016s, p90 0.021s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.906 |
+| `bagging_fraction` | 0.059 |
+| `bagging_freq` | 0.008 |
+| `lambda_l1` | 0.007 |
+| `learning_rate` | 0.007 |
+| `feature_fraction` | 0.006 |
+| `num_leaves` | 0.004 |
+| `max_depth` | 0.002 |
+| `extra_trees` | 0.000 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.8294 | 0.0263 | 0.7992 |
+| True | 22 | 0.8461 | 0.0274 | 0.8170 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8366 | 0.8283 | 0.8300 | 0.8273 | **Q4** [0.2758, ∞) |
+| `num_leaves` | 0.8261 | 0.8267 | 0.8299 | 0.8396 | **Q1** [None, 15.0] |
+| `max_depth` | 0.8351 | 0.8372 | 0.8280 | 0.8230 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.8565 | 0.8175 | 0.8182 | 0.8338 | **Q2** [14.0, 17.0] |
+| `lambda_l1` | 0.8284 | 0.8235 | 0.8347 | 0.8357 | **Q2** [0.0001, 0.0004] |
+| `lambda_l2` | 0.8363 | 0.8285 | 0.8232 | 0.8343 | **Q3** [0.0001, 0.0003] |
+| `feature_fraction` | 0.8343 | 0.8259 | 0.8245 | 0.8376 | **Q3** [0.6627, 0.6925] |
+| `bagging_fraction` | 0.8400 | 0.8243 | 0.8248 | 0.8332 | **Q2** [0.8401, 0.8623] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/naive-lightgbm](slice_fred_gdp@s43_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.54157** (winner retrained in 0.04s, cv score of winner: 0.8044)
+- cv best RMSE: 0.8044, median: 0.8233, p10: 0.8116
+- train: median 0.025s/fold, mean 0.027s, p90 0.039s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.968 |
+| `bagging_fraction` | 0.010 |
+| `learning_rate` | 0.009 |
+| `extra_trees` | 0.004 |
+| `feature_fraction` | 0.004 |
+| `num_leaves` | 0.002 |
+| `max_depth` | 0.001 |
+| `bagging_freq` | 0.001 |
+| `n_models` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 271 | 0.8246 | 0.0138 | 0.8044 |
+| True | 29 | 0.8374 | 0.0148 | 0.8095 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8365 | 0.8277 | 0.8204 | 0.8187 | **Q4** [0.2708, ∞) |
+| `num_leaves` | 0.8344 | 0.8249 | 0.8207 | 0.8237 | **Q3** [77.0, 86.0] |
+| `max_depth` | — | — | 0.8220 | 0.8368 | **Q3** [3.0, 5.0] |
+| `min_data_in_leaf` | 0.8329 | 0.8181 | 0.8189 | 0.8324 | **Q2** [22.0, 25.0] |
+| `lambda_l1` | 0.8341 | 0.8295 | 0.8200 | 0.8196 | **Q4** [0.1685, ∞) |
+| `lambda_l2` | 0.8283 | 0.8204 | 0.8208 | 0.8337 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.8337 | 0.8199 | 0.8220 | 0.8276 | **Q2** [0.858, 0.8859] |
+| `bagging_fraction` | 0.8328 | 0.8277 | 0.8205 | 0.8223 | **Q3** [0.9404, 0.9672] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/naive-ensemble](slice_fred_gdp@s43_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 1.50874** (winner retrained in 0.10s, cv score of winner: 0.8110)
+- cv best RMSE: 0.8110, median: 0.8575, p10: 0.8264
+- train: median 0.129s/fold, mean 0.136s, p90 0.197s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.950 |
+| `learning_rate` | 0.006 |
+| `mixture_diversity_lambda` | 0.005 |
+| `lambda_l1` | 0.005 |
+| `mixture_r_smoothing` | 0.005 |
+| `bagging_freq` | 0.004 |
+| `mixture_init` | 0.004 |
+| `mixture_num_experts` | 0.004 |
+| `mixture_gate_type` | 0.004 |
+| `mixture_balance_factor` | 0.003 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 0.8863 (n=264) | gbdt | Δ +0.0561 | p=7.00e-04 |
+| `mixture_routing_mode` | **expert_choice** | 0.8851 (n=270) | token_choice | Δ +0.0861 | p=1.10e-05 |
+| `mixture_init` | **random** | 0.8757 (n=248) | uniform | Δ +0.0920 | p=6.80e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 264 | 0.8863 | 0.0779 | 0.8110 |
+| gbdt | 19 | 0.9424 | 0.0573 | 0.8439 |
+| none | 17 | 0.9547 | 0.0818 | 0.8431 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 270 | 0.8851 | 0.0739 | 0.8110 |
+| token_choice | 30 | 0.9712 | 0.0867 | 0.8315 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 252 | 0.8856 | 0.0755 | 0.8110 |
+| em | 29 | 0.9279 | 0.0864 | 0.8252 |
+| loss_only | 19 | 0.9485 | 0.0861 | 0.8351 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 248 | 0.8757 | 0.0670 | 0.8110 |
+| uniform | 14 | 0.9677 | 0.0587 | 0.9234 |
+| gmm | 14 | 0.9713 | 0.0810 | 0.8805 |
+| tree_hierarchical | 24 | 0.9910 | 0.0867 | 0.8802 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 227 | 0.8885 | 0.0772 | 0.8110 |
+| none | 55 | 0.8985 | 0.0823 | 0.8160 |
+| ema | 18 | 0.9451 | 0.0819 | 0.8351 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 146 | 0.8828 | 0.0788 | 0.8110 |
+| False | 154 | 0.9040 | 0.0790 | 0.8128 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 277 | 0.8874 | 0.0776 | 0.8110 |
+| False | 23 | 0.9698 | 0.0625 | 0.8640 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9928 | — | — | 0.8903 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 0.9146 | 0.8600 | 0.8724 | 0.9277 | **Q2** [0.1808, 0.201] |
+| `mixture_warmup_iters` | 0.9455 | 0.8860 | 0.8743 | 0.8746 | **Q3** [48.0, 49.0] |
+| `mixture_balance_factor` | 0.9184 | — | — | 0.8869 | **Q4** [6.0, ∞) |
+| `learning_rate` | 0.9064 | 0.8630 | 0.8918 | 0.9135 | **Q2** [0.0491, 0.0555] |
+| `num_leaves` | 0.8931 | 0.8678 | 0.8921 | 0.9227 | **Q2** [39.0, 47.5] |
+| `max_depth` | — | — | 0.8804 | 0.9081 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 0.8569 | 0.8455 | 0.8729 | 0.9814 | **Q2** [7.0, 9.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/moe](slice_fred_gdp@s43_moe.png)
+
+
+---
+
+## fred_gdp@s44  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.52337** (winner retrained in 0.02s, cv score of winner: 0.8117)
+- cv best RMSE: 0.8117, median: 0.8302, p10: 0.8197
+- train: median 0.015s/fold, mean 0.016s, p90 0.024s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.740 |
+| `learning_rate` | 0.153 |
+| `bagging_fraction` | 0.054 |
+| `num_leaves` | 0.015 |
+| `bagging_freq` | 0.014 |
+| `extra_trees` | 0.011 |
+| `max_depth` | 0.009 |
+| `feature_fraction` | 0.004 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 273 | 0.8323 | 0.0129 | 0.8117 |
+| True | 27 | 0.8364 | 0.0097 | 0.8218 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8337 | 0.8346 | 0.8311 | 0.8314 | **Q3** [0.0474, 0.0804] |
+| `num_leaves` | 0.8316 | 0.8285 | 0.8311 | 0.8390 | **Q2** [20.0, 29.0] |
+| `max_depth` | 0.8363 | 0.8330 | 0.8297 | 0.8354 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 0.8391 | 0.8294 | 0.8254 | 0.8376 | **Q3** [16.0, 20.0] |
+| `lambda_l1` | 0.8321 | 0.8339 | 0.8289 | 0.8359 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.8372 | 0.8316 | 0.8311 | 0.8309 | **Q4** [0.2105, ∞) |
+| `feature_fraction` | 0.8376 | 0.8345 | 0.8291 | 0.8297 | **Q3** [0.748, 0.8971] |
+| `bagging_fraction` | 0.8316 | 0.8278 | 0.8316 | 0.8398 | **Q2** [0.5409, 0.5594] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/naive-lightgbm](slice_fred_gdp@s44_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.53460** (winner retrained in 0.05s, cv score of winner: 0.8101)
+- cv best RMSE: 0.8101, median: 0.8252, p10: 0.8139
+- train: median 0.028s/fold, mean 0.029s, p90 0.038s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.920 |
+| `learning_rate` | 0.030 |
+| `bagging_fraction` | 0.011 |
+| `num_leaves` | 0.010 |
+| `bagging_freq` | 0.009 |
+| `extra_trees` | 0.008 |
+| `feature_fraction` | 0.006 |
+| `max_depth` | 0.003 |
+| `lambda_l2` | 0.002 |
+| `n_models` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 260 | 0.8255 | 0.0107 | 0.8101 |
+| True | 40 | 0.8375 | 0.0134 | 0.8162 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8293 | 0.8223 | 0.8294 | 0.8274 | **Q2** [0.0498, 0.0854] |
+| `num_leaves` | 0.8260 | 0.8283 | 0.8293 | 0.8250 | **Q4** [116.0, ∞) |
+| `max_depth` | 0.8279 | 0.8305 | — | 0.8255 | **Q4** [10.0, ∞) |
+| `min_data_in_leaf` | 0.8336 | 0.8205 | 0.8206 | 0.8342 | **Q2** [22.0, 25.0] |
+| `lambda_l1` | 0.8314 | 0.8214 | 0.8256 | 0.8301 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 0.8303 | 0.8270 | 0.8229 | 0.8283 | **Q3** [0.186, 0.9973] |
+| `feature_fraction` | 0.8331 | 0.8271 | 0.8217 | 0.8265 | **Q3** [0.7364, 0.7612] |
+| `bagging_fraction` | 0.8256 | 0.8257 | 0.8263 | 0.8309 | **Q1** [None, 0.7274] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/naive-ensemble](slice_fred_gdp@s44_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 1.47690** (winner retrained in 2.37s, cv score of winner: 0.8144)
+- cv best RMSE: 0.8144, median: 0.8929, p10: 0.8341
+- train: median 0.120s/fold, mean 0.651s, p90 2.584s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.973 |
+| `learning_rate` | 0.006 |
+| `extra_trees` | 0.005 |
+| `num_leaves` | 0.004 |
+| `mixture_diversity_lambda` | 0.002 |
+| `mixture_gate_type` | 0.002 |
+| `mixture_warmup_iters` | 0.001 |
+| `feature_fraction` | 0.001 |
+| `mixture_balance_factor` | 0.001 |
+| `bagging_fraction` | 0.001 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 0.8915 (n=259) | expert_choice | Δ +0.0768 | p=0.00e+00 |
+| `mixture_r_smoothing` | **none** | 0.8897 (n=212) | ema | Δ +0.0391 | p=1.78e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 162 | 0.8907 | 0.0592 | 0.8256 |
+| none | 72 | 0.9094 | 0.0890 | 0.8144 |
+| leaf_reuse | 66 | 0.9217 | 0.0647 | 0.8360 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 259 | 0.8915 | 0.0636 | 0.8144 |
+| expert_choice | 41 | 0.9683 | 0.0715 | 0.8406 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 165 | 0.8914 | 0.0623 | 0.8256 |
+| loss_only | 69 | 0.9076 | 0.0817 | 0.8144 |
+| em | 66 | 0.9228 | 0.0688 | 0.8360 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 121 | 0.8842 | 0.0712 | 0.8144 |
+| uniform | 142 | 0.9013 | 0.0618 | 0.8256 |
+| tree_hierarchical | 13 | 0.9515 | 0.0417 | 0.8979 |
+| gmm | 24 | 0.9695 | 0.0670 | 0.8761 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 212 | 0.8897 | 0.0651 | 0.8144 |
+| ema | 42 | 0.9288 | 0.0707 | 0.8357 |
+| markov | 46 | 0.9342 | 0.0733 | 0.8158 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 174 | 0.8988 | 0.0746 | 0.8144 |
+| True | 126 | 0.9064 | 0.0624 | 0.8308 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.8956 | 0.0636 | 0.8144 |
+| False | 21 | 0.9872 | 0.0904 | 0.8564 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9486 | — | — | 0.8865 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.9032 | 0.8832 | 0.8999 | 0.9219 | **Q2** [0.0405, 0.065] |
+| `mixture_warmup_iters` | 0.9052 | 0.9238 | 0.8881 | 0.8910 | **Q3** [29.0, 34.0] |
+| `mixture_balance_factor` | 0.9381 | 0.8828 | 0.9040 | 0.9018 | **Q2** [7.0, 8.0] |
+| `learning_rate` | 0.9000 | 0.8881 | 0.9039 | 0.9161 | **Q2** [0.0432, 0.0658] |
+| `num_leaves` | 0.9232 | 0.8965 | 0.9059 | 0.8824 | **Q4** [90.5, ∞) |
+| `max_depth` | 0.9249 | 0.8789 | 0.9109 | 0.9158 | **Q2** [6.0, 7.0] |
+| `min_data_in_leaf` | 0.8756 | 0.8530 | 0.8943 | 0.9794 | **Q2** [8.0, 11.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/moe](slice_fred_gdp@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| fred_gdp@s43 | `mixture_gate_type` | **leaf_reuse** | +0.0561 | 7.00e-04 |
+| fred_gdp@s43 | `mixture_routing_mode` | **expert_choice** | +0.0861 | 1.10e-05 |
+| fred_gdp@s43 | `mixture_init` | **random** | +0.0920 | 6.80e-05 |
+| fred_gdp@s44 | `mixture_routing_mode` | **token_choice** | +0.0768 | 0.00e+00 |
+| fred_gdp@s44 | `mixture_r_smoothing` | **none** | +0.0391 | 1.78e-03 |

--- a/bench_results/meth2_v081/ds_fred_gdp_summary.json
+++ b/bench_results/meth2_v081/ds_fred_gdp_summary.json
@@ -1,0 +1,3822 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "fred_gdp"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "0cf3634c544c8f91ada2261bdf448aad9bd4b491",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "fred_gdp": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.5061180109801906,
+      "cv_best": 0.8045707992835883,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0173
+     },
+     "43": {
+      "holdout_rmse": 1.5535232842937101,
+      "cv_best": 0.7992196638224648,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0336
+     },
+     "44": {
+      "holdout_rmse": 1.5233652372424795,
+      "cv_best": 0.8117366524936191,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0186
+     }
+    },
+    "holdout_mean": 1.527669,
+    "holdout_std": 0.019591,
+    "cv_best_mean": 0.805176
+   },
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.5515502482026273,
+      "cv_best": 0.8126744258544232,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0754
+     },
+     "43": {
+      "holdout_rmse": 1.541573367898821,
+      "cv_best": 0.804377846648159,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0371
+     },
+     "44": {
+      "holdout_rmse": 1.534599671220673,
+      "cv_best": 0.8100747886665787,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0549
+     }
+    },
+    "holdout_mean": 1.542574,
+    "holdout_std": 0.006956,
+    "cv_best_mean": 0.809042
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.4802434075723592,
+      "cv_best": 0.8247322611349475,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3714
+     },
+     "43": {
+      "holdout_rmse": 1.5087389560110513,
+      "cv_best": 0.8109643794506072,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0991
+     },
+     "44": {
+      "holdout_rmse": 1.4768956526684103,
+      "cv_best": 0.8144318837045725,
+      "crash_rate": 0.0,
+      "retrain_s": 2.3726
+     }
+    },
+    "holdout_mean": 1.488626,
+    "holdout_std": 0.014288,
+    "cv_best_mean": 0.81671
+   }
+  }
+ },
+ "runs": {
+  "fred_gdp@s42": {
+   "dataset": "fred_gdp",
+   "seed": 42,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8045707992835883,
+    "rmse_p10": 0.8112900804650067,
+    "rmse_median": 0.8281294145677633,
+    "train_s_median": 0.012732263654470444,
+    "train_s_mean": 0.013273282472044231,
+    "train_s_p90": 0.016616754233837128,
+    "best_params": {
+     "learning_rate": 0.26813269780124827,
+     "num_leaves": 10,
+     "max_depth": 3,
+     "min_data_in_leaf": 22,
+     "lambda_l1": 0.12967856053900614,
+     "lambda_l2": 1.4845794718946206e-06,
+     "feature_fraction": 0.9131884423534623,
+     "bagging_fraction": 0.8419513249064565,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8679,
+     "learning_rate": 0.041,
+     "max_depth": 0.0225,
+     "feature_fraction": 0.0172,
+     "bagging_fraction": 0.0167,
+     "bagging_freq": 0.016,
+     "extra_trees": 0.0103,
+     "num_leaves": 0.0083,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.8415,
+        "std": 0.0103,
+        "min": 0.8237
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.8276,
+        "std": 0.0146,
+        "min": 0.8046
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0139,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2113
+       ],
+       "n": 75,
+       "mean_rmse": 0.837
+      },
+      "Q2": {
+       "range": [
+        0.2113,
+        0.2513
+       ],
+       "n": 75,
+       "mean_rmse": 0.8285
+      },
+      "Q3": {
+       "range": [
+        0.2513,
+        0.2747
+       ],
+       "n": 75,
+       "mean_rmse": 0.8227
+      },
+      "Q4": {
+       "range": [
+        0.2747,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8264
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8229
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8247
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        24.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.83
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.8367
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.8319
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 97,
+       "mean_rmse": 0.827
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.8239
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 92,
+       "mean_rmse": 0.8327
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.8392
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        23.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.8207
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        28.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.822
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.8337
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.832
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8254
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0005
+       ],
+       "n": 75,
+       "mean_rmse": 0.8293
+      },
+      "Q4": {
+       "range": [
+        0.0005,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8279
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8262
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.826
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8294
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.833
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8639
+       ],
+       "n": 75,
+       "mean_rmse": 0.8354
+      },
+      "Q2": {
+       "range": [
+        0.8639,
+        0.892
+       ],
+       "n": 75,
+       "mean_rmse": 0.8244
+      },
+      "Q3": {
+       "range": [
+        0.892,
+        0.9171
+       ],
+       "n": 75,
+       "mean_rmse": 0.8248
+      },
+      "Q4": {
+       "range": [
+        0.9171,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8301
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7971
+       ],
+       "n": 75,
+       "mean_rmse": 0.8319
+      },
+      "Q2": {
+       "range": [
+        0.7971,
+        0.8357
+       ],
+       "n": 75,
+       "mean_rmse": 0.8227
+      },
+      "Q3": {
+       "range": [
+        0.8357,
+        0.8839
+       ],
+       "n": 75,
+       "mean_rmse": 0.8258
+      },
+      "Q4": {
+       "range": [
+        0.8839,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8343
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 25.4,
+    "holdout": {
+     "holdout_rmse": 1.5061180109801906,
+     "retrain_s": 0.0173,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8045707992835883
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8126744258544232,
+    "rmse_p10": 0.8163893048899579,
+    "rmse_median": 0.8285737852491809,
+    "train_s_median": 0.04057421814650297,
+    "train_s_mean": 0.04075189238414168,
+    "train_s_p90": 0.052275385856628435,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.19864151643367597,
+     "num_leaves": 126,
+     "max_depth": 12,
+     "min_data_in_leaf": 27,
+     "lambda_l1": 0.004424700876674261,
+     "lambda_l2": 0.006878647014152555,
+     "feature_fraction": 0.9140661874595216,
+     "bagging_fraction": 0.9414287102354527,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9039,
+     "num_leaves": 0.0269,
+     "bagging_fraction": 0.0233,
+     "bagging_freq": 0.0199,
+     "extra_trees": 0.0079,
+     "learning_rate": 0.0046,
+     "max_depth": 0.0045,
+     "feature_fraction": 0.0037,
+     "lambda_l2": 0.0035,
+     "n_models": 0.0017,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 279,
+        "mean": 0.8284,
+        "std": 0.0114,
+        "min": 0.8127
+       },
+       "True": {
+        "n": 21,
+        "mean": 0.8417,
+        "std": 0.0145,
+        "min": 0.8194
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0133,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0857
+       ],
+       "n": 75,
+       "mean_rmse": 0.8336
+      },
+      "Q2": {
+       "range": [
+        0.0857,
+        0.1523
+       ],
+       "n": 75,
+       "mean_rmse": 0.8293
+      },
+      "Q3": {
+       "range": [
+        0.1523,
+        0.188
+       ],
+       "n": 75,
+       "mean_rmse": 0.8236
+      },
+      "Q4": {
+       "range": [
+        0.188,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        82.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.836
+      },
+      "Q2": {
+       "range": [
+        82.0,
+        116.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.8348
+      },
+      "Q3": {
+       "range": [
+        116.5,
+        125.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.8256
+      },
+      "Q4": {
+       "range": [
+        125.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.8215
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.8344
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 98,
+       "mean_rmse": 0.8354
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 19,
+       "mean_rmse": 0.8338
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 143,
+       "mean_rmse": 0.8232
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.8355
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        24.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.8253
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        28.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.8231
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.834
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8325
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.8353
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0286
+       ],
+       "n": 75,
+       "mean_rmse": 0.8252
+      },
+      "Q4": {
+       "range": [
+        0.0286,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8243
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8344
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.07
+       ],
+       "n": 75,
+       "mean_rmse": 0.8308
+      },
+      "Q3": {
+       "range": [
+        0.07,
+        0.386
+       ],
+       "n": 75,
+       "mean_rmse": 0.8223
+      },
+      "Q4": {
+       "range": [
+        0.386,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8298
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.763
+       ],
+       "n": 75,
+       "mean_rmse": 0.8344
+      },
+      "Q2": {
+       "range": [
+        0.763,
+        0.8997
+       ],
+       "n": 75,
+       "mean_rmse": 0.8309
+      },
+      "Q3": {
+       "range": [
+        0.8997,
+        0.9372
+       ],
+       "n": 75,
+       "mean_rmse": 0.8248
+      },
+      "Q4": {
+       "range": [
+        0.9372,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8274
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7016
+       ],
+       "n": 75,
+       "mean_rmse": 0.8364
+      },
+      "Q2": {
+       "range": [
+        0.7016,
+        0.8828
+       ],
+       "n": 75,
+       "mean_rmse": 0.8335
+      },
+      "Q3": {
+       "range": [
+        0.8828,
+        0.949
+       ],
+       "n": 75,
+       "mean_rmse": 0.8226
+      },
+      "Q4": {
+       "range": [
+        0.949,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8249
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 67.2,
+    "holdout": {
+     "holdout_rmse": 1.5515502482026273,
+     "retrain_s": 0.0754,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.8126744258544232
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8247322611349475,
+    "rmse_p10": 0.8511553972066022,
+    "rmse_median": 0.9068590743149194,
+    "train_s_median": 0.14967499282211066,
+    "train_s_mean": 0.17874214935551086,
+    "train_s_p90": 0.25617433395236744,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.07226406619570223,
+     "num_leaves": 90,
+     "max_depth": 8,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 0.009416154422590754,
+     "lambda_l2": 0.0009049009977903102,
+     "feature_fraction": 0.5092566576404041,
+     "bagging_fraction": 0.5303922190709263,
+     "bagging_freq": 3,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 31,
+     "mixture_balance_factor": 5,
+     "mixture_smoothing_lambda": 0.7179526543222657,
+     "mixture_diversity_lambda": 0.2725347005056328,
+     "mixture_hard_m_step": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.3472217455506064,
+     "mixture_refit_every_n": 12,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 5,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9218,
+     "lambda_l1": 0.0224,
+     "mixture_warmup_iters": 0.0146,
+     "mixture_balance_factor": 0.0104,
+     "mixture_r_smoothing": 0.0053,
+     "mixture_init": 0.005,
+     "mixture_diversity_lambda": 0.0029,
+     "mixture_hard_m_step": 0.0027,
+     "bagging_freq": 0.0019,
+     "extra_trees": 0.0018,
+     "mixture_num_experts": 0.0017,
+     "lambda_l2": 0.0015,
+     "mixture_refit_leaves": 0.0014,
+     "mixture_routing_mode": 0.0011,
+     "num_leaves": 0.0011,
+     "max_depth": 0.0011,
+     "learning_rate": 0.0009,
+     "mixture_e_step_mode": 0.0009,
+     "mixture_gate_type": 0.0007,
+     "feature_fraction": 0.0005,
+     "bagging_fraction": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 207,
+        "mean": 0.9094,
+        "std": 0.0644,
+        "min": 0.8391
+       },
+       "none": {
+        "n": 71,
+        "mean": 0.9238,
+        "std": 0.0747,
+        "min": 0.8247
+       },
+       "gbdt": {
+        "n": 22,
+        "mean": 0.9539,
+        "std": 0.0743,
+        "min": 0.8596
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0144,
+       "p_value": 0.153723,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 253,
+        "mean": 0.9124,
+        "std": 0.0699,
+        "min": 0.8247
+       },
+       "expert_choice": {
+        "n": 47,
+        "mean": 0.9356,
+        "std": 0.0592,
+        "min": 0.8509
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0232,
+       "p_value": 0.020714,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 31,
+        "mean": 0.9544,
+        "std": 0.0706,
+        "min": 0.8558
+       },
+       "gate_only": {
+        "n": 227,
+        "mean": 0.9083,
+        "std": 0.0689,
+        "min": 0.8247
+       },
+       "em": {
+        "n": 42,
+        "mean": 0.9298,
+        "std": 0.0536,
+        "min": 0.8509
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0215,
+       "p_value": 0.027604,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 30,
+        "mean": 0.9431,
+        "std": 0.0742,
+        "min": 0.8596
+       },
+       "gmm": {
+        "n": 45,
+        "mean": 0.9197,
+        "std": 0.0762,
+        "min": 0.8247
+       },
+       "tree_hierarchical": {
+        "n": 17,
+        "mean": 0.9842,
+        "std": 0.0773,
+        "min": 0.8633
+       },
+       "uniform": {
+        "n": 208,
+        "mean": 0.9058,
+        "std": 0.0608,
+        "min": 0.8391
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "gmm",
+       "delta_mean": 0.0139,
+       "p_value": 0.260388,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 19,
+        "mean": 0.9795,
+        "std": 0.0992,
+        "min": 0.8555
+       },
+       "markov": {
+        "n": 150,
+        "mean": 0.9079,
+        "std": 0.0657,
+        "min": 0.8247
+       },
+       "none": {
+        "n": 131,
+        "mean": 0.9162,
+        "std": 0.0618,
+        "min": 0.8399
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.0083,
+       "p_value": 0.28163,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 197,
+        "mean": 0.9094,
+        "std": 0.0695,
+        "min": 0.8391
+       },
+       "False": {
+        "n": 103,
+        "mean": 0.9288,
+        "std": 0.0657,
+        "min": 0.8247
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0194,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 263,
+        "mean": 0.907,
+        "std": 0.0639,
+        "min": 0.8247
+       },
+       "False": {
+        "n": 37,
+        "mean": 0.9806,
+        "std": 0.0678,
+        "min": 0.8945
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0736,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 16,
+       "mean_rmse": 0.9731
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 284,
+       "mean_rmse": 0.9129
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3032
+       ],
+       "n": 75,
+       "mean_rmse": 0.9455
+      },
+      "Q2": {
+       "range": [
+        0.3032,
+        0.3921
+       ],
+       "n": 75,
+       "mean_rmse": 0.9038
+      },
+      "Q3": {
+       "range": [
+        0.3921,
+        0.4536
+       ],
+       "n": 75,
+       "mean_rmse": 0.9111
+      },
+      "Q4": {
+       "range": [
+        0.4536,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9039
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.9316
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        28.5
+       ],
+       "n": 80,
+       "mean_rmse": 0.8985
+      },
+      "Q3": {
+       "range": [
+        28.5,
+        31.0
+       ],
+       "n": 49,
+       "mean_rmse": 0.9177
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 101,
+       "mean_rmse": 0.9184
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.9202
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 133,
+       "mean_rmse": 0.8969
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 97,
+       "mean_rmse": 0.9393
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0718
+       ],
+       "n": 75,
+       "mean_rmse": 0.9325
+      },
+      "Q2": {
+       "range": [
+        0.0718,
+        0.0894
+       ],
+       "n": 75,
+       "mean_rmse": 0.8995
+      },
+      "Q3": {
+       "range": [
+        0.0894,
+        0.1149
+       ],
+       "n": 75,
+       "mean_rmse": 0.9025
+      },
+      "Q4": {
+       "range": [
+        0.1149,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9298
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        54.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.9118
+      },
+      "Q2": {
+       "range": [
+        54.0,
+        95.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.9357
+      },
+      "Q3": {
+       "range": [
+        95.0,
+        111.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.9036
+      },
+      "Q4": {
+       "range": [
+        111.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.9126
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 57,
+       "mean_rmse": 0.924
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.9167
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.9007
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.9267
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.8848
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.8697
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        15.0
+       ],
+       "n": 82,
+       "mean_rmse": 0.9137
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.9865
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 282.5,
+    "holdout": {
+     "holdout_rmse": 1.4802434075723592,
+     "retrain_s": 0.3714,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.8247322611349475
+    }
+   }
+  },
+  "fred_gdp@s43": {
+   "dataset": "fred_gdp",
+   "seed": 43,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.7992196638224648,
+    "rmse_p10": 0.8085264679899674,
+    "rmse_median": 0.8220148953021857,
+    "train_s_median": 0.01595159135758877,
+    "train_s_mean": 0.015978161404530206,
+    "train_s_p90": 0.021041702628135685,
+    "best_params": {
+     "learning_rate": 0.28855427282259166,
+     "num_leaves": 25,
+     "max_depth": 10,
+     "min_data_in_leaf": 17,
+     "lambda_l1": 0.0001244718758928286,
+     "lambda_l2": 0.00010625701033692853,
+     "feature_fraction": 0.6507202557716241,
+     "bagging_fraction": 0.8604126994569147,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.906,
+     "bagging_fraction": 0.059,
+     "bagging_freq": 0.0082,
+     "lambda_l1": 0.0075,
+     "learning_rate": 0.0067,
+     "feature_fraction": 0.0065,
+     "num_leaves": 0.0041,
+     "max_depth": 0.0016,
+     "extra_trees": 0.0004,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.8461,
+        "std": 0.0274,
+        "min": 0.817
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.8294,
+        "std": 0.0263,
+        "min": 0.7992
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0167,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1777
+       ],
+       "n": 75,
+       "mean_rmse": 0.8366
+      },
+      "Q2": {
+       "range": [
+        0.1777,
+        0.2454
+       ],
+       "n": 75,
+       "mean_rmse": 0.8283
+      },
+      "Q3": {
+       "range": [
+        0.2454,
+        0.2758
+       ],
+       "n": 75,
+       "mean_rmse": 0.83
+      },
+      "Q4": {
+       "range": [
+        0.2758,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8273
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.8261
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        23.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.8267
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        32.25
+       ],
+       "n": 76,
+       "mean_rmse": 0.8299
+      },
+      "Q4": {
+       "range": [
+        32.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8396
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.8351
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        10.0
+       ],
+       "n": 94,
+       "mean_rmse": 0.8372
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.828
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 0.823
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.8565
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        17.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.8175
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        21.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.8182
+      },
+      "Q4": {
+       "range": [
+        21.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.8338
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8284
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.8235
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0614
+       ],
+       "n": 75,
+       "mean_rmse": 0.8347
+      },
+      "Q4": {
+       "range": [
+        0.0614,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8357
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8363
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8285
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.8232
+      },
+      "Q4": {
+       "range": [
+        0.0003,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8343
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6343
+       ],
+       "n": 75,
+       "mean_rmse": 0.8343
+      },
+      "Q2": {
+       "range": [
+        0.6343,
+        0.6627
+       ],
+       "n": 75,
+       "mean_rmse": 0.8259
+      },
+      "Q3": {
+       "range": [
+        0.6627,
+        0.6925
+       ],
+       "n": 75,
+       "mean_rmse": 0.8245
+      },
+      "Q4": {
+       "range": [
+        0.6925,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8376
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8401
+       ],
+       "n": 75,
+       "mean_rmse": 0.84
+      },
+      "Q2": {
+       "range": [
+        0.8401,
+        0.8623
+       ],
+       "n": 75,
+       "mean_rmse": 0.8243
+      },
+      "Q3": {
+       "range": [
+        0.8623,
+        0.8838
+       ],
+       "n": 75,
+       "mean_rmse": 0.8248
+      },
+      "Q4": {
+       "range": [
+        0.8838,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8332
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 29.5,
+    "holdout": {
+     "holdout_rmse": 1.5535232842937101,
+     "retrain_s": 0.0336,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.7992196638224648
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.804377846648159,
+    "rmse_p10": 0.8115904384285573,
+    "rmse_median": 0.8233059636755975,
+    "train_s_median": 0.02450242228806019,
+    "train_s_mean": 0.02716084947685401,
+    "train_s_p90": 0.039213715568184856,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.2992397064020535,
+     "num_leaves": 80,
+     "max_depth": 3,
+     "min_data_in_leaf": 24,
+     "lambda_l1": 0.21805402994363113,
+     "lambda_l2": 7.360670235142667e-06,
+     "feature_fraction": 0.8665986492542982,
+     "bagging_fraction": 0.9445252943012582,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9677,
+     "bagging_fraction": 0.0102,
+     "learning_rate": 0.0095,
+     "extra_trees": 0.0037,
+     "feature_fraction": 0.0037,
+     "num_leaves": 0.002,
+     "max_depth": 0.0014,
+     "bagging_freq": 0.001,
+     "n_models": 0.0005,
+     "lambda_l1": 0.0002,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 271,
+        "mean": 0.8246,
+        "std": 0.0138,
+        "min": 0.8044
+       },
+       "True": {
+        "n": 29,
+        "mean": 0.8374,
+        "std": 0.0148,
+        "min": 0.8095
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0128,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1402
+       ],
+       "n": 75,
+       "mean_rmse": 0.8365
+      },
+      "Q2": {
+       "range": [
+        0.1402,
+        0.2364
+       ],
+       "n": 75,
+       "mean_rmse": 0.8277
+      },
+      "Q3": {
+       "range": [
+        0.2364,
+        0.2708
+       ],
+       "n": 75,
+       "mean_rmse": 0.8204
+      },
+      "Q4": {
+       "range": [
+        0.2708,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8187
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        57.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8344
+      },
+      "Q2": {
+       "range": [
+        57.0,
+        77.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8249
+      },
+      "Q3": {
+       "range": [
+        77.0,
+        86.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.8207
+      },
+      "Q4": {
+       "range": [
+        86.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.8237
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 222,
+       "mean_rmse": 0.822
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.8368
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.8329
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        25.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.8181
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        30.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.8189
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 0.8324
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.8341
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0234
+       ],
+       "n": 75,
+       "mean_rmse": 0.8295
+      },
+      "Q3": {
+       "range": [
+        0.0234,
+        0.1685
+       ],
+       "n": 75,
+       "mean_rmse": 0.82
+      },
+      "Q4": {
+       "range": [
+        0.1685,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8196
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8283
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8204
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8208
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8337
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.858
+       ],
+       "n": 75,
+       "mean_rmse": 0.8337
+      },
+      "Q2": {
+       "range": [
+        0.858,
+        0.8859
+       ],
+       "n": 75,
+       "mean_rmse": 0.8199
+      },
+      "Q3": {
+       "range": [
+        0.8859,
+        0.9164
+       ],
+       "n": 75,
+       "mean_rmse": 0.822
+      },
+      "Q4": {
+       "range": [
+        0.9164,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8276
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8596
+       ],
+       "n": 75,
+       "mean_rmse": 0.8328
+      },
+      "Q2": {
+       "range": [
+        0.8596,
+        0.9404
+       ],
+       "n": 75,
+       "mean_rmse": 0.8277
+      },
+      "Q3": {
+       "range": [
+        0.9404,
+        0.9672
+       ],
+       "n": 75,
+       "mean_rmse": 0.8205
+      },
+      "Q4": {
+       "range": [
+        0.9672,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8223
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 46.7,
+    "holdout": {
+     "holdout_rmse": 1.541573367898821,
+     "retrain_s": 0.0371,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.804377846648159
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8109643794506072,
+    "rmse_p10": 0.8263962980790093,
+    "rmse_median": 0.8575074848148999,
+    "train_s_median": 0.12864774968475104,
+    "train_s_mean": 0.13592458573977154,
+    "train_s_p90": 0.19743708290159706,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.05193537415524705,
+     "num_leaves": 38,
+     "max_depth": 3,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 1.3616583602125194,
+     "lambda_l2": 2.0137536041041512e-07,
+     "feature_fraction": 0.9290891044384422,
+     "bagging_fraction": 0.9882957703259613,
+     "bagging_freq": 2,
+     "extra_trees": true,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 49,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.3171899065831749,
+     "mixture_diversity_lambda": 0.2059172167953306,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 10,
+     "mixture_gate_num_leaves": 17,
+     "mixture_gate_learning_rate": 0.26147555618163343,
+     "mixture_gate_lambda_l2": 0.07326313810417427,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_retrain_interval": 22,
+     "mixture_expert_capacity_factor": 1.1348048473828483,
+     "mixture_expert_choice_boost": 7.277056938680313,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9499,
+     "learning_rate": 0.0059,
+     "mixture_diversity_lambda": 0.0053,
+     "lambda_l1": 0.0051,
+     "mixture_r_smoothing": 0.0047,
+     "bagging_freq": 0.0045,
+     "mixture_init": 0.0039,
+     "mixture_num_experts": 0.0037,
+     "mixture_gate_type": 0.0035,
+     "mixture_balance_factor": 0.0031,
+     "feature_fraction": 0.0025,
+     "max_depth": 0.0023,
+     "num_leaves": 0.0018,
+     "bagging_fraction": 0.001,
+     "mixture_warmup_iters": 0.0007,
+     "mixture_routing_mode": 0.0006,
+     "mixture_e_step_mode": 0.0005,
+     "lambda_l2": 0.0003,
+     "extra_trees": 0.0003,
+     "mixture_refit_leaves": 0.0002,
+     "mixture_hard_m_step": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 19,
+        "mean": 0.9424,
+        "std": 0.0573,
+        "min": 0.8439
+       },
+       "none": {
+        "n": 17,
+        "mean": 0.9547,
+        "std": 0.0818,
+        "min": 0.8431
+       },
+       "leaf_reuse": {
+        "n": 264,
+        "mean": 0.8863,
+        "std": 0.0779,
+        "min": 0.811
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0561,
+       "p_value": 0.0007,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 270,
+        "mean": 0.8851,
+        "std": 0.0739,
+        "min": 0.811
+       },
+       "token_choice": {
+        "n": 30,
+        "mean": 0.9712,
+        "std": 0.0867,
+        "min": 0.8315
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0861,
+       "p_value": 1.1e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 19,
+        "mean": 0.9485,
+        "std": 0.0861,
+        "min": 0.8351
+       },
+       "em": {
+        "n": 29,
+        "mean": 0.9279,
+        "std": 0.0864,
+        "min": 0.8252
+       },
+       "gate_only": {
+        "n": 252,
+        "mean": 0.8856,
+        "std": 0.0755,
+        "min": 0.811
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0423,
+       "p_value": 0.018379,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 14,
+        "mean": 0.9713,
+        "std": 0.081,
+        "min": 0.8805
+       },
+       "tree_hierarchical": {
+        "n": 24,
+        "mean": 0.991,
+        "std": 0.0867,
+        "min": 0.8802
+       },
+       "random": {
+        "n": 248,
+        "mean": 0.8757,
+        "std": 0.067,
+        "min": 0.811
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 0.9677,
+        "std": 0.0587,
+        "min": 0.9234
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.092,
+       "p_value": 6.8e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 18,
+        "mean": 0.9451,
+        "std": 0.0819,
+        "min": 0.8351
+       },
+       "none": {
+        "n": 55,
+        "mean": 0.8985,
+        "std": 0.0823,
+        "min": 0.816
+       },
+       "markov": {
+        "n": 227,
+        "mean": 0.8885,
+        "std": 0.0772,
+        "min": 0.811
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.01,
+       "p_value": 0.418975,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 146,
+        "mean": 0.8828,
+        "std": 0.0788,
+        "min": 0.811
+       },
+       "False": {
+        "n": 154,
+        "mean": 0.904,
+        "std": 0.079,
+        "min": 0.8128
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0212,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 23,
+        "mean": 0.9698,
+        "std": 0.0625,
+        "min": 0.864
+       },
+       "True": {
+        "n": 277,
+        "mean": 0.8874,
+        "std": 0.0776,
+        "min": 0.811
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0824,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 10,
+       "mean_rmse": 0.9928
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 290,
+       "mean_rmse": 0.8903
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1808
+       ],
+       "n": 75,
+       "mean_rmse": 0.9146
+      },
+      "Q2": {
+       "range": [
+        0.1808,
+        0.201
+       ],
+       "n": 75,
+       "mean_rmse": 0.86
+      },
+      "Q3": {
+       "range": [
+        0.201,
+        0.2257
+       ],
+       "n": 75,
+       "mean_rmse": 0.8724
+      },
+      "Q4": {
+       "range": [
+        0.2257,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9277
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        45.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.9455
+      },
+      "Q2": {
+       "range": [
+        45.0,
+        48.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.886
+      },
+      "Q3": {
+       "range": [
+        48.0,
+        49.0
+       ],
+       "n": 43,
+       "mean_rmse": 0.8743
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 124,
+       "mean_rmse": 0.8746
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.9184
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 235,
+       "mean_rmse": 0.8869
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0491
+       ],
+       "n": 75,
+       "mean_rmse": 0.9064
+      },
+      "Q2": {
+       "range": [
+        0.0491,
+        0.0555
+       ],
+       "n": 75,
+       "mean_rmse": 0.863
+      },
+      "Q3": {
+       "range": [
+        0.0555,
+        0.0638
+       ],
+       "n": 75,
+       "mean_rmse": 0.8918
+      },
+      "Q4": {
+       "range": [
+        0.0638,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9135
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.8931
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        47.5
+       ],
+       "n": 80,
+       "mean_rmse": 0.8678
+      },
+      "Q3": {
+       "range": [
+        47.5,
+        61.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.8921
+      },
+      "Q4": {
+       "range": [
+        61.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.9227
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 156,
+       "mean_rmse": 0.8804
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 144,
+       "mean_rmse": 0.9081
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 48,
+       "mean_rmse": 0.8569
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.8455
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 86,
+       "mean_rmse": 0.8729
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 0.9814
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 217.9,
+    "holdout": {
+     "holdout_rmse": 1.5087389560110513,
+     "retrain_s": 0.0991,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.8109643794506072
+    }
+   }
+  },
+  "fred_gdp@s44": {
+   "dataset": "fred_gdp",
+   "seed": 44,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8117366524936191,
+    "rmse_p10": 0.8197061923511014,
+    "rmse_median": 0.830175229918682,
+    "train_s_median": 0.014775496535003185,
+    "train_s_mean": 0.016173763807863,
+    "train_s_p90": 0.023961561992764474,
+    "best_params": {
+     "learning_rate": 0.10726070140919869,
+     "num_leaves": 28,
+     "max_depth": 8,
+     "min_data_in_leaf": 18,
+     "lambda_l1": 7.168951221560929e-07,
+     "lambda_l2": 2.311799168136852,
+     "feature_fraction": 0.9434770143567955,
+     "bagging_fraction": 0.5276087936299121,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.7398,
+     "learning_rate": 0.1534,
+     "bagging_fraction": 0.0545,
+     "num_leaves": 0.0147,
+     "bagging_freq": 0.0138,
+     "extra_trees": 0.0105,
+     "max_depth": 0.0085,
+     "feature_fraction": 0.0042,
+     "lambda_l2": 0.0003,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 273,
+        "mean": 0.8323,
+        "std": 0.0129,
+        "min": 0.8117
+       },
+       "True": {
+        "n": 27,
+        "mean": 0.8364,
+        "std": 0.0097,
+        "min": 0.8218
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0041,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0207
+       ],
+       "n": 75,
+       "mean_rmse": 0.8337
+      },
+      "Q2": {
+       "range": [
+        0.0207,
+        0.0474
+       ],
+       "n": 75,
+       "mean_rmse": 0.8346
+      },
+      "Q3": {
+       "range": [
+        0.0474,
+        0.0804
+       ],
+       "n": 75,
+       "mean_rmse": 0.8311
+      },
+      "Q4": {
+       "range": [
+        0.0804,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8314
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8316
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        29.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.8285
+      },
+      "Q3": {
+       "range": [
+        29.0,
+        40.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.8311
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.839
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.8363
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 37,
+       "mean_rmse": 0.833
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 134,
+       "mean_rmse": 0.8297
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 89,
+       "mean_rmse": 0.8354
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.8391
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        16.0
+       ],
+       "n": 55,
+       "mean_rmse": 0.8294
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        20.0
+       ],
+       "n": 92,
+       "mean_rmse": 0.8254
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.8376
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8321
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8339
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8289
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8359
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0047
+       ],
+       "n": 75,
+       "mean_rmse": 0.8372
+      },
+      "Q2": {
+       "range": [
+        0.0047,
+        0.0359
+       ],
+       "n": 75,
+       "mean_rmse": 0.8316
+      },
+      "Q3": {
+       "range": [
+        0.0359,
+        0.2105
+       ],
+       "n": 75,
+       "mean_rmse": 0.8311
+      },
+      "Q4": {
+       "range": [
+        0.2105,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5828
+       ],
+       "n": 75,
+       "mean_rmse": 0.8376
+      },
+      "Q2": {
+       "range": [
+        0.5828,
+        0.748
+       ],
+       "n": 75,
+       "mean_rmse": 0.8345
+      },
+      "Q3": {
+       "range": [
+        0.748,
+        0.8971
+       ],
+       "n": 75,
+       "mean_rmse": 0.8291
+      },
+      "Q4": {
+       "range": [
+        0.8971,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8297
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5409
+       ],
+       "n": 75,
+       "mean_rmse": 0.8316
+      },
+      "Q2": {
+       "range": [
+        0.5409,
+        0.5594
+       ],
+       "n": 75,
+       "mean_rmse": 0.8278
+      },
+      "Q3": {
+       "range": [
+        0.5594,
+        0.5923
+       ],
+       "n": 75,
+       "mean_rmse": 0.8316
+      },
+      "Q4": {
+       "range": [
+        0.5923,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8398
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 29.9,
+    "holdout": {
+     "holdout_rmse": 1.5233652372424795,
+     "retrain_s": 0.0186,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8117366524936191
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8100747886665787,
+    "rmse_p10": 0.8139441874065253,
+    "rmse_median": 0.8252378667420545,
+    "train_s_median": 0.027962344326078893,
+    "train_s_mean": 0.029012225398172938,
+    "train_s_p90": 0.03776222947984934,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.0806940929972825,
+     "num_leaves": 30,
+     "max_depth": 4,
+     "min_data_in_leaf": 24,
+     "lambda_l1": 1.0600690852663852e-05,
+     "lambda_l2": 0.08057686377466326,
+     "feature_fraction": 0.7525061327503624,
+     "bagging_fraction": 0.7114370131287513,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.92,
+     "learning_rate": 0.0298,
+     "bagging_fraction": 0.0106,
+     "num_leaves": 0.01,
+     "bagging_freq": 0.0089,
+     "extra_trees": 0.0077,
+     "feature_fraction": 0.0062,
+     "max_depth": 0.0031,
+     "lambda_l2": 0.002,
+     "n_models": 0.0016,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 40,
+        "mean": 0.8375,
+        "std": 0.0134,
+        "min": 0.8162
+       },
+       "False": {
+        "n": 260,
+        "mean": 0.8255,
+        "std": 0.0107,
+        "min": 0.8101
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.012,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0498
+       ],
+       "n": 75,
+       "mean_rmse": 0.8293
+      },
+      "Q2": {
+       "range": [
+        0.0498,
+        0.0854
+       ],
+       "n": 75,
+       "mean_rmse": 0.8223
+      },
+      "Q3": {
+       "range": [
+        0.0854,
+        0.1893
+       ],
+       "n": 75,
+       "mean_rmse": 0.8294
+      },
+      "Q4": {
+       "range": [
+        0.1893,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8274
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        33.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.826
+      },
+      "Q2": {
+       "range": [
+        33.75,
+        75.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8283
+      },
+      "Q3": {
+       "range": [
+        75.0,
+        116.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8293
+      },
+      "Q4": {
+       "range": [
+        116.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.825
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.8279
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.8305
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 169,
+       "mean_rmse": 0.8255
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8336
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        25.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.8205
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        30.0
+       ],
+       "n": 93,
+       "mean_rmse": 0.8206
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.8342
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8314
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8214
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.8256
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8301
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0017
+       ],
+       "n": 75,
+       "mean_rmse": 0.8303
+      },
+      "Q2": {
+       "range": [
+        0.0017,
+        0.186
+       ],
+       "n": 75,
+       "mean_rmse": 0.827
+      },
+      "Q3": {
+       "range": [
+        0.186,
+        0.9973
+       ],
+       "n": 75,
+       "mean_rmse": 0.8229
+      },
+      "Q4": {
+       "range": [
+        0.9973,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8283
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6774
+       ],
+       "n": 75,
+       "mean_rmse": 0.8331
+      },
+      "Q2": {
+       "range": [
+        0.6774,
+        0.7364
+       ],
+       "n": 75,
+       "mean_rmse": 0.8271
+      },
+      "Q3": {
+       "range": [
+        0.7364,
+        0.7612
+       ],
+       "n": 75,
+       "mean_rmse": 0.8217
+      },
+      "Q4": {
+       "range": [
+        0.7612,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8265
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7274
+       ],
+       "n": 75,
+       "mean_rmse": 0.8256
+      },
+      "Q2": {
+       "range": [
+        0.7274,
+        0.8219
+       ],
+       "n": 75,
+       "mean_rmse": 0.8257
+      },
+      "Q3": {
+       "range": [
+        0.8219,
+        0.8715
+       ],
+       "n": 75,
+       "mean_rmse": 0.8263
+      },
+      "Q4": {
+       "range": [
+        0.8715,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 49.6,
+    "holdout": {
+     "holdout_rmse": 1.534599671220673,
+     "retrain_s": 0.0549,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.8100747886665787
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.8144318837045725,
+    "rmse_p10": 0.8340525174947447,
+    "rmse_median": 0.8929181074018627,
+    "train_s_median": 0.11966542415320874,
+    "train_s_mean": 0.6509155019695559,
+    "train_s_p90": 2.5839973654970527,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.045301751302293955,
+     "num_leaves": 105,
+     "max_depth": 6,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 0.009487765063512696,
+     "lambda_l2": 8.539357786476138e-06,
+     "feature_fraction": 0.88904873556865,
+     "bagging_fraction": 0.7947844395446021,
+     "bagging_freq": 6,
+     "extra_trees": true,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 38,
+     "mixture_balance_factor": 8,
+     "mixture_diversity_lambda": 0.46373756581912684,
+     "mixture_hard_m_step": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.33548676387719745,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 4,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9734,
+     "learning_rate": 0.0059,
+     "extra_trees": 0.0051,
+     "num_leaves": 0.0043,
+     "mixture_diversity_lambda": 0.0017,
+     "mixture_gate_type": 0.0017,
+     "mixture_warmup_iters": 0.0014,
+     "feature_fraction": 0.0013,
+     "mixture_balance_factor": 0.0013,
+     "bagging_fraction": 0.0009,
+     "bagging_freq": 0.0007,
+     "mixture_init": 0.0006,
+     "mixture_hard_m_step": 0.0004,
+     "lambda_l1": 0.0003,
+     "max_depth": 0.0003,
+     "mixture_num_experts": 0.0002,
+     "mixture_routing_mode": 0.0002,
+     "mixture_r_smoothing": 0.0002,
+     "mixture_e_step_mode": 0.0,
+     "mixture_refit_leaves": 0.0,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 162,
+        "mean": 0.8907,
+        "std": 0.0592,
+        "min": 0.8256
+       },
+       "none": {
+        "n": 72,
+        "mean": 0.9094,
+        "std": 0.089,
+        "min": 0.8144
+       },
+       "leaf_reuse": {
+        "n": 66,
+        "mean": 0.9217,
+        "std": 0.0647,
+        "min": 0.836
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0187,
+       "p_value": 0.109202,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 259,
+        "mean": 0.8915,
+        "std": 0.0636,
+        "min": 0.8144
+       },
+       "expert_choice": {
+        "n": 41,
+        "mean": 0.9683,
+        "std": 0.0715,
+        "min": 0.8406
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0768,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 165,
+        "mean": 0.8914,
+        "std": 0.0623,
+        "min": 0.8256
+       },
+       "em": {
+        "n": 66,
+        "mean": 0.9228,
+        "std": 0.0688,
+        "min": 0.836
+       },
+       "loss_only": {
+        "n": 69,
+        "mean": 0.9076,
+        "std": 0.0817,
+        "min": 0.8144
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0162,
+       "p_value": 0.144028,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 142,
+        "mean": 0.9013,
+        "std": 0.0618,
+        "min": 0.8256
+       },
+       "tree_hierarchical": {
+        "n": 13,
+        "mean": 0.9515,
+        "std": 0.0417,
+        "min": 0.8979
+       },
+       "random": {
+        "n": 121,
+        "mean": 0.8842,
+        "std": 0.0712,
+        "min": 0.8144
+       },
+       "gmm": {
+        "n": 24,
+        "mean": 0.9695,
+        "std": 0.067,
+        "min": 0.8761
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.0171,
+       "p_value": 0.041122,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 212,
+        "mean": 0.8897,
+        "std": 0.0651,
+        "min": 0.8144
+       },
+       "ema": {
+        "n": 42,
+        "mean": 0.9288,
+        "std": 0.0707,
+        "min": 0.8357
+       },
+       "markov": {
+        "n": 46,
+        "mean": 0.9342,
+        "std": 0.0733,
+        "min": 0.8158
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0391,
+       "p_value": 0.001778,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 126,
+        "mean": 0.9064,
+        "std": 0.0624,
+        "min": 0.8308
+       },
+       "False": {
+        "n": 174,
+        "mean": 0.8988,
+        "std": 0.0746,
+        "min": 0.8144
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0076,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.8956,
+        "std": 0.0636,
+        "min": 0.8144
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.9872,
+        "std": 0.0904,
+        "min": 0.8564
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0916,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.9486
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 225,
+       "mean_rmse": 0.8865
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0405
+       ],
+       "n": 75,
+       "mean_rmse": 0.9032
+      },
+      "Q2": {
+       "range": [
+        0.0405,
+        0.065
+       ],
+       "n": 75,
+       "mean_rmse": 0.8832
+      },
+      "Q3": {
+       "range": [
+        0.065,
+        0.1804
+       ],
+       "n": 75,
+       "mean_rmse": 0.8999
+      },
+      "Q4": {
+       "range": [
+        0.1804,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9219
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.9052
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        29.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.9238
+      },
+      "Q3": {
+       "range": [
+        29.0,
+        34.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.8881
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.891
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 44,
+       "mean_rmse": 0.9381
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.8828
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.904
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 0.9018
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0432
+       ],
+       "n": 75,
+       "mean_rmse": 0.9
+      },
+      "Q2": {
+       "range": [
+        0.0432,
+        0.0658
+       ],
+       "n": 75,
+       "mean_rmse": 0.8881
+      },
+      "Q3": {
+       "range": [
+        0.0658,
+        0.1027
+       ],
+       "n": 75,
+       "mean_rmse": 0.9039
+      },
+      "Q4": {
+       "range": [
+        0.1027,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9161
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        47.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.9232
+      },
+      "Q2": {
+       "range": [
+        47.0,
+        64.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.8965
+      },
+      "Q3": {
+       "range": [
+        64.0,
+        90.5
+       ],
+       "n": 79,
+       "mean_rmse": 0.9059
+      },
+      "Q4": {
+       "range": [
+        90.5,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8824
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 27,
+       "mean_rmse": 0.9249
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.8789
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 35,
+       "mean_rmse": 0.9109
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 124,
+       "mean_rmse": 0.9158
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.8756
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.853
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        16.0
+       ],
+       "n": 94,
+       "mean_rmse": 0.8943
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.9794
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 987.3,
+    "holdout": {
+     "holdout_rmse": 1.4768956526684103,
+     "retrain_s": 2.3726,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.8144318837045725
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_hmm_report.md
+++ b/bench_results/meth2_v081/ds_hmm_report.md
@@ -1,0 +1,682 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['hmm'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `0cf3634c544c`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| hmm | naive-lightgbm | **2.21802** ± 0.24377 | 2.27009 | 0.0% | 0.06 |
+| hmm | naive-ensemble | **2.20636** ± 0.24187 | 2.26524 | 0.0% | 0.13 |
+| hmm | moe | **2.21037** ± 0.24330 | 2.24682 | 0.0% | 0.22 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| hmm@s42 | naive-lightgbm | 2.2992 | 2.3152 | 0.033 | 58 |
+| hmm@s42 | naive-ensemble | 2.2955 | 2.3144 | 0.105 | 163 |
+| hmm@s42 | moe | 2.2914 | 2.3413 | 0.165 | 783 |
+| hmm@s43 | naive-lightgbm | 2.3800 | 2.3935 | 0.033 | 57 |
+| hmm@s43 | naive-ensemble | 2.3741 | 2.3876 | 0.089 | 152 |
+| hmm@s43 | moe | 2.3213 | 2.3586 | 0.240 | 414 |
+| hmm@s44 | naive-lightgbm | 2.1311 | 2.1423 | 0.028 | 54 |
+| hmm@s44 | naive-ensemble | 2.1261 | 2.1368 | 0.086 | 138 |
+| hmm@s44 | moe | 2.1278 | 2.1430 | 0.125 | 347 |
+
+
+
+---
+
+## hmm@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.88834** (winner retrained in 0.06s, cv score of winner: 2.2992)
+- cv best RMSE: 2.2992, median: 2.3152, p10: 2.3078
+- train: median 0.033s/fold, mean 0.034s, p90 0.041s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.429 |
+| `learning_rate` | 0.262 |
+| `min_data_in_leaf` | 0.101 |
+| `bagging_fraction` | 0.057 |
+| `num_leaves` | 0.056 |
+| `max_depth` | 0.048 |
+| `feature_fraction` | 0.027 |
+| `bagging_freq` | 0.012 |
+| `lambda_l2` | 0.005 |
+| `lambda_l1` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 2.3177 | 0.0143 | 2.2992 |
+| False | 20 | 2.3549 | 0.0208 | 2.3261 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.3258 | 2.3142 | 2.3149 | 2.3260 | **Q2** [0.0611, 0.0714] |
+| `num_leaves` | 2.3210 | 2.3205 | 2.3198 | 2.3196 | **Q4** [120.0, ∞) |
+| `max_depth` | — | — | 2.3163 | 2.3274 | **Q3** [3.0, 5.0] |
+| `min_data_in_leaf` | 2.3232 | 2.3162 | 2.3158 | 2.3262 | **Q3** [31.0, 36.0] |
+| `lambda_l1` | 2.3321 | 2.3174 | 2.3162 | 2.3152 | **Q4** [2.9866, ∞) |
+| `lambda_l2` | 2.3254 | 2.3201 | 2.3165 | 2.3189 | **Q3** [0.0494, 0.2783] |
+| `feature_fraction` | 2.3295 | 2.3163 | 2.3155 | 2.3195 | **Q3** [0.8977, 0.9296] |
+| `bagging_fraction` | 2.3310 | 2.3194 | 2.3147 | 2.3158 | **Q3** [0.934, 0.9603] |
+
+#### E. Slice plot
+
+![hmm@s42/naive-lightgbm](slice_hmm@s42_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.88558** (winner retrained in 0.17s, cv score of winner: 2.2955)
+- cv best RMSE: 2.2955, median: 2.3144, p10: 2.3046
+- train: median 0.105s/fold, mean 0.104s, p90 0.141s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.457 |
+| `learning_rate` | 0.307 |
+| `min_data_in_leaf` | 0.063 |
+| `bagging_fraction` | 0.050 |
+| `feature_fraction` | 0.043 |
+| `max_depth` | 0.039 |
+| `num_leaves` | 0.030 |
+| `lambda_l1` | 0.006 |
+| `bagging_freq` | 0.004 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 277 | 2.3167 | 0.0156 | 2.2955 |
+| False | 23 | 2.3513 | 0.0184 | 2.3146 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.3338 | 2.3168 | 2.3126 | 2.3140 | **Q3** [0.252, 0.2766] |
+| `num_leaves` | 2.3246 | 2.3162 | 2.3134 | 2.3230 | **Q3** [100.0, 105.0] |
+| `max_depth` | 2.3336 | 2.3238 | — | 2.3157 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 2.3218 | 2.3199 | 2.3131 | 2.3230 | **Q3** [30.0, 34.0] |
+| `lambda_l1` | 2.3133 | 2.3188 | 2.3269 | 2.3182 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.3234 | 2.3201 | 2.3163 | 2.3174 | **Q3** [0.003, 0.0226] |
+| `feature_fraction` | 2.3209 | 2.3217 | 2.3152 | 2.3195 | **Q3** [0.7787, 0.8628] |
+| `bagging_fraction` | 2.3241 | 2.3179 | 2.3153 | 2.3199 | **Q3** [0.825, 0.8466] |
+
+#### E. Slice plot
+
+![hmm@s42/naive-ensemble](slice_hmm@s42_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 1.89065** (winner retrained in 0.26s, cv score of winner: 2.2914)
+- cv best RMSE: 2.2914, median: 2.3413, p10: 2.3129
+- train: median 0.165s/fold, mean 0.514s, p90 1.957s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.203 |
+| `learning_rate` | 0.168 |
+| `mixture_diversity_lambda` | 0.155 |
+| `bagging_fraction` | 0.088 |
+| `mixture_init` | 0.082 |
+| `mixture_warmup_iters` | 0.050 |
+| `min_data_in_leaf` | 0.034 |
+| `mixture_num_experts` | 0.033 |
+| `num_leaves` | 0.029 |
+| `mixture_routing_mode` | 0.028 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 2.3336 (n=201) | none | Δ +0.0473 | p=0.00e+00 |
+| `mixture_routing_mode` | **expert_choice** | 2.3460 (n=277) | token_choice | Δ +0.0555 | p=3.07e-03 |
+| `mixture_e_step_mode` | **em** | 2.3379 (n=208) | gate_only | Δ +0.0376 | p=0.00e+00 |
+| `mixture_init` | **tree_hierarchical** | 2.3366 (n=201) | uniform | Δ +0.0367 | p=0.00e+00 |
+| `mixture_r_smoothing` | **none** | 2.3391 (n=230) | markov | Δ +0.0395 | p=7.55e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 201 | 2.3336 | 0.0243 | 2.2914 |
+| none | 77 | 2.3809 | 0.0353 | 2.3122 |
+| leaf_reuse | 22 | 2.3945 | 0.0812 | 2.3273 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 277 | 2.3460 | 0.0343 | 2.2914 |
+| token_choice | 23 | 2.4015 | 0.0780 | 2.3443 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 208 | 2.3379 | 0.0377 | 2.2914 |
+| gate_only | 47 | 2.3755 | 0.0416 | 2.3051 |
+| loss_only | 45 | 2.3809 | 0.0332 | 2.3122 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 201 | 2.3366 | 0.0403 | 2.2914 |
+| uniform | 40 | 2.3733 | 0.0282 | 2.3124 |
+| random | 45 | 2.3787 | 0.0273 | 2.3122 |
+| gmm | 14 | 2.3885 | 0.0416 | 2.3348 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 230 | 2.3391 | 0.0284 | 2.2914 |
+| markov | 17 | 2.3786 | 0.0380 | 2.3298 |
+| ema | 53 | 2.3896 | 0.0610 | 2.3122 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 225 | 2.3409 | 0.0408 | 2.2914 |
+| False | 75 | 2.3782 | 0.0323 | 2.3122 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.3470 | 0.0407 | 2.2914 |
+| False | 21 | 2.3936 | 0.0349 | 2.3409 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.3748 | — | — | 2.3423 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 2.3511 | 2.3314 | 2.3416 | 2.3768 | **Q2** [0.2232, 0.2582] |
+| `mixture_warmup_iters` | 2.3288 | 2.3312 | 2.3539 | 2.3821 | **Q1** [None, 7.0] |
+| `mixture_balance_factor` | 2.3823 | 2.3417 | — | 2.3398 | **Q4** [7.0, ∞) |
+| `learning_rate` | 2.3525 | 2.3272 | 2.3595 | 2.3618 | **Q2** [0.0664, 0.0853] |
+| `num_leaves` | 2.3773 | 2.3506 | 2.3361 | 2.3388 | **Q3** [111.0, 119.0] |
+| `max_depth` | — | 2.3334 | 2.3480 | 2.3807 | **Q2** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.3442 | 2.3266 | 2.3496 | 2.3780 | **Q2** [28.0, 32.0] |
+
+#### E. Slice plot
+
+![hmm@s42/moe](slice_hmm@s42_moe.png)
+
+
+---
+
+## hmm@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.47018** (winner retrained in 0.07s, cv score of winner: 2.3800)
+- cv best RMSE: 2.3800, median: 2.3935, p10: 2.3844
+- train: median 0.033s/fold, mean 0.034s, p90 0.046s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.532 |
+| `extra_trees` | 0.222 |
+| `learning_rate` | 0.098 |
+| `bagging_fraction` | 0.056 |
+| `lambda_l1` | 0.035 |
+| `feature_fraction` | 0.033 |
+| `max_depth` | 0.013 |
+| `num_leaves` | 0.005 |
+| `bagging_freq` | 0.003 |
+| `lambda_l2` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.3973 | 0.0165 | 2.3800 |
+| False | 21 | 2.4486 | 0.0327 | 2.4035 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.4073 | 2.3941 | 2.3955 | 2.4069 | **Q2** [0.0531, 0.0605] |
+| `num_leaves` | 2.3941 | 2.4000 | 2.4058 | 2.4035 | **Q1** [None, 15.75] |
+| `max_depth` | 2.4084 | 2.3978 | 2.3967 | 2.4019 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | 2.3942 | 2.3915 | 2.3982 | 2.4191 | **Q2** [7.0, 10.0] |
+| `lambda_l1` | 2.4157 | 2.3956 | 2.3973 | 2.3950 | **Q4** [4.0999, ∞) |
+| `lambda_l2` | 2.4147 | 2.3962 | 2.3976 | 2.3951 | **Q4** [1.2586, ∞) |
+| `feature_fraction` | 2.4142 | 2.4004 | 2.3950 | 2.3941 | **Q4** [0.9768, ∞) |
+| `bagging_fraction` | 2.4139 | 2.3994 | 2.3933 | 2.3972 | **Q3** [0.892, 0.921] |
+
+#### E. Slice plot
+
+![hmm@s43/naive-lightgbm](slice_hmm@s43_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.46958** (winner retrained in 0.12s, cv score of winner: 2.3741)
+- cv best RMSE: 2.3741, median: 2.3876, p10: 2.3785
+- train: median 0.089s/fold, mean 0.098s, p90 0.151s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.523 |
+| `min_data_in_leaf` | 0.222 |
+| `learning_rate` | 0.215 |
+| `lambda_l1` | 0.013 |
+| `bagging_fraction` | 0.006 |
+| `bagging_freq` | 0.006 |
+| `feature_fraction` | 0.004 |
+| `num_leaves` | 0.004 |
+| `max_depth` | 0.003 |
+| `n_models` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 2.3910 | 0.0183 | 2.3741 |
+| False | 20 | 2.4489 | 0.0188 | 2.4261 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.4087 | 2.3928 | 2.3905 | 2.3875 | **Q4** [0.2655, ∞) |
+| `num_leaves` | 2.3946 | 2.3916 | 2.3948 | 2.3990 | **Q2** [20.0, 25.5] |
+| `max_depth` | 2.4131 | 2.3953 | — | 2.3897 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.3886 | 2.3913 | 2.3893 | 2.4099 | **Q1** [None, 7.75] |
+| `lambda_l1` | 2.4131 | 2.3930 | 2.3869 | 2.3865 | **Q4** [5.8577, ∞) |
+| `lambda_l2` | 2.3935 | 2.3898 | 2.3918 | 2.4044 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 2.4070 | 2.3939 | 2.3901 | 2.3885 | **Q4** [0.9816, ∞) |
+| `bagging_fraction` | 2.3984 | 2.3924 | 2.3896 | 2.3992 | **Q3** [0.7428, 0.7681] |
+
+#### E. Slice plot
+
+![hmm@s43/naive-ensemble](slice_hmm@s43_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 2.48033** (winner retrained in 0.27s, cv score of winner: 2.3213)
+- cv best RMSE: 2.3213, median: 2.3586, p10: 2.3380
+- train: median 0.240s/fold, mean 0.267s, p90 0.412s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_e_step_mode` | 0.344 |
+| `mixture_routing_mode` | 0.180 |
+| `mixture_gate_type` | 0.101 |
+| `mixture_r_smoothing` | 0.071 |
+| `bagging_freq` | 0.055 |
+| `mixture_diversity_lambda` | 0.051 |
+| `num_leaves` | 0.043 |
+| `learning_rate` | 0.029 |
+| `min_data_in_leaf` | 0.024 |
+| `feature_fraction` | 0.022 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 2.3690 (n=266) | gbdt | Δ +0.0451 | p=2.42e-03 |
+| `mixture_routing_mode` | **token_choice** | 2.3710 (n=280) | expert_choice | Δ +0.0916 | p=1.30e-05 |
+| `mixture_e_step_mode` | **gate_only** | 2.3659 (n=265) | loss_only | Δ +0.0647 | p=6.69e-04 |
+| `mixture_r_smoothing` | **ema** | 2.3624 (n=163) | markov | Δ +0.0265 | p=2.60e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 266 | 2.3690 | 0.0436 | 2.3213 |
+| gbdt | 18 | 2.4141 | 0.0518 | 2.3617 |
+| none | 16 | 2.4707 | 0.0784 | 2.3799 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 280 | 2.3710 | 0.0456 | 2.3213 |
+| expert_choice | 20 | 2.4626 | 0.0687 | 2.3749 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 265 | 2.3659 | 0.0366 | 2.3213 |
+| loss_only | 18 | 2.4306 | 0.0642 | 2.3725 |
+| em | 17 | 2.4955 | 0.0689 | 2.3819 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 255 | 2.3720 | 0.0514 | 2.3213 |
+| random | 16 | 2.3897 | 0.0304 | 2.3666 |
+| uniform | 14 | 2.3928 | 0.0250 | 2.3607 |
+| gmm | 15 | 2.4363 | 0.0694 | 2.3727 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 163 | 2.3624 | 0.0326 | 2.3213 |
+| markov | 121 | 2.3889 | 0.0610 | 2.3361 |
+| none | 16 | 2.4386 | 0.0778 | 2.3393 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 211 | 2.3635 | 0.0372 | 2.3213 |
+| True | 89 | 2.4093 | 0.0679 | 2.3448 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 277 | 2.3741 | 0.0522 | 2.3213 |
+| False | 23 | 2.4129 | 0.0455 | 2.3500 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.4735 | — | — | 2.3738 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 2.3750 | 2.3537 | 2.3814 | 2.3985 | **Q2** [0.3094, 0.3349] |
+| `mixture_warmup_iters` | 2.3628 | 2.3648 | 2.3793 | 2.3969 | **Q1** [None, 8.0] |
+| `mixture_balance_factor` | 2.3838 | — | — | 2.3755 | **Q4** [6.0, ∞) |
+| `learning_rate` | 2.3999 | 2.3754 | 2.3649 | 2.3683 | **Q3** [0.1507, 0.1813] |
+| `num_leaves` | 2.3929 | 2.3568 | 2.3691 | 2.3890 | **Q2** [80.75, 90.0] |
+| `max_depth` | 2.3970 | 2.4049 | — | 2.3611 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.3914 | 2.3647 | 2.3659 | 2.3883 | **Q2** [18.0, 24.0] |
+
+#### E. Slice plot
+
+![hmm@s43/moe](slice_hmm@s43_moe.png)
+
+
+---
+
+## hmm@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.29553** (winner retrained in 0.04s, cv score of winner: 2.1311)
+- cv best RMSE: 2.1311, median: 2.1423, p10: 2.1347
+- train: median 0.028s/fold, mean 0.032s, p90 0.043s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.495 |
+| `max_depth` | 0.155 |
+| `bagging_fraction` | 0.121 |
+| `min_data_in_leaf` | 0.092 |
+| `learning_rate` | 0.075 |
+| `feature_fraction` | 0.040 |
+| `num_leaves` | 0.017 |
+| `bagging_freq` | 0.003 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 278 | 2.1441 | 0.0129 | 2.1311 |
+| False | 22 | 2.1867 | 0.0243 | 2.1570 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.1514 | 2.1411 | 2.1454 | 2.1511 | **Q2** [0.0406, 0.0468] |
+| `num_leaves` | 2.1552 | 2.1441 | 2.1438 | 2.1462 | **Q3** [102.0, 112.0] |
+| `max_depth` | — | — | 2.1430 | 2.1581 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.1393 | 2.1438 | 2.1472 | 2.1582 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.1468 | 2.1476 | 2.1447 | 2.1498 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 2.1443 | 2.1449 | 2.1449 | 2.1548 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.1508 | 2.1424 | 2.1434 | 2.1522 | **Q2** [0.7138, 0.7421] |
+| `bagging_fraction` | 2.1590 | 2.1422 | 2.1434 | 2.1443 | **Q2** [0.8818, 0.9284] |
+
+#### E. Slice plot
+
+![hmm@s44/naive-lightgbm](slice_hmm@s44_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.26391** (winner retrained in 0.09s, cv score of winner: 2.1261)
+- cv best RMSE: 2.1261, median: 2.1368, p10: 2.1309
+- train: median 0.086s/fold, mean 0.089s, p90 0.111s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.354 |
+| `extra_trees` | 0.326 |
+| `min_data_in_leaf` | 0.192 |
+| `feature_fraction` | 0.051 |
+| `bagging_fraction` | 0.025 |
+| `num_leaves` | 0.019 |
+| `bagging_freq` | 0.012 |
+| `lambda_l1` | 0.011 |
+| `max_depth` | 0.006 |
+| `n_models` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.1405 | 0.0146 | 2.1261 |
+| False | 21 | 2.1840 | 0.0223 | 2.1586 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.1595 | 2.1392 | 2.1359 | 2.1394 | **Q3** [0.1555, 0.1872] |
+| `num_leaves` | 2.1464 | 2.1367 | 2.1387 | 2.1521 | **Q2** [52.0, 58.0] |
+| `max_depth` | — | — | 2.1398 | 2.1535 | **Q3** [3.0, 8.0] |
+| `min_data_in_leaf` | 2.1376 | 2.1386 | 2.1416 | 2.1553 | **Q1** [None, 8.0] |
+| `lambda_l1` | 2.1547 | 2.1422 | 2.1396 | 2.1375 | **Q4** [5.8191, ∞) |
+| `lambda_l2` | 2.1390 | 2.1381 | 2.1434 | 2.1535 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 2.1481 | 2.1408 | 2.1442 | 2.1409 | **Q2** [0.6187, 0.6597] |
+| `bagging_fraction` | 2.1497 | 2.1378 | 2.1386 | 2.1479 | **Q2** [0.6736, 0.735] |
+
+#### E. Slice plot
+
+![hmm@s44/naive-ensemble](slice_hmm@s44_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 2.26012** (winner retrained in 0.15s, cv score of winner: 2.1278)
+- cv best RMSE: 2.1278, median: 2.1430, p10: 2.1345
+- train: median 0.125s/fold, mean 0.225s, p90 0.291s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.625 |
+| `feature_fraction` | 0.099 |
+| `mixture_routing_mode` | 0.093 |
+| `learning_rate` | 0.027 |
+| `mixture_r_smoothing` | 0.025 |
+| `bagging_fraction` | 0.019 |
+| `mixture_balance_factor` | 0.016 |
+| `mixture_warmup_iters` | 0.015 |
+| `mixture_gate_type` | 0.014 |
+| `min_data_in_leaf` | 0.013 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 248 | 2.1613 | 0.0589 | 2.1278 |
+| leaf_reuse | 36 | 2.1708 | 0.0534 | 2.1336 |
+| gbdt | 16 | 2.2004 | 0.0696 | 2.1390 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 253 | 2.1617 | 0.0595 | 2.1278 |
+| token_choice | 47 | 2.1799 | 0.0573 | 2.1373 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 155 | 2.1586 | 0.0550 | 2.1293 |
+| em | 108 | 2.1670 | 0.0627 | 2.1278 |
+| gate_only | 37 | 2.1819 | 0.0642 | 2.1373 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 249 | 2.1506 | 0.0338 | 2.1278 |
+| uniform | 21 | 2.1630 | 0.0353 | 2.1383 |
+| gmm | 16 | 2.2358 | 0.0906 | 2.1404 |
+| tree_hierarchical | 14 | 2.3333 | 0.0819 | 2.1612 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 257 | 2.1590 | 0.0567 | 2.1278 |
+| ema | 27 | 2.1859 | 0.0540 | 2.1397 |
+| markov | 16 | 2.2173 | 0.0772 | 2.1366 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 272 | 2.1615 | 0.0568 | 2.1278 |
+| True | 28 | 2.1940 | 0.0755 | 2.1313 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.1623 | 0.0599 | 2.1278 |
+| False | 21 | 2.1939 | 0.0451 | 2.1552 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.1877 | — | — | 2.1616 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 2.1540 | 2.1519 | 2.1671 | 2.1851 | **Q2** [0.0221, 0.0423] |
+| `mixture_warmup_iters` | 2.1656 | 2.1639 | 2.1556 | 2.1699 | **Q3** [21.5, 24.0] |
+| `mixture_balance_factor` | 2.1606 | — | 2.1621 | 2.1731 | **Q1** [None, 5.0] |
+| `learning_rate` | 2.1796 | 2.1568 | 2.1491 | 2.1726 | **Q3** [0.0761, 0.0932] |
+| `num_leaves` | 2.1557 | 2.1741 | 2.1560 | 2.1720 | **Q1** [None, 39.0] |
+| `max_depth` | — | — | 2.1577 | 2.1812 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.1556 | 2.1572 | 2.1669 | 2.1774 | **Q1** [None, 8.0] |
+
+#### E. Slice plot
+
+![hmm@s44/moe](slice_hmm@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| hmm@s42 | `mixture_gate_type` | **gbdt** | +0.0473 | 0.00e+00 |
+| hmm@s42 | `mixture_routing_mode` | **expert_choice** | +0.0555 | 3.07e-03 |
+| hmm@s42 | `mixture_e_step_mode` | **em** | +0.0376 | 0.00e+00 |
+| hmm@s42 | `mixture_init` | **tree_hierarchical** | +0.0367 | 0.00e+00 |
+| hmm@s42 | `mixture_r_smoothing` | **none** | +0.0395 | 7.55e-04 |
+| hmm@s43 | `mixture_gate_type` | **leaf_reuse** | +0.0451 | 2.42e-03 |
+| hmm@s43 | `mixture_routing_mode` | **token_choice** | +0.0916 | 1.30e-05 |
+| hmm@s43 | `mixture_e_step_mode` | **gate_only** | +0.0647 | 6.69e-04 |
+| hmm@s43 | `mixture_r_smoothing` | **ema** | +0.0265 | 2.60e-05 |

--- a/bench_results/meth2_v081/ds_hmm_summary.json
+++ b/bench_results/meth2_v081/ds_hmm_summary.json
@@ -1,0 +1,3754 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "hmm"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "0cf3634c544c8f91ada2261bdf448aad9bd4b491",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "hmm": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.888342906785671,
+      "cv_best": 2.2991586479654282,
+      "crash_rate": 0.0,
+      "retrain_s": 0.059
+     },
+     "43": {
+      "holdout_rmse": 2.4701788835392824,
+      "cv_best": 2.379979557922336,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0675
+     },
+     "44": {
+      "holdout_rmse": 2.29552544390291,
+      "cv_best": 2.1311368317391413,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0394
+     }
+    },
+    "holdout_mean": 2.218016,
+    "holdout_std": 0.243775,
+    "cv_best_mean": 2.270092
+   },
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.8855786920464555,
+      "cv_best": 2.2955295709001278,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1697
+     },
+     "43": {
+      "holdout_rmse": 2.4695834158689207,
+      "cv_best": 2.3741243851915868,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1246
+     },
+     "44": {
+      "holdout_rmse": 2.2639089592522867,
+      "cv_best": 2.1260558614273632,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0895
+     }
+    },
+    "holdout_mean": 2.206357,
+    "holdout_std": 0.241867,
+    "cv_best_mean": 2.265237
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.890645288243279,
+      "cv_best": 2.2914192531450532,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2585
+     },
+     "43": {
+      "holdout_rmse": 2.480334949636432,
+      "cv_best": 2.321258834502795,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2672
+     },
+     "44": {
+      "holdout_rmse": 2.2601212441590333,
+      "cv_best": 2.1277937201663955,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1474
+     }
+    },
+    "holdout_mean": 2.210367,
+    "holdout_std": 0.243297,
+    "cv_best_mean": 2.246824
+   }
+  }
+ },
+ "runs": {
+  "hmm@s42": {
+   "dataset": "hmm",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.045793656680186444,
+    "std": 2.4137364484700643
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.2991586479654282,
+    "rmse_p10": 2.3078319097059055,
+    "rmse_median": 2.315209081827666,
+    "train_s_median": 0.032953614741563796,
+    "train_s_mean": 0.034447418052703134,
+    "train_s_p90": 0.04100794199854137,
+    "best_params": {
+     "learning_rate": 0.09493440081364529,
+     "num_leaves": 125,
+     "max_depth": 5,
+     "min_data_in_leaf": 41,
+     "lambda_l1": 0.7722375890086123,
+     "lambda_l2": 1.9149345992899975,
+     "feature_fraction": 0.8426373035251148,
+     "bagging_fraction": 0.9850867005699576,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.429,
+     "learning_rate": 0.2615,
+     "min_data_in_leaf": 0.101,
+     "bagging_fraction": 0.0574,
+     "num_leaves": 0.0557,
+     "max_depth": 0.0482,
+     "feature_fraction": 0.0266,
+     "bagging_freq": 0.0119,
+     "lambda_l2": 0.0052,
+     "lambda_l1": 0.0036
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 280,
+        "mean": 2.3177,
+        "std": 0.0143,
+        "min": 2.2992
+       },
+       "False": {
+        "n": 20,
+        "mean": 2.3549,
+        "std": 0.0208,
+        "min": 2.3261
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0372,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0611
+       ],
+       "n": 75,
+       "mean_rmse": 2.3258
+      },
+      "Q2": {
+       "range": [
+        0.0611,
+        0.0714
+       ],
+       "n": 75,
+       "mean_rmse": 2.3142
+      },
+      "Q3": {
+       "range": [
+        0.0714,
+        0.0859
+       ],
+       "n": 75,
+       "mean_rmse": 2.3149
+      },
+      "Q4": {
+       "range": [
+        0.0859,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.326
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        64.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.321
+      },
+      "Q2": {
+       "range": [
+        64.0,
+        108.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.3205
+      },
+      "Q3": {
+       "range": [
+        108.0,
+        120.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3198
+      },
+      "Q4": {
+       "range": [
+        120.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.3196
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 195,
+       "mean_rmse": 2.3163
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 105,
+       "mean_rmse": 2.3274
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 62,
+       "mean_rmse": 2.3232
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        31.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.3162
+      },
+      "Q3": {
+       "range": [
+        31.0,
+        36.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.3158
+      },
+      "Q4": {
+       "range": [
+        36.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.3262
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.3513
+       ],
+       "n": 75,
+       "mean_rmse": 2.3321
+      },
+      "Q2": {
+       "range": [
+        0.3513,
+        1.2675
+       ],
+       "n": 75,
+       "mean_rmse": 2.3174
+      },
+      "Q3": {
+       "range": [
+        1.2675,
+        2.9866
+       ],
+       "n": 75,
+       "mean_rmse": 2.3162
+      },
+      "Q4": {
+       "range": [
+        2.9866,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3152
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0009
+       ],
+       "n": 75,
+       "mean_rmse": 2.3254
+      },
+      "Q2": {
+       "range": [
+        0.0009,
+        0.0494
+       ],
+       "n": 75,
+       "mean_rmse": 2.3201
+      },
+      "Q3": {
+       "range": [
+        0.0494,
+        0.2783
+       ],
+       "n": 75,
+       "mean_rmse": 2.3165
+      },
+      "Q4": {
+       "range": [
+        0.2783,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3189
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8461
+       ],
+       "n": 75,
+       "mean_rmse": 2.3295
+      },
+      "Q2": {
+       "range": [
+        0.8461,
+        0.8977
+       ],
+       "n": 75,
+       "mean_rmse": 2.3163
+      },
+      "Q3": {
+       "range": [
+        0.8977,
+        0.9296
+       ],
+       "n": 75,
+       "mean_rmse": 2.3155
+      },
+      "Q4": {
+       "range": [
+        0.9296,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3195
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.902
+       ],
+       "n": 75,
+       "mean_rmse": 2.331
+      },
+      "Q2": {
+       "range": [
+        0.902,
+        0.934
+       ],
+       "n": 75,
+       "mean_rmse": 2.3194
+      },
+      "Q3": {
+       "range": [
+        0.934,
+        0.9603
+       ],
+       "n": 75,
+       "mean_rmse": 2.3147
+      },
+      "Q4": {
+       "range": [
+        0.9603,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3158
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 57.5,
+    "holdout": {
+     "holdout_rmse": 1.888342906785671,
+     "retrain_s": 0.059,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.2991586479654282
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.2955295709001278,
+    "rmse_p10": 2.30463019318857,
+    "rmse_median": 2.314444653588591,
+    "train_s_median": 0.10527463722974062,
+    "train_s_mean": 0.10440469699601333,
+    "train_s_p90": 0.14144350338727235,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.2735553207246474,
+     "num_leaves": 100,
+     "max_depth": 11,
+     "min_data_in_leaf": 32,
+     "lambda_l1": 5.4867114993007284e-08,
+     "lambda_l2": 0.025740081056207047,
+     "feature_fraction": 0.8622267756963871,
+     "bagging_fraction": 0.8397630512682251,
+     "bagging_freq": 6,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4567,
+     "learning_rate": 0.3068,
+     "min_data_in_leaf": 0.0634,
+     "bagging_fraction": 0.0497,
+     "feature_fraction": 0.0431,
+     "max_depth": 0.0393,
+     "num_leaves": 0.0298,
+     "lambda_l1": 0.0056,
+     "bagging_freq": 0.0041,
+     "lambda_l2": 0.0008,
+     "n_models": 0.0005
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 23,
+        "mean": 2.3513,
+        "std": 0.0184,
+        "min": 2.3146
+       },
+       "True": {
+        "n": 277,
+        "mean": 2.3167,
+        "std": 0.0156,
+        "min": 2.2955
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0346,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2105
+       ],
+       "n": 75,
+       "mean_rmse": 2.3338
+      },
+      "Q2": {
+       "range": [
+        0.2105,
+        0.252
+       ],
+       "n": 75,
+       "mean_rmse": 2.3168
+      },
+      "Q3": {
+       "range": [
+        0.252,
+        0.2766
+       ],
+       "n": 75,
+       "mean_rmse": 2.3126
+      },
+      "Q4": {
+       "range": [
+        0.2766,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.314
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        93.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3246
+      },
+      "Q2": {
+       "range": [
+        93.75,
+        100.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3162
+      },
+      "Q3": {
+       "range": [
+        100.0,
+        105.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.3134
+      },
+      "Q4": {
+       "range": [
+        105.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.323
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 45,
+       "mean_rmse": 2.3336
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 35,
+       "mean_rmse": 2.3238
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 220,
+       "mean_rmse": 2.3157
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        24.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.3218
+      },
+      "Q2": {
+       "range": [
+        24.0,
+        30.0
+       ],
+       "n": 61,
+       "mean_rmse": 2.3199
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        34.0
+       ],
+       "n": 83,
+       "mean_rmse": 2.3131
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 2.323
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.3133
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 2.3188
+      },
+      "Q3": {
+       "range": [
+        0.0002,
+        1.277
+       ],
+       "n": 75,
+       "mean_rmse": 2.3269
+      },
+      "Q4": {
+       "range": [
+        1.277,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3182
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 2.3234
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.003
+       ],
+       "n": 75,
+       "mean_rmse": 2.3201
+      },
+      "Q3": {
+       "range": [
+        0.003,
+        0.0226
+       ],
+       "n": 75,
+       "mean_rmse": 2.3163
+      },
+      "Q4": {
+       "range": [
+        0.0226,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3174
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5697
+       ],
+       "n": 75,
+       "mean_rmse": 2.3209
+      },
+      "Q2": {
+       "range": [
+        0.5697,
+        0.7787
+       ],
+       "n": 75,
+       "mean_rmse": 2.3217
+      },
+      "Q3": {
+       "range": [
+        0.7787,
+        0.8628
+       ],
+       "n": 75,
+       "mean_rmse": 2.3152
+      },
+      "Q4": {
+       "range": [
+        0.8628,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3195
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7616
+       ],
+       "n": 75,
+       "mean_rmse": 2.3241
+      },
+      "Q2": {
+       "range": [
+        0.7616,
+        0.825
+       ],
+       "n": 75,
+       "mean_rmse": 2.3179
+      },
+      "Q3": {
+       "range": [
+        0.825,
+        0.8466
+       ],
+       "n": 75,
+       "mean_rmse": 2.3153
+      },
+      "Q4": {
+       "range": [
+        0.8466,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3199
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 162.7,
+    "holdout": {
+     "holdout_rmse": 1.8855786920464555,
+     "retrain_s": 0.1697,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.2955295709001278
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.2914192531450532,
+    "rmse_p10": 2.3129375728793433,
+    "rmse_median": 2.3412921291539552,
+    "train_s_median": 0.16498812809586527,
+    "train_s_mean": 0.5140658333549897,
+    "train_s_p90": 1.9574095225334172,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.04918705259303714,
+     "num_leaves": 117,
+     "max_depth": 3,
+     "min_data_in_leaf": 31,
+     "lambda_l1": 0.0010401591043041872,
+     "lambda_l2": 0.0008673964533143763,
+     "feature_fraction": 0.5622646760958214,
+     "bagging_fraction": 0.8664116807589549,
+     "bagging_freq": 1,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 10,
+     "mixture_balance_factor": 7,
+     "mixture_diversity_lambda": 0.28556615411890884,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 32,
+     "mixture_gate_learning_rate": 0.17604820801389276,
+     "mixture_gate_lambda_l2": 9.947240821736015,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 1.427649730726334,
+     "mixture_expert_choice_boost": 27.81808906991802,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.2028,
+     "learning_rate": 0.1678,
+     "mixture_diversity_lambda": 0.1549,
+     "bagging_fraction": 0.0881,
+     "mixture_init": 0.0822,
+     "mixture_warmup_iters": 0.0495,
+     "min_data_in_leaf": 0.0338,
+     "mixture_num_experts": 0.033,
+     "num_leaves": 0.0287,
+     "mixture_routing_mode": 0.0278,
+     "mixture_refit_leaves": 0.0224,
+     "max_depth": 0.0199,
+     "extra_trees": 0.0153,
+     "bagging_freq": 0.0146,
+     "mixture_r_smoothing": 0.0134,
+     "mixture_balance_factor": 0.0128,
+     "feature_fraction": 0.0124,
+     "mixture_hard_m_step": 0.0105,
+     "mixture_e_step_mode": 0.0042,
+     "lambda_l2": 0.0038,
+     "lambda_l1": 0.0021
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 22,
+        "mean": 2.3945,
+        "std": 0.0812,
+        "min": 2.3273
+       },
+       "none": {
+        "n": 77,
+        "mean": 2.3809,
+        "std": 0.0353,
+        "min": 2.3122
+       },
+       "gbdt": {
+        "n": 201,
+        "mean": 2.3336,
+        "std": 0.0243,
+        "min": 2.2914
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0473,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 23,
+        "mean": 2.4015,
+        "std": 0.078,
+        "min": 2.3443
+       },
+       "expert_choice": {
+        "n": 277,
+        "mean": 2.346,
+        "std": 0.0343,
+        "min": 2.2914
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0555,
+       "p_value": 0.00307,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 45,
+        "mean": 2.3809,
+        "std": 0.0332,
+        "min": 2.3122
+       },
+       "gate_only": {
+        "n": 47,
+        "mean": 2.3755,
+        "std": 0.0416,
+        "min": 2.3051
+       },
+       "em": {
+        "n": 208,
+        "mean": 2.3379,
+        "std": 0.0377,
+        "min": 2.2914
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0376,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 45,
+        "mean": 2.3787,
+        "std": 0.0273,
+        "min": 2.3122
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 2.3885,
+        "std": 0.0416,
+        "min": 2.3348
+       },
+       "tree_hierarchical": {
+        "n": 201,
+        "mean": 2.3366,
+        "std": 0.0403,
+        "min": 2.2914
+       },
+       "uniform": {
+        "n": 40,
+        "mean": 2.3733,
+        "std": 0.0282,
+        "min": 2.3124
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "uniform",
+       "delta_mean": 0.0367,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 53,
+        "mean": 2.3896,
+        "std": 0.061,
+        "min": 2.3122
+       },
+       "markov": {
+        "n": 17,
+        "mean": 2.3786,
+        "std": 0.038,
+        "min": 2.3298
+       },
+       "none": {
+        "n": 230,
+        "mean": 2.3391,
+        "std": 0.0284,
+        "min": 2.2914
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.0395,
+       "p_value": 0.000755,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 225,
+        "mean": 2.3409,
+        "std": 0.0408,
+        "min": 2.2914
+       },
+       "False": {
+        "n": 75,
+        "mean": 2.3782,
+        "std": 0.0323,
+        "min": 2.3122
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0373,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.347,
+        "std": 0.0407,
+        "min": 2.2914
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.3936,
+        "std": 0.0349,
+        "min": 2.3409
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0466,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.3748
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 227,
+       "mean_rmse": 2.3423
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2232
+       ],
+       "n": 75,
+       "mean_rmse": 2.3511
+      },
+      "Q2": {
+       "range": [
+        0.2232,
+        0.2582
+       ],
+       "n": 75,
+       "mean_rmse": 2.3314
+      },
+      "Q3": {
+       "range": [
+        0.2582,
+        0.337
+       ],
+       "n": 75,
+       "mean_rmse": 2.3416
+      },
+      "Q4": {
+       "range": [
+        0.337,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3768
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3288
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.3312
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        30.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.3539
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.3821
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3823
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 43,
+       "mean_rmse": 2.3417
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 185,
+       "mean_rmse": 2.3398
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0664
+       ],
+       "n": 75,
+       "mean_rmse": 2.3525
+      },
+      "Q2": {
+       "range": [
+        0.0664,
+        0.0853
+       ],
+       "n": 75,
+       "mean_rmse": 2.3272
+      },
+      "Q3": {
+       "range": [
+        0.0853,
+        0.2188
+       ],
+       "n": 75,
+       "mean_rmse": 2.3595
+      },
+      "Q4": {
+       "range": [
+        0.2188,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3618
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        93.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3773
+      },
+      "Q2": {
+       "range": [
+        93.75,
+        111.0
+       ],
+       "n": 65,
+       "mean_rmse": 2.3506
+      },
+      "Q3": {
+       "range": [
+        111.0,
+        119.0
+       ],
+       "n": 81,
+       "mean_rmse": 2.3361
+      },
+      "Q4": {
+       "range": [
+        119.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.3388
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 133,
+       "mean_rmse": 2.3334
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        8.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.348
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.3807
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        28.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.3442
+      },
+      "Q2": {
+       "range": [
+        28.0,
+        32.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.3266
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        45.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.3496
+      },
+      "Q4": {
+       "range": [
+        45.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 2.378
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 783.4,
+    "holdout": {
+     "holdout_rmse": 1.890645288243279,
+     "retrain_s": 0.2585,
+     "predict_s": 0.0007,
+     "cv_rmse_of_winner": 2.2914192531450532
+    }
+   }
+  },
+  "hmm@s43": {
+   "dataset": "hmm",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.4217584667381496,
+    "std": 2.6151502465431355
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.379979557922336,
+    "rmse_p10": 2.3844018557755606,
+    "rmse_median": 2.3935301279425514,
+    "train_s_median": 0.033165021985769275,
+    "train_s_mean": 0.034378600942591826,
+    "train_s_p90": 0.04573315247893334,
+    "best_params": {
+     "learning_rate": 0.05661476441827138,
+     "num_leaves": 20,
+     "max_depth": 8,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 2.899525875709731,
+     "lambda_l2": 1.4537344690996084,
+     "feature_fraction": 0.9559564891707837,
+     "bagging_fraction": 0.8605286620730526,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5322,
+     "extra_trees": 0.2218,
+     "learning_rate": 0.0983,
+     "bagging_fraction": 0.056,
+     "lambda_l1": 0.035,
+     "feature_fraction": 0.0331,
+     "max_depth": 0.0131,
+     "num_leaves": 0.005,
+     "bagging_freq": 0.0029,
+     "lambda_l2": 0.0027
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.3973,
+        "std": 0.0165,
+        "min": 2.38
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.4486,
+        "std": 0.0327,
+        "min": 2.4035
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0513,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0531
+       ],
+       "n": 75,
+       "mean_rmse": 2.4073
+      },
+      "Q2": {
+       "range": [
+        0.0531,
+        0.0605
+       ],
+       "n": 75,
+       "mean_rmse": 2.3941
+      },
+      "Q3": {
+       "range": [
+        0.0605,
+        0.0725
+       ],
+       "n": 75,
+       "mean_rmse": 2.3955
+      },
+      "Q4": {
+       "range": [
+        0.0725,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.4069
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        15.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3941
+      },
+      "Q2": {
+       "range": [
+        15.75,
+        26.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.4
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        73.5
+       ],
+       "n": 79,
+       "mean_rmse": 2.4058
+      },
+      "Q4": {
+       "range": [
+        73.5,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.4035
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 52,
+       "mean_rmse": 2.4084
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 50,
+       "mean_rmse": 2.3978
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 83,
+       "mean_rmse": 2.3967
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 115,
+       "mean_rmse": 2.4019
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 49,
+       "mean_rmse": 2.3942
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.3915
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        18.0
+       ],
+       "n": 88,
+       "mean_rmse": 2.3982
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.4191
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.8358
+       ],
+       "n": 75,
+       "mean_rmse": 2.4157
+      },
+      "Q2": {
+       "range": [
+        0.8358,
+        2.2098
+       ],
+       "n": 75,
+       "mean_rmse": 2.3956
+      },
+      "Q3": {
+       "range": [
+        2.2098,
+        4.0999
+       ],
+       "n": 75,
+       "mean_rmse": 2.3973
+      },
+      "Q4": {
+       "range": [
+        4.0999,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.395
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0696
+       ],
+       "n": 75,
+       "mean_rmse": 2.4147
+      },
+      "Q2": {
+       "range": [
+        0.0696,
+        0.4908
+       ],
+       "n": 75,
+       "mean_rmse": 2.3962
+      },
+      "Q3": {
+       "range": [
+        0.4908,
+        1.2586
+       ],
+       "n": 75,
+       "mean_rmse": 2.3976
+      },
+      "Q4": {
+       "range": [
+        1.2586,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3951
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.907
+       ],
+       "n": 75,
+       "mean_rmse": 2.4142
+      },
+      "Q2": {
+       "range": [
+        0.907,
+        0.9594
+       ],
+       "n": 75,
+       "mean_rmse": 2.4004
+      },
+      "Q3": {
+       "range": [
+        0.9594,
+        0.9768
+       ],
+       "n": 75,
+       "mean_rmse": 2.395
+      },
+      "Q4": {
+       "range": [
+        0.9768,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3941
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8543
+       ],
+       "n": 75,
+       "mean_rmse": 2.4139
+      },
+      "Q2": {
+       "range": [
+        0.8543,
+        0.892
+       ],
+       "n": 75,
+       "mean_rmse": 2.3994
+      },
+      "Q3": {
+       "range": [
+        0.892,
+        0.921
+       ],
+       "n": 75,
+       "mean_rmse": 2.3933
+      },
+      "Q4": {
+       "range": [
+        0.921,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3972
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 56.7,
+    "holdout": {
+     "holdout_rmse": 2.4701788835392824,
+     "retrain_s": 0.0675,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.379979557922336
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.3741243851915868,
+    "rmse_p10": 2.3785087743282265,
+    "rmse_median": 2.3875729559268652,
+    "train_s_median": 0.08935012761503458,
+    "train_s_mean": 0.09791020555918414,
+    "train_s_p90": 0.15063032556325198,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.2601991604099602,
+     "num_leaves": 26,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 5.469864015425689,
+     "lambda_l2": 2.2385052701086353e-07,
+     "feature_fraction": 0.990435882846028,
+     "bagging_fraction": 0.7389852735861216,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.5235,
+     "min_data_in_leaf": 0.2219,
+     "learning_rate": 0.2155,
+     "lambda_l1": 0.0128,
+     "bagging_fraction": 0.0062,
+     "bagging_freq": 0.0056,
+     "feature_fraction": 0.004,
+     "num_leaves": 0.0038,
+     "max_depth": 0.0032,
+     "n_models": 0.0026,
+     "lambda_l2": 0.0009
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 20,
+        "mean": 2.4489,
+        "std": 0.0188,
+        "min": 2.4261
+       },
+       "True": {
+        "n": 280,
+        "mean": 2.391,
+        "std": 0.0183,
+        "min": 2.3741
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0579,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.171
+       ],
+       "n": 75,
+       "mean_rmse": 2.4087
+      },
+      "Q2": {
+       "range": [
+        0.171,
+        0.2408
+       ],
+       "n": 75,
+       "mean_rmse": 2.3928
+      },
+      "Q3": {
+       "range": [
+        0.2408,
+        0.2655
+       ],
+       "n": 75,
+       "mean_rmse": 2.3905
+      },
+      "Q4": {
+       "range": [
+        0.2655,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3875
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.3946
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        25.5
+       ],
+       "n": 86,
+       "mean_rmse": 2.3916
+      },
+      "Q3": {
+       "range": [
+        25.5,
+        38.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.3948
+      },
+      "Q4": {
+       "range": [
+        38.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.399
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 51,
+       "mean_rmse": 2.4131
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.3953
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 186,
+       "mean_rmse": 2.3897
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3886
+      },
+      "Q2": {
+       "range": [
+        7.75,
+        10.0
+       ],
+       "n": 60,
+       "mean_rmse": 2.3913
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        15.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.3893
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 2.4099
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        1.256
+       ],
+       "n": 75,
+       "mean_rmse": 2.4131
+      },
+      "Q2": {
+       "range": [
+        1.256,
+        3.5851
+       ],
+       "n": 75,
+       "mean_rmse": 2.393
+      },
+      "Q3": {
+       "range": [
+        3.5851,
+        5.8577
+       ],
+       "n": 75,
+       "mean_rmse": 2.3869
+      },
+      "Q4": {
+       "range": [
+        5.8577,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3865
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.3935
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.3898
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.3918
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.4044
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9334
+       ],
+       "n": 75,
+       "mean_rmse": 2.407
+      },
+      "Q2": {
+       "range": [
+        0.9334,
+        0.9649
+       ],
+       "n": 75,
+       "mean_rmse": 2.3939
+      },
+      "Q3": {
+       "range": [
+        0.9649,
+        0.9816
+       ],
+       "n": 75,
+       "mean_rmse": 2.3901
+      },
+      "Q4": {
+       "range": [
+        0.9816,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3885
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7225
+       ],
+       "n": 75,
+       "mean_rmse": 2.3984
+      },
+      "Q2": {
+       "range": [
+        0.7225,
+        0.7428
+       ],
+       "n": 75,
+       "mean_rmse": 2.3924
+      },
+      "Q3": {
+       "range": [
+        0.7428,
+        0.7681
+       ],
+       "n": 75,
+       "mean_rmse": 2.3896
+      },
+      "Q4": {
+       "range": [
+        0.7681,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3992
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 152.1,
+    "holdout": {
+     "holdout_rmse": 2.4695834158689207,
+     "retrain_s": 0.1246,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.3741243851915868
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.321258834502795,
+    "rmse_p10": 2.337980711428011,
+    "rmse_median": 2.358560177128537,
+    "train_s_median": 0.23950783275067805,
+    "train_s_mean": 0.26707255912075445,
+    "train_s_p90": 0.4124684542417528,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.23921319029130733,
+     "num_leaves": 68,
+     "max_depth": 3,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 1.0396058755346698e-06,
+     "lambda_l2": 0.3010789103261221,
+     "feature_fraction": 0.9724674913600748,
+     "bagging_fraction": 0.9437908860033131,
+     "bagging_freq": 0,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 10,
+     "mixture_balance_factor": 4,
+     "mixture_smoothing_lambda": 0.847697302501381,
+     "mixture_diversity_lambda": 0.29107719914382496,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 42,
+     "mixture_gate_learning_rate": 0.02052981774642584,
+     "mixture_gate_lambda_l2": 9.006261196830508,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_retrain_interval": 15,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_e_step_mode": 0.3445,
+     "mixture_routing_mode": 0.1805,
+     "mixture_gate_type": 0.1011,
+     "mixture_r_smoothing": 0.0711,
+     "bagging_freq": 0.0553,
+     "mixture_diversity_lambda": 0.0508,
+     "num_leaves": 0.0434,
+     "learning_rate": 0.0292,
+     "min_data_in_leaf": 0.0238,
+     "feature_fraction": 0.022,
+     "bagging_fraction": 0.0215,
+     "lambda_l2": 0.0118,
+     "mixture_balance_factor": 0.0102,
+     "mixture_init": 0.0085,
+     "mixture_warmup_iters": 0.0082,
+     "max_depth": 0.0075,
+     "mixture_refit_leaves": 0.0039,
+     "mixture_hard_m_step": 0.0029,
+     "extra_trees": 0.0016,
+     "mixture_num_experts": 0.0013,
+     "lambda_l1": 0.0008
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 18,
+        "mean": 2.4141,
+        "std": 0.0518,
+        "min": 2.3617
+       },
+       "none": {
+        "n": 16,
+        "mean": 2.4707,
+        "std": 0.0784,
+        "min": 2.3799
+       },
+       "leaf_reuse": {
+        "n": 266,
+        "mean": 2.369,
+        "std": 0.0436,
+        "min": 2.3213
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0451,
+       "p_value": 0.00242,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 20,
+        "mean": 2.4626,
+        "std": 0.0687,
+        "min": 2.3749
+       },
+       "token_choice": {
+        "n": 280,
+        "mean": 2.371,
+        "std": 0.0456,
+        "min": 2.3213
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0916,
+       "p_value": 1.3e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 18,
+        "mean": 2.4306,
+        "std": 0.0642,
+        "min": 2.3725
+       },
+       "em": {
+        "n": 17,
+        "mean": 2.4955,
+        "std": 0.0689,
+        "min": 2.3819
+       },
+       "gate_only": {
+        "n": 265,
+        "mean": 2.3659,
+        "std": 0.0366,
+        "min": 2.3213
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0647,
+       "p_value": 0.000669,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 15,
+        "mean": 2.4363,
+        "std": 0.0694,
+        "min": 2.3727
+       },
+       "tree_hierarchical": {
+        "n": 255,
+        "mean": 2.372,
+        "std": 0.0514,
+        "min": 2.3213
+       },
+       "random": {
+        "n": 16,
+        "mean": 2.3897,
+        "std": 0.0304,
+        "min": 2.3666
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 2.3928,
+        "std": 0.025,
+        "min": 2.3607
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "random",
+       "delta_mean": 0.0177,
+       "p_value": 0.049879,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 163,
+        "mean": 2.3624,
+        "std": 0.0326,
+        "min": 2.3213
+       },
+       "none": {
+        "n": 16,
+        "mean": 2.4386,
+        "std": 0.0778,
+        "min": 2.3393
+       },
+       "markov": {
+        "n": 121,
+        "mean": 2.3889,
+        "std": 0.061,
+        "min": 2.3361
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0265,
+       "p_value": 2.6e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 89,
+        "mean": 2.4093,
+        "std": 0.0679,
+        "min": 2.3448
+       },
+       "False": {
+        "n": 211,
+        "mean": 2.3635,
+        "std": 0.0372,
+        "min": 2.3213
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0458,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 23,
+        "mean": 2.4129,
+        "std": 0.0455,
+        "min": 2.35
+       },
+       "True": {
+        "n": 277,
+        "mean": 2.3741,
+        "std": 0.0522,
+        "min": 2.3213
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0388,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 10,
+       "mean_rmse": 2.4735
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 290,
+       "mean_rmse": 2.3738
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3094
+       ],
+       "n": 75,
+       "mean_rmse": 2.375
+      },
+      "Q2": {
+       "range": [
+        0.3094,
+        0.3349
+       ],
+       "n": 75,
+       "mean_rmse": 2.3537
+      },
+      "Q3": {
+       "range": [
+        0.3349,
+        0.3916
+       ],
+       "n": 75,
+       "mean_rmse": 2.3814
+      },
+      "Q4": {
+       "range": [
+        0.3916,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3985
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 47,
+       "mean_rmse": 2.3628
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 95,
+       "mean_rmse": 2.3648
+      },
+      "Q3": {
+       "range": [
+        12.0,
+        18.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.3793
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 2.3969
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 58,
+       "mean_rmse": 2.3838
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 242,
+       "mean_rmse": 2.3755
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.107
+       ],
+       "n": 75,
+       "mean_rmse": 2.3999
+      },
+      "Q2": {
+       "range": [
+        0.107,
+        0.1507
+       ],
+       "n": 75,
+       "mean_rmse": 2.3754
+      },
+      "Q3": {
+       "range": [
+        0.1507,
+        0.1813
+       ],
+       "n": 75,
+       "mean_rmse": 2.3649
+      },
+      "Q4": {
+       "range": [
+        0.1813,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.3683
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        80.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.3929
+      },
+      "Q2": {
+       "range": [
+        80.75,
+        90.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.3568
+      },
+      "Q3": {
+       "range": [
+        90.0,
+        112.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.3691
+      },
+      "Q4": {
+       "range": [
+        112.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.389
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.397
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 49,
+       "mean_rmse": 2.4049
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 177,
+       "mean_rmse": 2.3611
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.3914
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        24.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.3647
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        31.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.3659
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.3883
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 413.8,
+    "holdout": {
+     "holdout_rmse": 2.480334949636432,
+     "retrain_s": 0.2672,
+     "predict_s": 0.001,
+     "cv_rmse_of_winner": 2.321258834502795
+    }
+   }
+  },
+  "hmm@s44": {
+   "dataset": "hmm",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.3382988881406865,
+    "std": 2.4175724001792345
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.1311368317391413,
+    "rmse_p10": 2.1347059782531117,
+    "rmse_median": 2.1422571636194356,
+    "train_s_median": 0.028049694932997228,
+    "train_s_mean": 0.03237962528442343,
+    "train_s_p90": 0.043470142595469954,
+    "best_params": {
+     "learning_rate": 0.04318059687956437,
+     "num_leaves": 111,
+     "max_depth": 3,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 7.813033892417652e-06,
+     "lambda_l2": 3.991685143866207e-05,
+     "feature_fraction": 0.7461439832744696,
+     "bagging_fraction": 0.9298644845780416,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4949,
+     "max_depth": 0.1553,
+     "bagging_fraction": 0.1215,
+     "min_data_in_leaf": 0.0916,
+     "learning_rate": 0.075,
+     "feature_fraction": 0.0402,
+     "num_leaves": 0.0166,
+     "bagging_freq": 0.0028,
+     "lambda_l1": 0.0012,
+     "lambda_l2": 0.0009
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 22,
+        "mean": 2.1867,
+        "std": 0.0243,
+        "min": 2.157
+       },
+       "True": {
+        "n": 278,
+        "mean": 2.1441,
+        "std": 0.0129,
+        "min": 2.1311
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0426,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0406
+       ],
+       "n": 75,
+       "mean_rmse": 2.1514
+      },
+      "Q2": {
+       "range": [
+        0.0406,
+        0.0468
+       ],
+       "n": 75,
+       "mean_rmse": 2.1411
+      },
+      "Q3": {
+       "range": [
+        0.0468,
+        0.0612
+       ],
+       "n": 75,
+       "mean_rmse": 2.1454
+      },
+      "Q4": {
+       "range": [
+        0.0612,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1511
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        88.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.1552
+      },
+      "Q2": {
+       "range": [
+        88.0,
+        102.0
+       ],
+       "n": 76,
+       "mean_rmse": 2.1441
+      },
+      "Q3": {
+       "range": [
+        102.0,
+        112.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.1438
+      },
+      "Q4": {
+       "range": [
+        112.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.1462
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 216,
+       "mean_rmse": 2.143
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 2.1581
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 70,
+       "mean_rmse": 2.1393
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.1438
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.25
+       ],
+       "n": 78,
+       "mean_rmse": 2.1472
+      },
+      "Q4": {
+       "range": [
+        14.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1582
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1468
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1476
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1447
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1498
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1443
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0006
+       ],
+       "n": 75,
+       "mean_rmse": 2.1449
+      },
+      "Q3": {
+       "range": [
+        0.0006,
+        0.0048
+       ],
+       "n": 75,
+       "mean_rmse": 2.1449
+      },
+      "Q4": {
+       "range": [
+        0.0048,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1548
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7138
+       ],
+       "n": 75,
+       "mean_rmse": 2.1508
+      },
+      "Q2": {
+       "range": [
+        0.7138,
+        0.7421
+       ],
+       "n": 75,
+       "mean_rmse": 2.1424
+      },
+      "Q3": {
+       "range": [
+        0.7421,
+        0.7952
+       ],
+       "n": 75,
+       "mean_rmse": 2.1434
+      },
+      "Q4": {
+       "range": [
+        0.7952,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1522
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8818
+       ],
+       "n": 75,
+       "mean_rmse": 2.159
+      },
+      "Q2": {
+       "range": [
+        0.8818,
+        0.9284
+       ],
+       "n": 75,
+       "mean_rmse": 2.1422
+      },
+      "Q3": {
+       "range": [
+        0.9284,
+        0.9542
+       ],
+       "n": 75,
+       "mean_rmse": 2.1434
+      },
+      "Q4": {
+       "range": [
+        0.9542,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1443
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 53.5,
+    "holdout": {
+     "holdout_rmse": 2.29552544390291,
+     "retrain_s": 0.0394,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.1311368317391413
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.1260558614273632,
+    "rmse_p10": 2.1309237511523103,
+    "rmse_median": 2.1368470442990297,
+    "train_s_median": 0.0855847205966711,
+    "train_s_mean": 0.08899711854259174,
+    "train_s_p90": 0.11064528129994873,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.21491711563942517,
+     "num_leaves": 63,
+     "max_depth": 3,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 6.454905276901322,
+     "lambda_l2": 1.0320206592878025e-08,
+     "feature_fraction": 0.6851949884154437,
+     "bagging_fraction": 0.7295100103623365,
+     "bagging_freq": 2,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.3538,
+     "extra_trees": 0.3261,
+     "min_data_in_leaf": 0.1917,
+     "feature_fraction": 0.0508,
+     "bagging_fraction": 0.0249,
+     "num_leaves": 0.0192,
+     "bagging_freq": 0.0119,
+     "lambda_l1": 0.0115,
+     "max_depth": 0.006,
+     "n_models": 0.0038,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.1405,
+        "std": 0.0146,
+        "min": 2.1261
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.184,
+        "std": 0.0223,
+        "min": 2.1586
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0435,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0982
+       ],
+       "n": 75,
+       "mean_rmse": 2.1595
+      },
+      "Q2": {
+       "range": [
+        0.0982,
+        0.1555
+       ],
+       "n": 75,
+       "mean_rmse": 2.1392
+      },
+      "Q3": {
+       "range": [
+        0.1555,
+        0.1872
+       ],
+       "n": 75,
+       "mean_rmse": 2.1359
+      },
+      "Q4": {
+       "range": [
+        0.1872,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1394
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        52.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.1464
+      },
+      "Q2": {
+       "range": [
+        52.0,
+        58.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.1367
+      },
+      "Q3": {
+       "range": [
+        58.0,
+        68.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.1387
+      },
+      "Q4": {
+       "range": [
+        68.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.1521
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        8.0
+       ],
+       "n": 219,
+       "mean_rmse": 2.1398
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.1535
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.1376
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1386
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        17.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.1416
+      },
+      "Q4": {
+       "range": [
+        17.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 2.1553
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.4797
+       ],
+       "n": 75,
+       "mean_rmse": 2.1547
+      },
+      "Q2": {
+       "range": [
+        0.4797,
+        3.2552
+       ],
+       "n": 75,
+       "mean_rmse": 2.1422
+      },
+      "Q3": {
+       "range": [
+        3.2552,
+        5.8191
+       ],
+       "n": 75,
+       "mean_rmse": 2.1396
+      },
+      "Q4": {
+       "range": [
+        5.8191,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1375
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.139
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1381
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.1434
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1535
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6187
+       ],
+       "n": 75,
+       "mean_rmse": 2.1481
+      },
+      "Q2": {
+       "range": [
+        0.6187,
+        0.6597
+       ],
+       "n": 75,
+       "mean_rmse": 2.1408
+      },
+      "Q3": {
+       "range": [
+        0.6597,
+        0.7094
+       ],
+       "n": 75,
+       "mean_rmse": 2.1442
+      },
+      "Q4": {
+       "range": [
+        0.7094,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1409
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6736
+       ],
+       "n": 75,
+       "mean_rmse": 2.1497
+      },
+      "Q2": {
+       "range": [
+        0.6736,
+        0.735
+       ],
+       "n": 75,
+       "mean_rmse": 2.1378
+      },
+      "Q3": {
+       "range": [
+        0.735,
+        0.7581
+       ],
+       "n": 75,
+       "mean_rmse": 2.1386
+      },
+      "Q4": {
+       "range": [
+        0.7581,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1479
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 138.3,
+    "holdout": {
+     "holdout_rmse": 2.2639089592522867,
+     "retrain_s": 0.0895,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.1260558614273632
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.1277937201663955,
+    "rmse_p10": 2.134503296936796,
+    "rmse_median": 2.143011551588498,
+    "train_s_median": 0.12501213401556016,
+    "train_s_mean": 0.2248691858785848,
+    "train_s_p90": 0.2906913369521499,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.076159095503806,
+     "num_leaves": 62,
+     "max_depth": 3,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 6.218530663872866e-07,
+     "lambda_l2": 0.26354312817429204,
+     "feature_fraction": 0.7024314959157708,
+     "bagging_fraction": 0.9442948395954206,
+     "bagging_freq": 6,
+     "extra_trees": true,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 9,
+     "mixture_balance_factor": 5,
+     "mixture_diversity_lambda": 0.00013384912932266901,
+     "mixture_hard_m_step": false,
+     "mixture_expert_capacity_factor": 1.300485235253607,
+     "mixture_expert_choice_boost": 20.429577070327547,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.6246,
+     "feature_fraction": 0.0986,
+     "mixture_routing_mode": 0.0931,
+     "learning_rate": 0.0269,
+     "mixture_r_smoothing": 0.0254,
+     "bagging_fraction": 0.0189,
+     "mixture_balance_factor": 0.0159,
+     "mixture_warmup_iters": 0.0152,
+     "mixture_gate_type": 0.0136,
+     "min_data_in_leaf": 0.013,
+     "mixture_e_step_mode": 0.0128,
+     "num_leaves": 0.0116,
+     "mixture_diversity_lambda": 0.0085,
+     "bagging_freq": 0.0048,
+     "mixture_num_experts": 0.0046,
+     "mixture_refit_leaves": 0.004,
+     "lambda_l1": 0.0026,
+     "mixture_hard_m_step": 0.0022,
+     "max_depth": 0.0017,
+     "lambda_l2": 0.0015,
+     "extra_trees": 0.0004
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 16,
+        "mean": 2.2004,
+        "std": 0.0696,
+        "min": 2.139
+       },
+       "none": {
+        "n": 248,
+        "mean": 2.1613,
+        "std": 0.0589,
+        "min": 2.1278
+       },
+       "leaf_reuse": {
+        "n": 36,
+        "mean": 2.1708,
+        "std": 0.0534,
+        "min": 2.1336
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0095,
+       "p_value": 0.334658,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 47,
+        "mean": 2.1799,
+        "std": 0.0573,
+        "min": 2.1373
+       },
+       "expert_choice": {
+        "n": 253,
+        "mean": 2.1617,
+        "std": 0.0595,
+        "min": 2.1278
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0182,
+       "p_value": 0.052555,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 37,
+        "mean": 2.1819,
+        "std": 0.0642,
+        "min": 2.1373
+       },
+       "em": {
+        "n": 108,
+        "mean": 2.167,
+        "std": 0.0627,
+        "min": 2.1278
+       },
+       "loss_only": {
+        "n": 155,
+        "mean": 2.1586,
+        "std": 0.055,
+        "min": 2.1293
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0084,
+       "p_value": 0.264656,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 21,
+        "mean": 2.163,
+        "std": 0.0353,
+        "min": 2.1383
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 2.3333,
+        "std": 0.0819,
+        "min": 2.1612
+       },
+       "random": {
+        "n": 249,
+        "mean": 2.1506,
+        "std": 0.0338,
+        "min": 2.1278
+       },
+       "gmm": {
+        "n": 16,
+        "mean": 2.2358,
+        "std": 0.0906,
+        "min": 2.1404
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.0124,
+       "p_value": 0.142853,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 257,
+        "mean": 2.159,
+        "std": 0.0567,
+        "min": 2.1278
+       },
+       "ema": {
+        "n": 27,
+        "mean": 2.1859,
+        "std": 0.054,
+        "min": 2.1397
+       },
+       "markov": {
+        "n": 16,
+        "mean": 2.2173,
+        "std": 0.0772,
+        "min": 2.1366
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0269,
+       "p_value": 0.022,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 28,
+        "mean": 2.194,
+        "std": 0.0755,
+        "min": 2.1313
+       },
+       "False": {
+        "n": 272,
+        "mean": 2.1615,
+        "std": 0.0568,
+        "min": 2.1278
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0325,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.1623,
+        "std": 0.0599,
+        "min": 2.1278
+       },
+       "False": {
+        "n": 21,
+        "mean": 2.1939,
+        "std": 0.0451,
+        "min": 2.1552
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0316,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 34,
+       "mean_rmse": 2.1877
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 266,
+       "mean_rmse": 2.1616
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0221
+       ],
+       "n": 75,
+       "mean_rmse": 2.154
+      },
+      "Q2": {
+       "range": [
+        0.0221,
+        0.0423
+       ],
+       "n": 75,
+       "mean_rmse": 2.1519
+      },
+      "Q3": {
+       "range": [
+        0.0423,
+        0.1128
+       ],
+       "n": 75,
+       "mean_rmse": 2.1671
+      },
+      "Q4": {
+       "range": [
+        0.1128,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1851
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.1656
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        21.5
+       ],
+       "n": 76,
+       "mean_rmse": 2.1639
+      },
+      "Q3": {
+       "range": [
+        21.5,
+        24.0
+       ],
+       "n": 59,
+       "mean_rmse": 2.1556
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 91,
+       "mean_rmse": 2.1699
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.1606
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 150,
+       "mean_rmse": 2.1621
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.1731
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0632
+       ],
+       "n": 75,
+       "mean_rmse": 2.1796
+      },
+      "Q2": {
+       "range": [
+        0.0632,
+        0.0761
+       ],
+       "n": 75,
+       "mean_rmse": 2.1568
+      },
+      "Q3": {
+       "range": [
+        0.0761,
+        0.0932
+       ],
+       "n": 75,
+       "mean_rmse": 2.1491
+      },
+      "Q4": {
+       "range": [
+        0.0932,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.1726
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.1557
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        82.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.1741
+      },
+      "Q3": {
+       "range": [
+        82.0,
+        94.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.156
+      },
+      "Q4": {
+       "range": [
+        94.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.172
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 213,
+       "mean_rmse": 2.1577
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 87,
+       "mean_rmse": 2.1812
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 67,
+       "mean_rmse": 2.1556
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.1572
+      },
+      "Q3": {
+       "range": [
+        12.0,
+        19.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.1669
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.1774
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 346.9,
+    "holdout": {
+     "holdout_rmse": 2.2601212441590333,
+     "retrain_s": 0.1474,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 2.1277937201663955
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_houses_ensemble_report.md
+++ b/bench_results/meth2_v081/ds_houses_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['houses'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| houses | naive-ensemble | **48923.76265** ± 850.01220 | 50476.70623 | 0.0% | 0.82 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| houses@s42 | naive-ensemble | 50578.9081 | 50981.6644 | 0.679 | 940 |
+| houses@s43 | naive-ensemble | 50415.3430 | 50739.7084 | 0.734 | 1044 |
+| houses@s44 | naive-ensemble | 50435.8676 | 51099.2628 | 0.659 | 861 |
+
+
+
+---
+
+## houses@s42  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 50074.59416** (winner retrained in 0.97s, cv score of winner: 50578.9081)
+- cv best RMSE: 50578.9081, median: 50981.6644, p10: 50734.1221
+- train: median 0.679s/fold, mean 0.623s, p90 0.805s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.536 |
+| `extra_trees` | 0.388 |
+| `min_data_in_leaf` | 0.038 |
+| `feature_fraction` | 0.014 |
+| `num_leaves` | 0.011 |
+| `max_depth` | 0.009 |
+| `bagging_freq` | 0.002 |
+| `bagging_fraction` | 0.001 |
+| `n_models` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 51748.6664 | 3014.1058 | 50578.9081 |
+| True | 20 | 64637.5571 | 7290.6405 | 55924.7269 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 55201.3691 | 51575.4940 | 51266.5691 | 52388.2708 | **Q3** [0.0848, 0.0982] |
+| `num_leaves` | 53904.5898 | 51916.7492 | 51301.5756 | 53288.6499 | **Q3** [76.0, 87.0] |
+| `max_depth` | 56780.4814 | 52525.5377 | — | 51618.5296 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 51907.8658 | 51624.5413 | 52007.1930 | 54763.9636 | **Q2** [14.0, 18.5] |
+| `lambda_l1` | 51361.2993 | 51987.7430 | 52142.8813 | 54939.7795 | **Q1** [None, 0.0] |
+| `lambda_l2` | 52272.7789 | 53378.5415 | 52007.9284 | 52772.4543 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 52483.4408 | 51419.9953 | 51532.1766 | 54996.0904 | **Q2** [0.6921, 0.7093] |
+| `bagging_fraction` | 53876.8157 | 51333.9294 | 52120.6982 | 53100.2597 | **Q2** [0.8437, 0.8759] |
+
+#### E. Slice plot
+
+![houses@s42/naive-ensemble](slice_houses@s42_naive-ensemble.png)
+
+
+---
+
+## houses@s43  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 48649.13130** (winner retrained in 0.90s, cv score of winner: 50415.3430)
+- cv best RMSE: 50415.3430, median: 50739.7084, p10: 50517.3258
+- train: median 0.734s/fold, mean 0.693s, p90 0.980s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.564 |
+| `learning_rate` | 0.347 |
+| `max_depth` | 0.052 |
+| `min_data_in_leaf` | 0.010 |
+| `bagging_fraction` | 0.009 |
+| `num_leaves` | 0.007 |
+| `feature_fraction` | 0.006 |
+| `bagging_freq` | 0.003 |
+| `n_models` | 0.001 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 51618.1532 | 2572.2672 | 50415.3430 |
+| True | 22 | 63943.2345 | 5724.1284 | 55828.6091 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54972.8666 | 51116.4459 | 51552.3147 | 52446.3430 | **Q2** [0.0665, 0.0764] |
+| `num_leaves` | 53020.2347 | 51361.9096 | 51955.5208 | 53766.3171 | **Q2** [60.0, 70.5] |
+| `max_depth` | 55668.8406 | 51845.0431 | — | 51891.6972 | **Q2** [10.0, 11.0] |
+| `min_data_in_leaf` | 51587.5479 | 51413.4106 | 51860.5632 | 55073.7576 | **Q2** [10.0, 13.0] |
+| `lambda_l1` | 52281.4770 | 52297.3752 | 51852.3108 | 53656.8071 | **Q3** [0.0, 0.0002] |
+| `lambda_l2` | 53156.2125 | 51790.0639 | 51600.2993 | 53541.3944 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 52495.8225 | 51417.6715 | 51701.2794 | 54473.1968 | **Q2** [0.6052, 0.6371] |
+| `bagging_fraction` | 53971.5358 | 51764.9898 | 51378.1243 | 52973.3202 | **Q3** [0.8349, 0.8602] |
+
+#### E. Slice plot
+
+![houses@s43/naive-ensemble](slice_houses@s43_naive-ensemble.png)
+
+
+---
+
+## houses@s44  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 48047.56250** (winner retrained in 0.60s, cv score of winner: 50435.8676)
+- cv best RMSE: 50435.8676, median: 51099.2628, p10: 50815.4997
+- train: median 0.659s/fold, mean 0.571s, p90 0.764s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.566 |
+| `extra_trees` | 0.400 |
+| `feature_fraction` | 0.011 |
+| `n_models` | 0.005 |
+| `max_depth` | 0.005 |
+| `num_leaves` | 0.004 |
+| `min_data_in_leaf` | 0.004 |
+| `bagging_fraction` | 0.003 |
+| `bagging_freq` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 51895.2195 | 3020.6784 | 50435.8676 |
+| True | 20 | 62912.3473 | 6320.9872 | 57054.2326 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54939.3252 | 51662.7108 | 51329.0514 | 52587.6911 | **Q3** [0.1114, 0.1294] |
+| `num_leaves` | 52726.4566 | 51899.1814 | 52106.5290 | 53727.2554 | **Q2** [59.0, 64.0] |
+| `max_depth` | 55750.8352 | 52347.7495 | — | 51792.4584 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 51594.7326 | 52217.0060 | 52249.4160 | 54272.8034 | **Q1** [None, 11.0] |
+| `lambda_l1` | 51866.3206 | 52379.4503 | 51749.6752 | 54523.3324 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 53868.6318 | 52993.0084 | 51778.9643 | 51878.1741 | **Q3** [0.5249, 1.6767] |
+| `feature_fraction` | 54017.0045 | 51846.4190 | 51465.8423 | 53189.5128 | **Q3** [0.776, 0.7944] |
+| `bagging_fraction` | 52382.4300 | 51944.4746 | 52277.0778 | 53914.7962 | **Q2** [0.7278, 0.7511] |
+
+#### E. Slice plot
+
+![houses@s44/naive-ensemble](slice_houses@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v081/ds_houses_ensemble_summary.json
+++ b/bench_results/meth2_v081/ds_houses_ensemble_summary.json
@@ -1,0 +1,1169 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "houses"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "houses": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 50074.594155623854,
+      "cv_best": 50578.908104620496,
+      "crash_rate": 0.0,
+      "retrain_s": 0.9709
+     },
+     "43": {
+      "holdout_rmse": 48649.13130174589,
+      "cv_best": 50415.34297364139,
+      "crash_rate": 0.0,
+      "retrain_s": 0.8965
+     },
+     "44": {
+      "holdout_rmse": 48047.56250190863,
+      "cv_best": 50435.867618499484,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5979
+     }
+    },
+    "holdout_mean": 48923.762653,
+    "holdout_std": 850.012202,
+    "cv_best_mean": 50476.706232
+   }
+  }
+ },
+ "runs": {
+  "houses@s42": {
+   "dataset": "houses",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 206067.006875,
+    "std": 114867.76939213117
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50578.908104620496,
+    "rmse_p10": 50734.12208136886,
+    "rmse_median": 50981.664435016646,
+    "train_s_median": 0.679318618029356,
+    "train_s_mean": 0.6233840198591352,
+    "train_s_p90": 0.8049974856525661,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.07889191593103738,
+     "num_leaves": 91,
+     "max_depth": 12,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 0.03680457646379009,
+     "lambda_l2": 1.4051239839834946e-05,
+     "feature_fraction": 0.6989720470459899,
+     "bagging_fraction": 0.8895979396238413,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5361,
+     "extra_trees": 0.3882,
+     "min_data_in_leaf": 0.0382,
+     "feature_fraction": 0.0144,
+     "num_leaves": 0.0109,
+     "max_depth": 0.0093,
+     "bagging_freq": 0.0018,
+     "bagging_fraction": 0.001,
+     "n_models": 0.0001,
+     "lambda_l1": 0.0,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 51748.6664,
+        "std": 3014.1058,
+        "min": 50578.9081
+       },
+       "True": {
+        "n": 20,
+        "mean": 64637.5571,
+        "std": 7290.6405,
+        "min": 55924.7269
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12888.8907,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0726
+       ],
+       "n": 75,
+       "mean_rmse": 55201.3691
+      },
+      "Q2": {
+       "range": [
+        0.0726,
+        0.0848
+       ],
+       "n": 75,
+       "mean_rmse": 51575.494
+      },
+      "Q3": {
+       "range": [
+        0.0848,
+        0.0982
+       ],
+       "n": 75,
+       "mean_rmse": 51266.5691
+      },
+      "Q4": {
+       "range": [
+        0.0982,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52388.2708
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        61.0
+       ],
+       "n": 71,
+       "mean_rmse": 53904.5898
+      },
+      "Q2": {
+       "range": [
+        61.0,
+        76.0
+       ],
+       "n": 75,
+       "mean_rmse": 51916.7492
+      },
+      "Q3": {
+       "range": [
+        76.0,
+        87.0
+       ],
+       "n": 73,
+       "mean_rmse": 51301.5756
+      },
+      "Q4": {
+       "range": [
+        87.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 53288.6499
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 51,
+       "mean_rmse": 56780.4814
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 37,
+       "mean_rmse": 52525.5377
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 212,
+       "mean_rmse": 51618.5296
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 70,
+       "mean_rmse": 51907.8658
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.5
+       ],
+       "n": 80,
+       "mean_rmse": 51624.5413
+      },
+      "Q3": {
+       "range": [
+        18.5,
+        23.0
+       ],
+       "n": 71,
+       "mean_rmse": 52007.193
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 54763.9636
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 51361.2993
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 51987.743
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52142.8813
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54939.7795
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52272.7789
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 53378.5415
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52007.9284
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52772.4543
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6921
+       ],
+       "n": 75,
+       "mean_rmse": 52483.4408
+      },
+      "Q2": {
+       "range": [
+        0.6921,
+        0.7093
+       ],
+       "n": 75,
+       "mean_rmse": 51419.9953
+      },
+      "Q3": {
+       "range": [
+        0.7093,
+        0.7346
+       ],
+       "n": 75,
+       "mean_rmse": 51532.1766
+      },
+      "Q4": {
+       "range": [
+        0.7346,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54996.0904
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8437
+       ],
+       "n": 75,
+       "mean_rmse": 53876.8157
+      },
+      "Q2": {
+       "range": [
+        0.8437,
+        0.8759
+       ],
+       "n": 75,
+       "mean_rmse": 51333.9294
+      },
+      "Q3": {
+       "range": [
+        0.8759,
+        0.8978
+       ],
+       "n": 75,
+       "mean_rmse": 52120.6982
+      },
+      "Q4": {
+       "range": [
+        0.8978,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53100.2597
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 939.6,
+    "holdout": {
+     "holdout_rmse": 50074.594155623854,
+     "retrain_s": 0.9709,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 50578.908104620496
+    }
+   }
+  },
+  "houses@s43": {
+   "dataset": "houses",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 207292.308625,
+    "std": 114725.69189141605
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50415.34297364139,
+    "rmse_p10": 50517.32577794939,
+    "rmse_median": 50739.70841674534,
+    "train_s_median": 0.7344209266826511,
+    "train_s_mean": 0.6932577963396908,
+    "train_s_p90": 0.9801519906148318,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.08639269080621133,
+     "num_leaves": 69,
+     "max_depth": 10,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 6.265592143193706e-07,
+     "lambda_l2": 7.796878003571206e-06,
+     "feature_fraction": 0.6449841509760923,
+     "bagging_fraction": 0.8232249027520648,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.5643,
+     "learning_rate": 0.3467,
+     "max_depth": 0.0519,
+     "min_data_in_leaf": 0.01,
+     "bagging_fraction": 0.0093,
+     "num_leaves": 0.0069,
+     "feature_fraction": 0.0057,
+     "bagging_freq": 0.0033,
+     "n_models": 0.0008,
+     "lambda_l1": 0.0007,
+     "lambda_l2": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 51618.1532,
+        "std": 2572.2672,
+        "min": 50415.343
+       },
+       "True": {
+        "n": 22,
+        "mean": 63943.2345,
+        "std": 5724.1284,
+        "min": 55828.6091
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12325.0813,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0665
+       ],
+       "n": 75,
+       "mean_rmse": 54972.8666
+      },
+      "Q2": {
+       "range": [
+        0.0665,
+        0.0764
+       ],
+       "n": 75,
+       "mean_rmse": 51116.4459
+      },
+      "Q3": {
+       "range": [
+        0.0764,
+        0.0883
+       ],
+       "n": 75,
+       "mean_rmse": 51552.3147
+      },
+      "Q4": {
+       "range": [
+        0.0883,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52446.343
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        60.0
+       ],
+       "n": 71,
+       "mean_rmse": 53020.2347
+      },
+      "Q2": {
+       "range": [
+        60.0,
+        70.5
+       ],
+       "n": 79,
+       "mean_rmse": 51361.9096
+      },
+      "Q3": {
+       "range": [
+        70.5,
+        92.0
+       ],
+       "n": 72,
+       "mean_rmse": 51955.5208
+      },
+      "Q4": {
+       "range": [
+        92.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 53766.3171
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 51,
+       "mean_rmse": 55668.8406
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 76,
+       "mean_rmse": 51845.0431
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 173,
+       "mean_rmse": 51891.6972
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 70,
+       "mean_rmse": 51587.5479
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        13.0
+       ],
+       "n": 74,
+       "mean_rmse": 51413.4106
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        20.0
+       ],
+       "n": 78,
+       "mean_rmse": 51860.5632
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 55073.7576
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52281.477
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52297.3752
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 51852.3108
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53656.8071
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 53156.2125
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 51790.0639
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 51600.2993
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53541.3944
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6052
+       ],
+       "n": 75,
+       "mean_rmse": 52495.8225
+      },
+      "Q2": {
+       "range": [
+        0.6052,
+        0.6371
+       ],
+       "n": 75,
+       "mean_rmse": 51417.6715
+      },
+      "Q3": {
+       "range": [
+        0.6371,
+        0.6775
+       ],
+       "n": 75,
+       "mean_rmse": 51701.2794
+      },
+      "Q4": {
+       "range": [
+        0.6775,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54473.1968
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8141
+       ],
+       "n": 75,
+       "mean_rmse": 53971.5358
+      },
+      "Q2": {
+       "range": [
+        0.8141,
+        0.8349
+       ],
+       "n": 75,
+       "mean_rmse": 51764.9898
+      },
+      "Q3": {
+       "range": [
+        0.8349,
+        0.8602
+       ],
+       "n": 75,
+       "mean_rmse": 51378.1243
+      },
+      "Q4": {
+       "range": [
+        0.8602,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52973.3202
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1044.3,
+    "holdout": {
+     "holdout_rmse": 48649.13130174589,
+     "retrain_s": 0.8965,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 50415.34297364139
+    }
+   }
+  },
+  "houses@s44": {
+   "dataset": "houses",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 205256.982,
+    "std": 114405.72363980168
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50435.867618499484,
+    "rmse_p10": 50815.49968269496,
+    "rmse_median": 51099.26279842231,
+    "train_s_median": 0.6587653981521726,
+    "train_s_mean": 0.5714219824684164,
+    "train_s_p90": 0.7641021321341396,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.0896011001194879,
+     "num_leaves": 52,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 5.401492171467869e-05,
+     "lambda_l2": 0.04593426827430568,
+     "feature_fraction": 0.5069221627176856,
+     "bagging_fraction": 0.8150268274067398,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5656,
+     "extra_trees": 0.4001,
+     "feature_fraction": 0.0108,
+     "n_models": 0.0051,
+     "max_depth": 0.0048,
+     "num_leaves": 0.0045,
+     "min_data_in_leaf": 0.0044,
+     "bagging_fraction": 0.0033,
+     "bagging_freq": 0.0011,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 62912.3473,
+        "std": 6320.9872,
+        "min": 57054.2326
+       },
+       "False": {
+        "n": 280,
+        "mean": 51895.2195,
+        "std": 3020.6784,
+        "min": 50435.8676
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11017.1278,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0902
+       ],
+       "n": 75,
+       "mean_rmse": 54939.3252
+      },
+      "Q2": {
+       "range": [
+        0.0902,
+        0.1114
+       ],
+       "n": 75,
+       "mean_rmse": 51662.7108
+      },
+      "Q3": {
+       "range": [
+        0.1114,
+        0.1294
+       ],
+       "n": 75,
+       "mean_rmse": 51329.0514
+      },
+      "Q4": {
+       "range": [
+        0.1294,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52587.6911
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        59.0
+       ],
+       "n": 73,
+       "mean_rmse": 52726.4566
+      },
+      "Q2": {
+       "range": [
+        59.0,
+        64.0
+       ],
+       "n": 71,
+       "mean_rmse": 51899.1814
+      },
+      "Q3": {
+       "range": [
+        64.0,
+        71.0
+       ],
+       "n": 78,
+       "mean_rmse": 52106.529
+      },
+      "Q4": {
+       "range": [
+        71.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 53727.2554
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 57,
+       "mean_rmse": 55750.8352
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 46,
+       "mean_rmse": 52347.7495
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 197,
+       "mean_rmse": 51792.4584
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 63,
+       "mean_rmse": 51594.7326
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        15.0
+       ],
+       "n": 77,
+       "mean_rmse": 52217.006
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        22.0
+       ],
+       "n": 82,
+       "mean_rmse": 52249.416
+      },
+      "Q4": {
+       "range": [
+        22.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 54272.8034
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 51866.3206
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52379.4503
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 51749.6752
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54523.3324
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 53868.6318
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.5249
+       ],
+       "n": 75,
+       "mean_rmse": 52993.0084
+      },
+      "Q3": {
+       "range": [
+        0.5249,
+        1.6767
+       ],
+       "n": 75,
+       "mean_rmse": 51778.9643
+      },
+      "Q4": {
+       "range": [
+        1.6767,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 51878.1741
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7359
+       ],
+       "n": 75,
+       "mean_rmse": 54017.0045
+      },
+      "Q2": {
+       "range": [
+        0.7359,
+        0.776
+       ],
+       "n": 75,
+       "mean_rmse": 51846.419
+      },
+      "Q3": {
+       "range": [
+        0.776,
+        0.7944
+       ],
+       "n": 75,
+       "mean_rmse": 51465.8423
+      },
+      "Q4": {
+       "range": [
+        0.7944,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53189.5128
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7278
+       ],
+       "n": 75,
+       "mean_rmse": 52382.43
+      },
+      "Q2": {
+       "range": [
+        0.7278,
+        0.7511
+       ],
+       "n": 75,
+       "mean_rmse": 51944.4746
+      },
+      "Q3": {
+       "range": [
+        0.7511,
+        0.8178
+       ],
+       "n": 75,
+       "mean_rmse": 52277.0778
+      },
+      "Q4": {
+       "range": [
+        0.8178,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53914.7962
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 861.1,
+    "holdout": {
+     "holdout_rmse": 48047.56250190863,
+     "retrain_s": 0.5979,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 50435.867618499484
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_houses_report.md
+++ b/bench_results/meth2_v081/ds_houses_report.md
@@ -1,0 +1,503 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['houses'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| houses | naive-lightgbm | **49805.38271** ± 962.89058 | 50811.46230 | 0.0% | 0.48 |
+| houses | moe | **48930.56383** ± 669.41513 | 50541.22167 | 0.0% | 2.06 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| houses@s42 | naive-lightgbm | 50683.0901 | 51224.1336 | 0.197 | 300 |
+| houses@s42 | moe | 50328.3599 | 51141.4085 | 1.113 | 2013 |
+| houses@s43 | naive-lightgbm | 51076.3747 | 51723.6494 | 0.345 | 496 |
+| houses@s43 | moe | 50705.3778 | 51454.1465 | 1.032 | 1790 |
+| houses@s44 | naive-lightgbm | 50674.9222 | 51222.7143 | 0.424 | 568 |
+| houses@s44 | moe | 50589.9273 | 51070.8269 | 1.555 | 2121 |
+
+
+
+---
+
+## houses@s42  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 50760.44294** (winner retrained in 0.22s, cv score of winner: 50683.0901)
+- cv best RMSE: 50683.0901, median: 51224.1336, p10: 50895.5274
+- train: median 0.197s/fold, mean 0.195s, p90 0.241s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.667 |
+| `extra_trees` | 0.289 |
+| `min_data_in_leaf` | 0.016 |
+| `feature_fraction` | 0.010 |
+| `max_depth` | 0.008 |
+| `bagging_fraction` | 0.004 |
+| `num_leaves` | 0.003 |
+| `bagging_freq` | 0.002 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 51888.9305 | 3228.7653 | 50683.0901 |
+| True | 22 | 65625.9156 | 10037.1753 | 57820.1777 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 55845.0459 | 51310.6123 | 51856.6872 | 52572.8922 | **Q2** [0.0884, 0.1021] |
+| `num_leaves` | 53047.3600 | 51953.3869 | 51484.0810 | 55174.9507 | **Q3** [36.0, 44.0] |
+| `max_depth` | 56986.4618 | 52400.8256 | — | 51756.6192 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 52753.3685 | 51803.1950 | 51974.3697 | 54945.4953 | **Q2** [17.0, 21.0] |
+| `lambda_l1` | 53364.3411 | 52532.0795 | 53811.8016 | 51877.0154 | **Q4** [0.1035, ∞) |
+| `lambda_l2` | 55110.6574 | 51893.7303 | 51780.1980 | 52800.6519 | **Q3** [0.1017, 0.379] |
+| `feature_fraction` | 55369.3077 | 51491.1940 | 51682.8047 | 53041.9312 | **Q2** [0.7235, 0.7507] |
+| `bagging_fraction` | 53204.3996 | 52442.3521 | 53142.7276 | 52795.7583 | **Q2** [0.6939, 0.7489] |
+
+#### E. Slice plot
+
+![houses@s42/naive-lightgbm](slice_houses@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 49606.48685** (winner retrained in 1.46s, cv score of winner: 50328.3599)
+- cv best RMSE: 50328.3599, median: 51141.4085, p10: 50554.8589
+- train: median 1.113s/fold, mean 1.320s, p90 1.740s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.475 |
+| `extra_trees` | 0.201 |
+| `mixture_gate_type` | 0.084 |
+| `min_data_in_leaf` | 0.077 |
+| `mixture_hard_m_step` | 0.039 |
+| `mixture_routing_mode` | 0.027 |
+| `mixture_refit_leaves` | 0.019 |
+| `mixture_warmup_iters` | 0.018 |
+| `mixture_init` | 0.018 |
+| `num_leaves` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 227 | 52561.0029 | 6368.4483 | 50328.3599 |
+| gbdt | 55 | 56240.5273 | 11281.4232 | 51145.6924 |
+| none | 18 | 63717.1137 | 13748.0140 | 51062.7292 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 220 | 53468.6453 | 7969.6502 | 50361.2373 |
+| token_choice | 80 | 55104.7843 | 9950.5723 | 50328.3599 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 158 | 53171.5982 | 6642.3209 | 50457.1591 |
+| gate_only | 106 | 53364.3401 | 7771.4590 | 50328.3599 |
+| loss_only | 36 | 58715.3375 | 14653.0101 | 51411.9706 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 202 | 52550.3983 | 6077.8880 | 50328.3599 |
+| uniform | 44 | 55715.1854 | 11224.4957 | 51411.9706 |
+| gmm | 29 | 55971.0784 | 11265.8340 | 50337.1123 |
+| tree_hierarchical | 25 | 59266.9930 | 12661.6279 | 50394.0203 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 207 | 52495.6730 | 4660.7289 | 50361.2373 |
+| markov | 64 | 56575.7168 | 14466.6525 | 50328.3599 |
+| none | 29 | 58070.1560 | 9808.6356 | 51633.6428 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 245 | 53320.6019 | 7898.1635 | 50361.2373 |
+| True | 55 | 56507.9501 | 10712.6703 | 50328.3599 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 53035.9593 | 7887.1092 | 50328.3599 |
+| True | 21 | 65450.0990 | 8960.5847 | 56860.8700 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 53654.6265 | — | 53838.5214 | 54089.7996 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 52374.4155 | 52238.5013 | 52833.9575 | 58172.9220 | **Q2** [0.032, 0.0776] |
+| `mixture_warmup_iters` | 52406.5517 | 56073.3724 | 52841.3306 | 54469.9122 | **Q1** [None, 8.75] |
+| `mixture_balance_factor` | 56881.4091 | 61967.6384 | — | 52203.9551 | **Q4** [9.0, ∞) |
+| `learning_rate` | 57435.0749 | 52550.6951 | 52185.2741 | 53448.7521 | **Q3** [0.1347, 0.1636] |
+| `num_leaves` | 54996.4036 | 52287.4793 | 55858.3200 | 52811.6703 | **Q2** [46.0, 57.5] |
+| `max_depth` | 57901.3487 | 53461.3992 | — | 52599.2521 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 53200.6035 | 53404.0227 | 52813.2276 | 56055.9596 | **Q3** [32.5, 41.0] |
+
+#### E. Slice plot
+
+![houses@s42/moe](slice_houses@s42_moe.png)
+
+
+---
+
+## houses@s43  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 50168.46687** (winner retrained in 0.55s, cv score of winner: 51076.3747)
+- cv best RMSE: 51076.3747, median: 51723.6494, p10: 51396.0980
+- train: median 0.345s/fold, mean 0.324s, p90 0.440s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.574 |
+| `learning_rate` | 0.271 |
+| `feature_fraction` | 0.057 |
+| `min_data_in_leaf` | 0.037 |
+| `max_depth` | 0.034 |
+| `bagging_freq` | 0.013 |
+| `bagging_fraction` | 0.011 |
+| `num_leaves` | 0.002 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 52383.8445 | 2614.0622 | 51076.3747 |
+| True | 21 | 64191.2960 | 5869.1887 | 57331.5582 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54846.3206 | 52554.2688 | 52209.4324 | 53231.4426 | **Q3** [0.0676, 0.0786] |
+| `num_leaves` | 54728.3649 | 52898.7171 | 52641.8450 | 52584.7191 | **Q4** [117.0, ∞) |
+| `max_depth` | 55898.8596 | 52305.1409 | 53184.8689 | 53192.0540 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 52738.2128 | 52435.7065 | 52297.1280 | 55178.8607 | **Q3** [17.0, 24.0] |
+| `lambda_l1` | 53621.7121 | 52673.3426 | 52469.2696 | 54077.1402 | **Q3** [0.0, 0.0001] |
+| `lambda_l2` | 53797.3334 | 53224.9688 | 52603.0649 | 53216.0974 | **Q3** [0.222, 0.8473] |
+| `feature_fraction` | 54145.7746 | 52498.8939 | 52392.1659 | 53804.6301 | **Q3** [0.7851, 0.8138] |
+| `bagging_fraction` | 53940.5034 | 52654.5802 | 53087.9937 | 53158.3872 | **Q2** [0.782, 0.8405] |
+
+#### E. Slice plot
+
+![houses@s43/naive-lightgbm](slice_houses@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 49166.64150** (winner retrained in 2.51s, cv score of winner: 50705.3778)
+- cv best RMSE: 50705.3778, median: 51454.1465, p10: 50923.4819
+- train: median 1.032s/fold, mean 1.170s, p90 1.719s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.516 |
+| `max_depth` | 0.111 |
+| `extra_trees` | 0.088 |
+| `bagging_freq` | 0.069 |
+| `mixture_refit_leaves` | 0.055 |
+| `min_data_in_leaf` | 0.053 |
+| `mixture_diversity_lambda` | 0.031 |
+| `mixture_gate_type` | 0.021 |
+| `mixture_warmup_iters` | 0.019 |
+| `mixture_balance_factor` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 179 | 52866.5474 | 6220.6660 | 50705.3778 |
+| leaf_reuse | 100 | 53685.4918 | 6373.4063 | 50796.7843 |
+| none | 21 | 65120.0933 | 22218.9926 | 51294.3960 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 204 | 53506.3314 | 8840.3014 | 50705.3778 |
+| expert_choice | 96 | 55040.5365 | 9183.4818 | 51077.4343 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 189 | 53111.9626 | 7324.2664 | 50736.4124 |
+| gate_only | 83 | 53848.7232 | 6533.9606 | 51077.4343 |
+| loss_only | 28 | 60413.5055 | 18134.1152 | 50705.3778 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 245 | 53078.8314 | 7167.8098 | 50705.3778 |
+| gmm | 16 | 53912.5258 | 1899.4457 | 51655.0006 |
+| uniform | 24 | 58768.9707 | 15595.3853 | 51155.2892 |
+| tree_hierarchical | 15 | 61454.2483 | 16579.1002 | 51191.7155 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 245 | 52588.9081 | 5704.8175 | 50705.3778 |
+| markov | 37 | 57923.3044 | 12378.8113 | 51615.3225 |
+| none | 18 | 65096.5767 | 20104.9514 | 51538.8151 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 274 | 52918.0363 | 6769.5434 | 50705.3778 |
+| True | 26 | 65370.8143 | 17490.4114 | 51384.6113 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 53420.1525 | 8856.2560 | 50705.3778 |
+| True | 20 | 62077.0209 | 6451.7889 | 56970.8863 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 58698.8078 | — | — | 53697.1794 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 53070.2117 | 52584.8410 | 52521.7762 | 57812.2793 | **Q3** [0.1181, 0.1421] |
+| `mixture_warmup_iters` | 52904.4205 | 52822.8717 | 53658.9723 | 56188.9507 | **Q2** [12.0, 14.0] |
+| `mixture_balance_factor` | 59625.8324 | 52480.4251 | — | 52769.0678 | **Q2** [9.0, 10.0] |
+| `learning_rate` | 58862.5035 | 51947.7161 | 51888.1531 | 53290.7355 | **Q3** [0.1313, 0.1694] |
+| `num_leaves` | 53584.9353 | 52029.8004 | 52594.1891 | 57723.1666 | **Q2** [27.0, 32.0] |
+| `max_depth` | 56743.4058 | 52483.7026 | — | 53560.6274 | **Q2** [7.0, 8.0] |
+| `min_data_in_leaf` | 52719.5208 | 53415.7267 | 52202.8965 | 57565.4635 | **Q3** [22.0, 27.0] |
+
+#### E. Slice plot
+
+![houses@s43/moe](slice_houses@s43_moe.png)
+
+
+---
+
+## houses@s44  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 48487.23831** (winner retrained in 0.68s, cv score of winner: 50674.9222)
+- cv best RMSE: 50674.9222, median: 51222.7143, p10: 50855.8811
+- train: median 0.424s/fold, mean 0.372s, p90 0.567s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.692 |
+| `learning_rate` | 0.219 |
+| `min_data_in_leaf` | 0.041 |
+| `max_depth` | 0.024 |
+| `feature_fraction` | 0.011 |
+| `bagging_fraction` | 0.006 |
+| `bagging_freq` | 0.003 |
+| `num_leaves` | 0.002 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 52023.0161 | 2849.5999 | 50674.9222 |
+| True | 20 | 65091.4977 | 4234.1415 | 58652.9668 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 55034.4959 | 51555.5742 | 52070.6520 | 52916.2707 | **Q2** [0.0547, 0.0629] |
+| `num_leaves` | 54040.3712 | 53077.1628 | 52163.2740 | 52344.9255 | **Q3** [110.0, 116.25] |
+| `max_depth` | 54770.7357 | 53077.9487 | — | 52205.8020 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 51813.2123 | 51580.5544 | 52392.5069 | 55575.1304 | **Q2** [12.0, 15.0] |
+| `lambda_l1` | 54635.0590 | 52656.6604 | 51978.5144 | 52306.7590 | **Q3** [0.1121, 0.6478] |
+| `lambda_l2` | 54169.3509 | 52512.7667 | 51859.7302 | 53035.1450 | **Q3** [0.0008, 0.0033] |
+| `feature_fraction` | 54831.5402 | 52020.4412 | 51598.4895 | 53126.5219 | **Q3** [0.7333, 0.7547] |
+| `bagging_fraction` | 53409.2827 | 52100.9552 | 53134.6432 | 52932.1117 | **Q2** [0.8281, 0.8641] |
+
+#### E. Slice plot
+
+![houses@s44/naive-lightgbm](slice_houses@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 48018.56314** (winner retrained in 2.20s, cv score of winner: 50589.9273)
+- cv best RMSE: 50589.9273, median: 51070.8269, p10: 50742.9081
+- train: median 1.555s/fold, mean 1.395s, p90 1.998s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.390 |
+| `extra_trees` | 0.207 |
+| `min_data_in_leaf` | 0.081 |
+| `mixture_init` | 0.073 |
+| `max_depth` | 0.061 |
+| `mixture_hard_m_step` | 0.046 |
+| `num_leaves` | 0.042 |
+| `mixture_r_smoothing` | 0.021 |
+| `feature_fraction` | 0.019 |
+| `bagging_freq` | 0.016 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 52913.8376 (n=258) | expert_choice | Δ +9376.2789 | p=6.72e-03 |
+| `mixture_init` | **uniform** | 52756.1869 (n=242) | tree_hierarchical | Δ +3942.9164 | p=3.73e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 167 | 53463.2453 | 7286.9204 | 50589.9273 |
+| none | 98 | 54828.5029 | 13304.8481 | 50654.0919 |
+| gbdt | 35 | 56182.8498 | 11838.6863 | 50863.9007 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 258 | 52913.8376 | 6177.5775 | 50589.9273 |
+| expert_choice | 42 | 62290.1165 | 20911.4932 | 50764.1484 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 167 | 53457.6306 | 7280.0732 | 50589.9273 |
+| loss_only | 97 | 54455.4010 | 12248.8014 | 50654.0919 |
+| gate_only | 36 | 57176.5774 | 14497.4678 | 50863.9007 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 242 | 52756.1869 | 6947.7786 | 50589.9273 |
+| tree_hierarchical | 16 | 56699.1033 | 4324.0192 | 51802.8678 |
+| random | 28 | 58706.8823 | 12195.6176 | 51284.8351 |
+| gmm | 14 | 67855.6715 | 28608.9037 | 52030.5229 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 246 | 52710.0895 | 5988.0027 | 50589.9273 |
+| none | 25 | 59012.3863 | 14535.8784 | 51013.1889 |
+| markov | 29 | 62964.2524 | 21918.5678 | 50965.0651 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 265 | 53100.9391 | 7798.4288 | 50589.9273 |
+| True | 35 | 62748.7465 | 18817.7422 | 53485.5830 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 53220.1237 | 9282.0985 | 50589.9273 |
+| True | 20 | 68316.0177 | 12267.1583 | 57306.1212 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 54681.2728 | 70944.6474 | — | 52920.2660 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 54564.6107 | 52005.6751 | 53029.8492 | 57305.9316 | **Q2** [0.1355, 0.1658] |
+| `mixture_warmup_iters` | 57036.4245 | 52273.1550 | 54688.2600 | 53148.9989 | **Q2** [31.0, 36.0] |
+| `mixture_balance_factor` | 54444.2875 | 57889.6490 | 53627.9676 | 53154.0900 | **Q4** [9.0, ∞) |
+| `learning_rate` | 59137.9441 | 52262.9935 | 52171.0060 | 53334.1230 | **Q3** [0.1004, 0.1229] |
+| `num_leaves` | 58963.9617 | 52539.5857 | 53414.8579 | 52077.2859 | **Q4** [118.25, ∞) |
+| `max_depth` | 62658.8768 | 55333.5254 | — | 52173.4793 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 53911.4772 | 51964.4502 | 52823.0953 | 57963.8021 | **Q2** [16.0, 19.0] |
+
+#### E. Slice plot
+
+![houses@s44/moe](slice_houses@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| houses@s44 | `mixture_routing_mode` | **token_choice** | +9376.2789 | 6.72e-03 |
+| houses@s44 | `mixture_init` | **uniform** | +3942.9164 | 3.73e-03 |

--- a/bench_results/meth2_v081/ds_houses_summary.json
+++ b/bench_results/meth2_v081/ds_houses_summary.json
@@ -1,0 +1,2764 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "houses"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "houses": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 50760.44294032335,
+      "cv_best": 50683.0900785632,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2207
+     },
+     "43": {
+      "holdout_rmse": 50168.46687248024,
+      "cv_best": 51076.37465143886,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5474
+     },
+     "44": {
+      "holdout_rmse": 48487.23831014311,
+      "cv_best": 50674.92215781791,
+      "crash_rate": 0.0,
+      "retrain_s": 0.675
+     }
+    },
+    "holdout_mean": 49805.382708,
+    "holdout_std": 962.890581,
+    "cv_best_mean": 50811.462296
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 49606.48685119638,
+      "cv_best": 50328.35989200953,
+      "crash_rate": 0.0,
+      "retrain_s": 1.4599
+     },
+     "43": {
+      "holdout_rmse": 49166.64149965156,
+      "cv_best": 50705.37780363464,
+      "crash_rate": 0.0,
+      "retrain_s": 2.511
+     },
+     "44": {
+      "holdout_rmse": 48018.56313783864,
+      "cv_best": 50589.92730979582,
+      "crash_rate": 0.0,
+      "retrain_s": 2.2019
+     }
+    },
+    "holdout_mean": 48930.56383,
+    "holdout_std": 669.415133,
+    "cv_best_mean": 50541.221668
+   }
+  }
+ },
+ "runs": {
+  "houses@s42": {
+   "dataset": "houses",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 206067.006875,
+    "std": 114867.76939213117
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50683.0900785632,
+    "rmse_p10": 50895.52743146411,
+    "rmse_median": 51224.133646789225,
+    "train_s_median": 0.19681762028485536,
+    "train_s_mean": 0.19475266273443897,
+    "train_s_p90": 0.2413581806048751,
+    "best_params": {
+     "learning_rate": 0.09549031388166374,
+     "num_leaves": 33,
+     "max_depth": 12,
+     "min_data_in_leaf": 17,
+     "lambda_l1": 0.1387994234815757,
+     "lambda_l2": 0.12921075526430417,
+     "feature_fraction": 0.8036813953393781,
+     "bagging_fraction": 0.7461121609117708,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6671,
+     "extra_trees": 0.2889,
+     "min_data_in_leaf": 0.0161,
+     "feature_fraction": 0.0101,
+     "max_depth": 0.0083,
+     "bagging_fraction": 0.004,
+     "num_leaves": 0.0031,
+     "bagging_freq": 0.0017,
+     "lambda_l2": 0.0007,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 65625.9156,
+        "std": 10037.1753,
+        "min": 57820.1777
+       },
+       "False": {
+        "n": 278,
+        "mean": 51888.9305,
+        "std": 3228.7653,
+        "min": 50683.0901
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 13736.9851,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0884
+       ],
+       "n": 75,
+       "mean_rmse": 55845.0459
+      },
+      "Q2": {
+       "range": [
+        0.0884,
+        0.1021
+       ],
+       "n": 75,
+       "mean_rmse": 51310.6123
+      },
+      "Q3": {
+       "range": [
+        0.1021,
+        0.117
+       ],
+       "n": 75,
+       "mean_rmse": 51856.6872
+      },
+      "Q4": {
+       "range": [
+        0.117,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52572.8922
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        31.0
+       ],
+       "n": 64,
+       "mean_rmse": 53047.36
+      },
+      "Q2": {
+       "range": [
+        31.0,
+        36.0
+       ],
+       "n": 84,
+       "mean_rmse": 51953.3869
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        44.0
+       ],
+       "n": 75,
+       "mean_rmse": 51484.081
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 55174.9507
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 57,
+       "mean_rmse": 56986.4618
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 68,
+       "mean_rmse": 52400.8256
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 175,
+       "mean_rmse": 51756.6192
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 70,
+       "mean_rmse": 52753.3685
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        21.0
+       ],
+       "n": 74,
+       "mean_rmse": 51803.195
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        26.0
+       ],
+       "n": 77,
+       "mean_rmse": 51974.3697
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 54945.4953
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 53364.3411
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0008
+       ],
+       "n": 75,
+       "mean_rmse": 52532.0795
+      },
+      "Q3": {
+       "range": [
+        0.0008,
+        0.1035
+       ],
+       "n": 75,
+       "mean_rmse": 53811.8016
+      },
+      "Q4": {
+       "range": [
+        0.1035,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 51877.0154
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0199
+       ],
+       "n": 75,
+       "mean_rmse": 55110.6574
+      },
+      "Q2": {
+       "range": [
+        0.0199,
+        0.1017
+       ],
+       "n": 75,
+       "mean_rmse": 51893.7303
+      },
+      "Q3": {
+       "range": [
+        0.1017,
+        0.379
+       ],
+       "n": 75,
+       "mean_rmse": 51780.198
+      },
+      "Q4": {
+       "range": [
+        0.379,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52800.6519
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7235
+       ],
+       "n": 75,
+       "mean_rmse": 55369.3077
+      },
+      "Q2": {
+       "range": [
+        0.7235,
+        0.7507
+       ],
+       "n": 75,
+       "mean_rmse": 51491.194
+      },
+      "Q3": {
+       "range": [
+        0.7507,
+        0.781
+       ],
+       "n": 75,
+       "mean_rmse": 51682.8047
+      },
+      "Q4": {
+       "range": [
+        0.781,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53041.9312
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6939
+       ],
+       "n": 75,
+       "mean_rmse": 53204.3996
+      },
+      "Q2": {
+       "range": [
+        0.6939,
+        0.7489
+       ],
+       "n": 75,
+       "mean_rmse": 52442.3521
+      },
+      "Q3": {
+       "range": [
+        0.7489,
+        0.8903
+       ],
+       "n": 75,
+       "mean_rmse": 53142.7276
+      },
+      "Q4": {
+       "range": [
+        0.8903,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52795.7583
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 300.3,
+    "holdout": {
+     "holdout_rmse": 50760.44294032335,
+     "retrain_s": 0.2207,
+     "predict_s": 0.0023,
+     "cv_rmse_of_winner": 50683.0900785632
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50328.35989200953,
+    "rmse_p10": 50554.858904789144,
+    "rmse_median": 51141.40845536494,
+    "train_s_median": 1.1125805649906397,
+    "train_s_mean": 1.320225389013688,
+    "train_s_p90": 1.7401297951862222,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.1552247026196236,
+     "num_leaves": 44,
+     "max_depth": 11,
+     "min_data_in_leaf": 12,
+     "lambda_l1": 0.20793422367578476,
+     "lambda_l2": 2.9772621957782618e-05,
+     "feature_fraction": 0.6898418312183099,
+     "bagging_fraction": 0.9287447037695944,
+     "bagging_freq": 2,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 5,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.8960644553785924,
+     "mixture_diversity_lambda": 0.1354312019114925,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 13,
+     "mixture_gate_learning_rate": 0.06253927851076233,
+     "mixture_gate_lambda_l2": 0.0073144213362915655,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_retrain_interval": 9,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.475,
+     "extra_trees": 0.2012,
+     "mixture_gate_type": 0.0837,
+     "min_data_in_leaf": 0.0774,
+     "mixture_hard_m_step": 0.0388,
+     "mixture_routing_mode": 0.0274,
+     "mixture_refit_leaves": 0.019,
+     "mixture_warmup_iters": 0.018,
+     "mixture_init": 0.0179,
+     "num_leaves": 0.0121,
+     "feature_fraction": 0.0059,
+     "bagging_fraction": 0.0056,
+     "mixture_r_smoothing": 0.0048,
+     "mixture_diversity_lambda": 0.0042,
+     "mixture_balance_factor": 0.0026,
+     "mixture_num_experts": 0.0019,
+     "max_depth": 0.0013,
+     "mixture_e_step_mode": 0.0013,
+     "lambda_l2": 0.001,
+     "bagging_freq": 0.0008,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 227,
+        "mean": 52561.0029,
+        "std": 6368.4483,
+        "min": 50328.3599
+       },
+       "none": {
+        "n": 18,
+        "mean": 63717.1137,
+        "std": 13748.014,
+        "min": 51062.7292
+       },
+       "gbdt": {
+        "n": 55,
+        "mean": 56240.5273,
+        "std": 11281.4232,
+        "min": 51145.6924
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 3679.5244,
+       "p_value": 0.024182,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 80,
+        "mean": 55104.7843,
+        "std": 9950.5723,
+        "min": 50328.3599
+       },
+       "expert_choice": {
+        "n": 220,
+        "mean": 53468.6453,
+        "std": 7969.6502,
+        "min": 50361.2373
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 1636.139,
+       "p_value": 0.190401,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 36,
+        "mean": 58715.3375,
+        "std": 14653.0101,
+        "min": 51411.9706
+       },
+       "gate_only": {
+        "n": 106,
+        "mean": 53364.3401,
+        "std": 7771.459,
+        "min": 50328.3599
+       },
+       "em": {
+        "n": 158,
+        "mean": 53171.5982,
+        "std": 6642.3209,
+        "min": 50457.1591
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 192.7419,
+       "p_value": 0.835208,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 202,
+        "mean": 52550.3983,
+        "std": 6077.888,
+        "min": 50328.3599
+       },
+       "gmm": {
+        "n": 29,
+        "mean": 55971.0784,
+        "std": 11265.834,
+        "min": 50337.1123
+       },
+       "tree_hierarchical": {
+        "n": 25,
+        "mean": 59266.993,
+        "std": 12661.6279,
+        "min": 50394.0203
+       },
+       "uniform": {
+        "n": 44,
+        "mean": 55715.1854,
+        "std": 11224.4957,
+        "min": 51411.9706
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 3164.7871,
+       "p_value": 0.079126,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 207,
+        "mean": 52495.673,
+        "std": 4660.7289,
+        "min": 50361.2373
+       },
+       "markov": {
+        "n": 64,
+        "mean": 56575.7168,
+        "std": 14466.6525,
+        "min": 50328.3599
+       },
+       "none": {
+        "n": 29,
+        "mean": 58070.156,
+        "std": 9808.6356,
+        "min": 51633.6428
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 4080.0438,
+       "p_value": 0.030973,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 55,
+        "mean": 56507.9501,
+        "std": 10712.6703,
+        "min": 50328.3599
+       },
+       "False": {
+        "n": 245,
+        "mean": 53320.6019,
+        "std": 7898.1635,
+        "min": 50361.2373
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 3187.3482,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 65450.099,
+        "std": 8960.5847,
+        "min": 56860.87
+       },
+       "False": {
+        "n": 279,
+        "mean": 53035.9593,
+        "std": 7887.1092,
+        "min": 50328.3599
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12414.1397,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 72,
+       "mean_rmse": 53654.6265
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 96,
+       "mean_rmse": 53838.5214
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 54089.7996
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.032
+       ],
+       "n": 75,
+       "mean_rmse": 52374.4155
+      },
+      "Q2": {
+       "range": [
+        0.032,
+        0.0776
+       ],
+       "n": 75,
+       "mean_rmse": 52238.5013
+      },
+      "Q3": {
+       "range": [
+        0.0776,
+        0.1324
+       ],
+       "n": 75,
+       "mean_rmse": 52833.9575
+      },
+      "Q4": {
+       "range": [
+        0.1324,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 58172.922
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        8.75
+       ],
+       "n": 75,
+       "mean_rmse": 52406.5517
+      },
+      "Q2": {
+       "range": [
+        8.75,
+        32.0
+       ],
+       "n": 68,
+       "mean_rmse": 56073.3724
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        40.0
+       ],
+       "n": 76,
+       "mean_rmse": 52841.3306
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 54469.9122
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 59,
+       "mean_rmse": 56881.4091
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 24,
+       "mean_rmse": 61967.6384
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 217,
+       "mean_rmse": 52203.9551
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1056
+       ],
+       "n": 75,
+       "mean_rmse": 57435.0749
+      },
+      "Q2": {
+       "range": [
+        0.1056,
+        0.1347
+       ],
+       "n": 75,
+       "mean_rmse": 52550.6951
+      },
+      "Q3": {
+       "range": [
+        0.1347,
+        0.1636
+       ],
+       "n": 75,
+       "mean_rmse": 52185.2741
+      },
+      "Q4": {
+       "range": [
+        0.1636,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53448.7521
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        46.0
+       ],
+       "n": 68,
+       "mean_rmse": 54996.4036
+      },
+      "Q2": {
+       "range": [
+        46.0,
+        57.5
+       ],
+       "n": 82,
+       "mean_rmse": 52287.4793
+      },
+      "Q3": {
+       "range": [
+        57.5,
+        117.0
+       ],
+       "n": 73,
+       "mean_rmse": 55858.32
+      },
+      "Q4": {
+       "range": [
+        117.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 52811.6703
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 69,
+       "mean_rmse": 57901.3487
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 30,
+       "mean_rmse": 53461.3992
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 201,
+       "mean_rmse": 52599.2521
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 69,
+       "mean_rmse": 53200.6035
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        32.5
+       ],
+       "n": 81,
+       "mean_rmse": 53404.0227
+      },
+      "Q3": {
+       "range": [
+        32.5,
+        41.0
+       ],
+       "n": 72,
+       "mean_rmse": 52813.2276
+      },
+      "Q4": {
+       "range": [
+        41.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 56055.9596
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 2012.6,
+    "holdout": {
+     "holdout_rmse": 49606.48685119638,
+     "retrain_s": 1.4599,
+     "predict_s": 0.0202,
+     "cv_rmse_of_winner": 50328.35989200953
+    }
+   }
+  },
+  "houses@s43": {
+   "dataset": "houses",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 207292.308625,
+    "std": 114725.69189141605
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 51076.37465143886,
+    "rmse_p10": 51396.0980270342,
+    "rmse_median": 51723.64940425394,
+    "train_s_median": 0.3451721740886569,
+    "train_s_mean": 0.32412877927968897,
+    "train_s_p90": 0.4398726436123252,
+    "best_params": {
+     "learning_rate": 0.06050195723850515,
+     "num_leaves": 119,
+     "max_depth": 9,
+     "min_data_in_leaf": 13,
+     "lambda_l1": 3.016875278768682e-05,
+     "lambda_l2": 0.0789116553941158,
+     "feature_fraction": 0.7902336523801551,
+     "bagging_fraction": 0.8032336644229776,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.5744,
+     "learning_rate": 0.271,
+     "feature_fraction": 0.0574,
+     "min_data_in_leaf": 0.0368,
+     "max_depth": 0.0337,
+     "bagging_freq": 0.0126,
+     "bagging_fraction": 0.0114,
+     "num_leaves": 0.0017,
+     "lambda_l2": 0.001,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 64191.296,
+        "std": 5869.1887,
+        "min": 57331.5582
+       },
+       "False": {
+        "n": 279,
+        "mean": 52383.8445,
+        "std": 2614.0622,
+        "min": 51076.3747
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11807.4515,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.059
+       ],
+       "n": 75,
+       "mean_rmse": 54846.3206
+      },
+      "Q2": {
+       "range": [
+        0.059,
+        0.0676
+       ],
+       "n": 75,
+       "mean_rmse": 52554.2688
+      },
+      "Q3": {
+       "range": [
+        0.0676,
+        0.0786
+       ],
+       "n": 75,
+       "mean_rmse": 52209.4324
+      },
+      "Q4": {
+       "range": [
+        0.0786,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53231.4426
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        82.75
+       ],
+       "n": 75,
+       "mean_rmse": 54728.3649
+      },
+      "Q2": {
+       "range": [
+        82.75,
+        105.0
+       ],
+       "n": 73,
+       "mean_rmse": 52898.7171
+      },
+      "Q3": {
+       "range": [
+        105.0,
+        117.0
+       ],
+       "n": 70,
+       "mean_rmse": 52641.845
+      },
+      "Q4": {
+       "range": [
+        117.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 52584.7191
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 35,
+       "mean_rmse": 55898.8596
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 100,
+       "mean_rmse": 52305.1409
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 77,
+       "mean_rmse": 53184.8689
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 88,
+       "mean_rmse": 53192.054
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 69,
+       "mean_rmse": 52738.2128
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        17.0
+       ],
+       "n": 73,
+       "mean_rmse": 52435.7065
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        24.0
+       ],
+       "n": 77,
+       "mean_rmse": 52297.128
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 55178.8607
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 53621.7121
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 52673.3426
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 52469.2696
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 54077.1402
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 53797.3334
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.222
+       ],
+       "n": 75,
+       "mean_rmse": 53224.9688
+      },
+      "Q3": {
+       "range": [
+        0.222,
+        0.8473
+       ],
+       "n": 75,
+       "mean_rmse": 52603.0649
+      },
+      "Q4": {
+       "range": [
+        0.8473,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53216.0974
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7286
+       ],
+       "n": 75,
+       "mean_rmse": 54145.7746
+      },
+      "Q2": {
+       "range": [
+        0.7286,
+        0.7851
+       ],
+       "n": 75,
+       "mean_rmse": 52498.8939
+      },
+      "Q3": {
+       "range": [
+        0.7851,
+        0.8138
+       ],
+       "n": 75,
+       "mean_rmse": 52392.1659
+      },
+      "Q4": {
+       "range": [
+        0.8138,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53804.6301
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.782
+       ],
+       "n": 75,
+       "mean_rmse": 53940.5034
+      },
+      "Q2": {
+       "range": [
+        0.782,
+        0.8405
+       ],
+       "n": 75,
+       "mean_rmse": 52654.5802
+      },
+      "Q3": {
+       "range": [
+        0.8405,
+        0.92
+       ],
+       "n": 75,
+       "mean_rmse": 53087.9937
+      },
+      "Q4": {
+       "range": [
+        0.92,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53158.3872
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 495.5,
+    "holdout": {
+     "holdout_rmse": 50168.46687248024,
+     "retrain_s": 0.5474,
+     "predict_s": 0.0037,
+     "cv_rmse_of_winner": 51076.37465143886
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50705.37780363464,
+    "rmse_p10": 50923.48189888602,
+    "rmse_median": 51454.146524172975,
+    "train_s_median": 1.0315291628241539,
+    "train_s_mean": 1.1696520087867974,
+    "train_s_p90": 1.7189060329273342,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.17233024759794976,
+     "num_leaves": 31,
+     "max_depth": 8,
+     "min_data_in_leaf": 21,
+     "lambda_l1": 0.7148109994490135,
+     "lambda_l2": 0.0013145915397587838,
+     "feature_fraction": 0.914708262756993,
+     "bagging_fraction": 0.7076228569302503,
+     "bagging_freq": 2,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 8,
+     "mixture_balance_factor": 10,
+     "mixture_smoothing_lambda": 0.698834354370835,
+     "mixture_diversity_lambda": 0.11003354614075166,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 55,
+     "mixture_gate_learning_rate": 0.36954267994195156,
+     "mixture_gate_lambda_l2": 5.838457206398919,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.516,
+     "max_depth": 0.1106,
+     "extra_trees": 0.0877,
+     "bagging_freq": 0.0685,
+     "mixture_refit_leaves": 0.0553,
+     "min_data_in_leaf": 0.0526,
+     "mixture_diversity_lambda": 0.0307,
+     "mixture_gate_type": 0.0209,
+     "mixture_warmup_iters": 0.0195,
+     "mixture_balance_factor": 0.0124,
+     "mixture_init": 0.0088,
+     "mixture_num_experts": 0.0044,
+     "mixture_e_step_mode": 0.0034,
+     "num_leaves": 0.0033,
+     "bagging_fraction": 0.0016,
+     "mixture_r_smoothing": 0.0014,
+     "lambda_l1": 0.0012,
+     "mixture_hard_m_step": 0.0011,
+     "feature_fraction": 0.0005,
+     "mixture_routing_mode": 0.0001,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 179,
+        "mean": 52866.5474,
+        "std": 6220.666,
+        "min": 50705.3778
+       },
+       "none": {
+        "n": 21,
+        "mean": 65120.0933,
+        "std": 22218.9926,
+        "min": 51294.396
+       },
+       "leaf_reuse": {
+        "n": 100,
+        "mean": 53685.4918,
+        "std": 6373.4063,
+        "min": 50796.7843
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 818.9444,
+       "p_value": 0.302541,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 96,
+        "mean": 55040.5365,
+        "std": 9183.4818,
+        "min": 51077.4343
+       },
+       "token_choice": {
+        "n": 204,
+        "mean": 53506.3314,
+        "std": 8840.3014,
+        "min": 50705.3778
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 1534.2051,
+       "p_value": 0.175559,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 28,
+        "mean": 60413.5055,
+        "std": 18134.1152,
+        "min": 50705.3778
+       },
+       "em": {
+        "n": 189,
+        "mean": 53111.9626,
+        "std": 7324.2664,
+        "min": 50736.4124
+       },
+       "gate_only": {
+        "n": 83,
+        "mean": 53848.7232,
+        "std": 6533.9606,
+        "min": 51077.4343
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 736.7606,
+       "p_value": 0.412965,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 16,
+        "mean": 53912.5258,
+        "std": 1899.4457,
+        "min": 51655.0006
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 61454.2483,
+        "std": 16579.1002,
+        "min": 51191.7155
+       },
+       "random": {
+        "n": 245,
+        "mean": 53078.8314,
+        "std": 7167.8098,
+        "min": 50705.3778
+       },
+       "uniform": {
+        "n": 24,
+        "mean": 58768.9707,
+        "std": 15595.3853,
+        "min": 51155.2892
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "gmm",
+       "delta_mean": 833.6944,
+       "p_value": 0.220244,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 245,
+        "mean": 52588.9081,
+        "std": 5704.8175,
+        "min": 50705.3778
+       },
+       "none": {
+        "n": 18,
+        "mean": 65096.5767,
+        "std": 20104.9514,
+        "min": 51538.8151
+       },
+       "markov": {
+        "n": 37,
+        "mean": 57923.3044,
+        "std": 12378.8113,
+        "min": 51615.3225
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 5334.3963,
+       "p_value": 0.015041,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 26,
+        "mean": 65370.8143,
+        "std": 17490.4114,
+        "min": 51384.6113
+       },
+       "False": {
+        "n": 274,
+        "mean": 52918.0363,
+        "std": 6769.5434,
+        "min": 50705.3778
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12452.778,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 53420.1525,
+        "std": 8856.256,
+        "min": 50705.3778
+       },
+       "True": {
+        "n": 20,
+        "mean": 62077.0209,
+        "std": 6451.7889,
+        "min": 56970.8863
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 8656.8684,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 18,
+       "mean_rmse": 58698.8078
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 282,
+       "mean_rmse": 53697.1794
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1003
+       ],
+       "n": 75,
+       "mean_rmse": 53070.2117
+      },
+      "Q2": {
+       "range": [
+        0.1003,
+        0.1181
+       ],
+       "n": 75,
+       "mean_rmse": 52584.841
+      },
+      "Q3": {
+       "range": [
+        0.1181,
+        0.1421
+       ],
+       "n": 75,
+       "mean_rmse": 52521.7762
+      },
+      "Q4": {
+       "range": [
+        0.1421,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 57812.2793
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 55,
+       "mean_rmse": 52904.4205
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        14.0
+       ],
+       "n": 65,
+       "mean_rmse": 52822.8717
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 102,
+       "mean_rmse": 53658.9723
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 56188.9507
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 55,
+       "mean_rmse": 59625.8324
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 30,
+       "mean_rmse": 52480.4251
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 215,
+       "mean_rmse": 52769.0678
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1102
+       ],
+       "n": 75,
+       "mean_rmse": 58862.5035
+      },
+      "Q2": {
+       "range": [
+        0.1102,
+        0.1313
+       ],
+       "n": 75,
+       "mean_rmse": 51947.7161
+      },
+      "Q3": {
+       "range": [
+        0.1313,
+        0.1694
+       ],
+       "n": 75,
+       "mean_rmse": 51888.1531
+      },
+      "Q4": {
+       "range": [
+        0.1694,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53290.7355
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        27.0
+       ],
+       "n": 73,
+       "mean_rmse": 53584.9353
+      },
+      "Q2": {
+       "range": [
+        27.0,
+        32.0
+       ],
+       "n": 73,
+       "mean_rmse": 52029.8004
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        49.0
+       ],
+       "n": 78,
+       "mean_rmse": 52594.1891
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 57723.1666
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 53,
+       "mean_rmse": 56743.4058
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 35,
+       "mean_rmse": 52483.7026
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 212,
+       "mean_rmse": 53560.6274
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 69,
+       "mean_rmse": 52719.5208
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        22.0
+       ],
+       "n": 74,
+       "mean_rmse": 53415.7267
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        27.0
+       ],
+       "n": 80,
+       "mean_rmse": 52202.8965
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 57565.4635
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1790.0,
+    "holdout": {
+     "holdout_rmse": 49166.64149965156,
+     "retrain_s": 2.511,
+     "predict_s": 0.0402,
+     "cv_rmse_of_winner": 50705.37780363464
+    }
+   }
+  },
+  "houses@s44": {
+   "dataset": "houses",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 205256.982,
+    "std": 114405.72363980168
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50674.92215781791,
+    "rmse_p10": 50855.88106275756,
+    "rmse_median": 51222.7142666577,
+    "train_s_median": 0.4244601562619209,
+    "train_s_mean": 0.3724037045600514,
+    "train_s_p90": 0.567390745729208,
+    "best_params": {
+     "learning_rate": 0.05477397277828664,
+     "num_leaves": 122,
+     "max_depth": 12,
+     "min_data_in_leaf": 12,
+     "lambda_l1": 0.13887399753506954,
+     "lambda_l2": 0.00012684810086755052,
+     "feature_fraction": 0.727676773124258,
+     "bagging_fraction": 0.8709943863799496,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.6924,
+     "learning_rate": 0.2192,
+     "min_data_in_leaf": 0.0413,
+     "max_depth": 0.0244,
+     "feature_fraction": 0.0112,
+     "bagging_fraction": 0.0058,
+     "bagging_freq": 0.0032,
+     "num_leaves": 0.0018,
+     "lambda_l1": 0.0006,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 52023.0161,
+        "std": 2849.5999,
+        "min": 50674.9222
+       },
+       "True": {
+        "n": 20,
+        "mean": 65091.4977,
+        "std": 4234.1415,
+        "min": 58652.9668
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 13068.4816,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0547
+       ],
+       "n": 75,
+       "mean_rmse": 55034.4959
+      },
+      "Q2": {
+       "range": [
+        0.0547,
+        0.0629
+       ],
+       "n": 75,
+       "mean_rmse": 51555.5742
+      },
+      "Q3": {
+       "range": [
+        0.0629,
+        0.084
+       ],
+       "n": 75,
+       "mean_rmse": 52070.652
+      },
+      "Q4": {
+       "range": [
+        0.084,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52916.2707
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        59.75
+       ],
+       "n": 75,
+       "mean_rmse": 54040.3712
+      },
+      "Q2": {
+       "range": [
+        59.75,
+        110.0
+       ],
+       "n": 71,
+       "mean_rmse": 53077.1628
+      },
+      "Q3": {
+       "range": [
+        110.0,
+        116.25
+       ],
+       "n": 79,
+       "mean_rmse": 52163.274
+      },
+      "Q4": {
+       "range": [
+        116.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52344.9255
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 54,
+       "mean_rmse": 54770.7357
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 78,
+       "mean_rmse": 53077.9487
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 168,
+       "mean_rmse": 52205.802
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 68,
+       "mean_rmse": 51813.2123
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 64,
+       "mean_rmse": 51580.5544
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        24.0
+       ],
+       "n": 92,
+       "mean_rmse": 52392.5069
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 55575.1304
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 54635.059
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.1121
+       ],
+       "n": 75,
+       "mean_rmse": 52656.6604
+      },
+      "Q3": {
+       "range": [
+        0.1121,
+        0.6478
+       ],
+       "n": 75,
+       "mean_rmse": 51978.5144
+      },
+      "Q4": {
+       "range": [
+        0.6478,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52306.759
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 54169.3509
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.0008
+       ],
+       "n": 75,
+       "mean_rmse": 52512.7667
+      },
+      "Q3": {
+       "range": [
+        0.0008,
+        0.0033
+       ],
+       "n": 75,
+       "mean_rmse": 51859.7302
+      },
+      "Q4": {
+       "range": [
+        0.0033,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53035.145
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6858
+       ],
+       "n": 75,
+       "mean_rmse": 54831.5402
+      },
+      "Q2": {
+       "range": [
+        0.6858,
+        0.7333
+       ],
+       "n": 75,
+       "mean_rmse": 52020.4412
+      },
+      "Q3": {
+       "range": [
+        0.7333,
+        0.7547
+       ],
+       "n": 75,
+       "mean_rmse": 51598.4895
+      },
+      "Q4": {
+       "range": [
+        0.7547,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53126.5219
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8281
+       ],
+       "n": 75,
+       "mean_rmse": 53409.2827
+      },
+      "Q2": {
+       "range": [
+        0.8281,
+        0.8641
+       ],
+       "n": 75,
+       "mean_rmse": 52100.9552
+      },
+      "Q3": {
+       "range": [
+        0.8641,
+        0.9357
+       ],
+       "n": 75,
+       "mean_rmse": 53134.6432
+      },
+      "Q4": {
+       "range": [
+        0.9357,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52932.1117
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 568.1,
+    "holdout": {
+     "holdout_rmse": 48487.23831014311,
+     "retrain_s": 0.675,
+     "predict_s": 0.0038,
+     "cv_rmse_of_winner": 50674.92215781791
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 50589.92730979582,
+    "rmse_p10": 50742.90811434553,
+    "rmse_median": 51070.8269046764,
+    "train_s_median": 1.5550872707739472,
+    "train_s_mean": 1.3946386051476,
+    "train_s_p90": 1.997707407511771,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.09475258457387942,
+     "num_leaves": 114,
+     "max_depth": 11,
+     "min_data_in_leaf": 18,
+     "lambda_l1": 6.780895952623572,
+     "lambda_l2": 0.002084244397679328,
+     "feature_fraction": 0.7221376053541949,
+     "bagging_fraction": 0.8386816902385497,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 39,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.36727649474346136,
+     "mixture_diversity_lambda": 0.15590840048598192,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 14,
+     "mixture_gate_learning_rate": 0.012746413532500426,
+     "mixture_gate_lambda_l2": 0.04967988269843521,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 19,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.3895,
+     "extra_trees": 0.2075,
+     "min_data_in_leaf": 0.0809,
+     "mixture_init": 0.0731,
+     "max_depth": 0.0615,
+     "mixture_hard_m_step": 0.0456,
+     "num_leaves": 0.0424,
+     "mixture_r_smoothing": 0.021,
+     "feature_fraction": 0.0194,
+     "bagging_freq": 0.0157,
+     "mixture_routing_mode": 0.0127,
+     "mixture_e_step_mode": 0.0089,
+     "mixture_diversity_lambda": 0.0076,
+     "mixture_warmup_iters": 0.0049,
+     "bagging_fraction": 0.0034,
+     "mixture_gate_type": 0.0027,
+     "lambda_l1": 0.002,
+     "mixture_balance_factor": 0.0008,
+     "mixture_refit_leaves": 0.0004,
+     "mixture_num_experts": 0.0001,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 35,
+        "mean": 56182.8498,
+        "std": 11838.6863,
+        "min": 50863.9007
+       },
+       "none": {
+        "n": 98,
+        "mean": 54828.5029,
+        "std": 13304.8481,
+        "min": 50654.0919
+       },
+       "leaf_reuse": {
+        "n": 167,
+        "mean": 53463.2453,
+        "std": 7286.9204,
+        "min": 50589.9273
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 1365.2576,
+       "p_value": 0.352928,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 258,
+        "mean": 52913.8376,
+        "std": 6177.5775,
+        "min": 50589.9273
+       },
+       "expert_choice": {
+        "n": 42,
+        "mean": 62290.1165,
+        "std": 20911.4932,
+        "min": 50764.1484
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 9376.2789,
+       "p_value": 0.006716,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 36,
+        "mean": 57176.5774,
+        "std": 14497.4678,
+        "min": 50863.9007
+       },
+       "em": {
+        "n": 167,
+        "mean": 53457.6306,
+        "std": 7280.0732,
+        "min": 50589.9273
+       },
+       "loss_only": {
+        "n": 97,
+        "mean": 54455.401,
+        "std": 12248.8014,
+        "min": 50654.0919
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 997.7704,
+       "p_value": 0.468299,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 242,
+        "mean": 52756.1869,
+        "std": 6947.7786,
+        "min": 50589.9273
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 56699.1033,
+        "std": 4324.0192,
+        "min": 51802.8678
+       },
+       "random": {
+        "n": 28,
+        "mean": 58706.8823,
+        "std": 12195.6176,
+        "min": 51284.8351
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 67855.6715,
+        "std": 28608.9037,
+        "min": 52030.5229
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 3942.9164,
+       "p_value": 0.003729,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 25,
+        "mean": 59012.3863,
+        "std": 14535.8784,
+        "min": 51013.1889
+       },
+       "ema": {
+        "n": 246,
+        "mean": 52710.0895,
+        "std": 5988.0027,
+        "min": 50589.9273
+       },
+       "markov": {
+        "n": 29,
+        "mean": 62964.2524,
+        "std": 21918.5678,
+        "min": 50965.0651
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 6302.2968,
+       "p_value": 0.045439,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 35,
+        "mean": 62748.7465,
+        "std": 18817.7422,
+        "min": 53485.583
+       },
+       "False": {
+        "n": 265,
+        "mean": 53100.9391,
+        "std": 7798.4288,
+        "min": 50589.9273
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 9647.8074,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 68316.0177,
+        "std": 12267.1583,
+        "min": 57306.1212
+       },
+       "False": {
+        "n": 280,
+        "mean": 53220.1237,
+        "std": 9282.0985,
+        "min": 50589.9273
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 15095.894,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 69,
+       "mean_rmse": 54681.2728
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 15,
+       "mean_rmse": 70944.6474
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 216,
+       "mean_rmse": 52920.266
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1355
+       ],
+       "n": 75,
+       "mean_rmse": 54564.6107
+      },
+      "Q2": {
+       "range": [
+        0.1355,
+        0.1658
+       ],
+       "n": 75,
+       "mean_rmse": 52005.6751
+      },
+      "Q3": {
+       "range": [
+        0.1658,
+        0.2615
+       ],
+       "n": 75,
+       "mean_rmse": 53029.8492
+      },
+      "Q4": {
+       "range": [
+        0.2615,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 57305.9316
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        31.0
+       ],
+       "n": 72,
+       "mean_rmse": 57036.4245
+      },
+      "Q2": {
+       "range": [
+        31.0,
+        36.0
+       ],
+       "n": 70,
+       "mean_rmse": 52273.155
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        41.0
+       ],
+       "n": 68,
+       "mean_rmse": 54688.26
+      },
+      "Q4": {
+       "range": [
+        41.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 53148.9989
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.75
+       ],
+       "n": 75,
+       "mean_rmse": 54444.2875
+      },
+      "Q2": {
+       "range": [
+        6.75,
+        8.0
+       ],
+       "n": 40,
+       "mean_rmse": 57889.649
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 75,
+       "mean_rmse": 53627.9676
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 110,
+       "mean_rmse": 53154.09
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0851
+       ],
+       "n": 75,
+       "mean_rmse": 59137.9441
+      },
+      "Q2": {
+       "range": [
+        0.0851,
+        0.1004
+       ],
+       "n": 75,
+       "mean_rmse": 52262.9935
+      },
+      "Q3": {
+       "range": [
+        0.1004,
+        0.1229
+       ],
+       "n": 75,
+       "mean_rmse": 52171.006
+      },
+      "Q4": {
+       "range": [
+        0.1229,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 53334.123
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        97.0
+       ],
+       "n": 73,
+       "mean_rmse": 58963.9617
+      },
+      "Q2": {
+       "range": [
+        97.0,
+        113.0
+       ],
+       "n": 70,
+       "mean_rmse": 52539.5857
+      },
+      "Q3": {
+       "range": [
+        113.0,
+        118.25
+       ],
+       "n": 82,
+       "mean_rmse": 53414.8579
+      },
+      "Q4": {
+       "range": [
+        118.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 52077.2859
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 50,
+       "mean_rmse": 62658.8768
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 29,
+       "mean_rmse": 55333.5254
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 221,
+       "mean_rmse": 52173.4793
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 65,
+       "mean_rmse": 53911.4772
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        19.0
+       ],
+       "n": 77,
+       "mean_rmse": 51964.4502
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        23.0
+       ],
+       "n": 77,
+       "mean_rmse": 52823.0953
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 57963.8021
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2120.8,
+    "holdout": {
+     "holdout_rmse": 48018.56313783864,
+     "retrain_s": 2.2019,
+     "predict_s": 0.0213,
+     "cv_rmse_of_winner": 50589.92730979582
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_sp500_basic_report.md
+++ b/bench_results/meth2_v081/ds_sp500_basic_report.md
@@ -1,0 +1,677 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['sp500_basic'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `d25c06cf3b86`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| sp500_basic | naive-lightgbm | **0.01104** ± 0.00001 | 0.00969 | 0.0% | 0.03 |
+| sp500_basic | naive-ensemble | **0.01103** ± 0.00001 | 0.00970 | 0.0% | 0.09 |
+| sp500_basic | moe | **0.01102** ± 0.00000 | 0.00970 | 0.0% | 0.25 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| sp500_basic@s42 | naive-lightgbm | 0.0097 | 0.0097 | 0.022 | 38 |
+| sp500_basic@s42 | naive-ensemble | 0.0097 | 0.0097 | 0.053 | 90 |
+| sp500_basic@s42 | moe | 0.0097 | 0.0097 | 0.147 | 312 |
+| sp500_basic@s43 | naive-lightgbm | 0.0097 | 0.0097 | 0.021 | 38 |
+| sp500_basic@s43 | naive-ensemble | 0.0097 | 0.0097 | 0.069 | 112 |
+| sp500_basic@s43 | moe | 0.0097 | 0.0097 | 0.103 | 222 |
+| sp500_basic@s44 | naive-lightgbm | 0.0097 | 0.0097 | 0.025 | 43 |
+| sp500_basic@s44 | naive-ensemble | 0.0097 | 0.0097 | 0.049 | 87 |
+| sp500_basic@s44 | moe | 0.0097 | 0.0097 | 0.180 | 390 |
+
+
+
+---
+
+## sp500_basic@s42  (search X=[3010, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01103** (winner retrained in 0.03s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.022s/fold, mean 0.022s, p90 0.028s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.561 |
+| `learning_rate` | 0.184 |
+| `lambda_l2` | 0.099 |
+| `feature_fraction` | 0.082 |
+| `extra_trees` | 0.031 |
+| `bagging_fraction` | 0.020 |
+| `num_leaves` | 0.011 |
+| `bagging_freq` | 0.010 |
+| `max_depth` | 0.002 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 0.0097 | 0.0000 | 0.0097 |
+| False | 20 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0464] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 19.0] |
+| `max_depth` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 59.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0004] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.6917] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.6112] |
+
+#### E. Slice plot
+
+![sp500_basic@s42/naive-lightgbm](slice_sp500_basic@s42_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.01103** (winner retrained in 0.07s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.053s/fold, mean 0.056s, p90 0.074s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.460 |
+| `min_data_in_leaf` | 0.221 |
+| `extra_trees` | 0.147 |
+| `bagging_fraction` | 0.052 |
+| `feature_fraction` | 0.048 |
+| `num_leaves` | 0.039 |
+| `bagging_freq` | 0.021 |
+| `max_depth` | 0.011 |
+| `lambda_l2` | 0.001 |
+| `n_models` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 22 | 0.0097 | 0.0000 | 0.0097 |
+| True | 278 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0327] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 43.0] |
+| `max_depth` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 8.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 76.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0006] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.6492] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.8138] |
+
+#### E. Slice plot
+
+![sp500_basic@s42/naive-ensemble](slice_sp500_basic@s42_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01101** (winner retrained in 0.19s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.147s/fold, mean 0.200s, p90 0.296s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `feature_fraction` | 0.234 |
+| `extra_trees` | 0.230 |
+| `mixture_hard_m_step` | 0.081 |
+| `bagging_fraction` | 0.075 |
+| `mixture_warmup_iters` | 0.053 |
+| `mixture_gate_type` | 0.048 |
+| `mixture_num_experts` | 0.041 |
+| `lambda_l2` | 0.035 |
+| `bagging_freq` | 0.029 |
+| `min_data_in_leaf` | 0.027 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 0.0097 (n=226) | expert_choice | Δ +0.0000 | p=0.00e+00 |
+| `mixture_e_step_mode` | **loss_only** | 0.0097 (n=69) | gate_only | Δ +0.0000 | p=0.00e+00 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 36 | 0.0097 | 0.0000 | 0.0097 |
+| none | 16 | 0.0097 | 0.0000 | 0.0097 |
+| gbdt | 248 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 226 | 0.0097 | 0.0000 | 0.0097 |
+| expert_choice | 74 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 69 | 0.0097 | 0.0000 | 0.0097 |
+| gate_only | 215 | 0.0097 | 0.0000 | 0.0097 |
+| em | 16 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 16 | 0.0097 | 0.0000 | 0.0097 |
+| gmm | 254 | 0.0097 | 0.0000 | 0.0097 |
+| tree_hierarchical | 16 | 0.0097 | 0.0000 | 0.0097 |
+| uniform | 14 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 36 | 0.0097 | 0.0000 | 0.0097 |
+| markov | 16 | 0.0097 | 0.0001 | 0.0097 |
+| none | 248 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0098 | 0.0000 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0098 | — | — | 0.0097 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.3292] |
+| `mixture_warmup_iters` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 24.0] |
+| `mixture_balance_factor` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 5.0] |
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0462] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 67.0] |
+| `max_depth` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 6.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 64.0] |
+
+#### E. Slice plot
+
+![sp500_basic@s42/moe](slice_sp500_basic@s42_moe.png)
+
+
+---
+
+## sp500_basic@s43  (search X=[3010, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01105** (winner retrained in 0.04s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.021s/fold, mean 0.022s, p90 0.027s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.508 |
+| `min_data_in_leaf` | 0.275 |
+| `learning_rate` | 0.078 |
+| `bagging_fraction` | 0.046 |
+| `feature_fraction` | 0.032 |
+| `num_leaves` | 0.030 |
+| `max_depth` | 0.014 |
+| `bagging_freq` | 0.013 |
+| `lambda_l2` | 0.003 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1027] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 87.5] |
+| `max_depth` | 0.0097 | 0.0097 | — | 0.0097 | **Q1** [None, 10.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 66.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.5668] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.5882] |
+
+#### E. Slice plot
+
+![sp500_basic@s43/naive-lightgbm](slice_sp500_basic@s43_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.01104** (winner retrained in 0.10s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.069s/fold, mean 0.071s, p90 0.088s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.339 |
+| `bagging_fraction` | 0.333 |
+| `feature_fraction` | 0.164 |
+| `min_data_in_leaf` | 0.089 |
+| `learning_rate` | 0.022 |
+| `num_leaves` | 0.020 |
+| `max_depth` | 0.013 |
+| `bagging_freq` | 0.011 |
+| `n_models` | 0.004 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 21 | 0.0097 | 0.0000 | 0.0097 |
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1532] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 23.0] |
+| `max_depth` | 0.0097 | 0.0097 | — | 0.0097 | **Q1** [None, 5.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 57.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0004] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.5239] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.5522] |
+
+#### E. Slice plot
+
+![sp500_basic@s43/naive-ensemble](slice_sp500_basic@s43_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01102** (winner retrained in 0.18s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.103s/fold, mean 0.140s, p90 0.235s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `max_depth` | 0.192 |
+| `num_leaves` | 0.144 |
+| `mixture_r_smoothing` | 0.132 |
+| `mixture_balance_factor` | 0.096 |
+| `mixture_refit_leaves` | 0.089 |
+| `mixture_routing_mode` | 0.088 |
+| `learning_rate` | 0.039 |
+| `mixture_diversity_lambda` | 0.035 |
+| `feature_fraction` | 0.023 |
+| `mixture_warmup_iters` | 0.022 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_r_smoothing` | **ema** | 0.0097 (n=240) | none | Δ +0.0001 | p=4.30e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 49 | 0.0097 | 0.0000 | 0.0097 |
+| none | 235 | 0.0097 | 0.0000 | 0.0097 |
+| leaf_reuse | 16 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 279 | 0.0097 | 0.0000 | 0.0097 |
+| token_choice | 21 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 235 | 0.0097 | 0.0000 | 0.0097 |
+| gate_only | 16 | 0.0097 | 0.0000 | 0.0097 |
+| loss_only | 49 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 24 | 0.0097 | 0.0000 | 0.0097 |
+| tree_hierarchical | 240 | 0.0097 | 0.0000 | 0.0097 |
+| random | 15 | 0.0097 | 0.0000 | 0.0097 |
+| uniform | 21 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 240 | 0.0097 | 0.0000 | 0.0097 |
+| none | 44 | 0.0098 | 0.0000 | 0.0097 |
+| markov | 16 | 0.0098 | 0.0000 | 0.0097 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 258 | 0.0097 | 0.0000 | 0.0097 |
+| False | 42 | 0.0097 | 0.0000 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 277 | 0.0097 | 0.0000 | 0.0097 |
+| False | 23 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0097 | — | — | 0.0097 | **Q1** [None, 4.0] |
+| `mixture_diversity_lambda` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0668] |
+| `mixture_warmup_iters` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 43.0] |
+| `mixture_balance_factor` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 4.75] |
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0706] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 52.5] |
+| `max_depth` | 0.0097 | — | 0.0097 | 0.0097 | **Q1** [None, 10.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 76.0] |
+
+#### E. Slice plot
+
+![sp500_basic@s43/moe](slice_sp500_basic@s43_moe.png)
+
+
+---
+
+## sp500_basic@s44  (search X=[3010, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01102** (winner retrained in 0.03s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.025s/fold, mean 0.025s, p90 0.030s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.399 |
+| `min_data_in_leaf` | 0.307 |
+| `feature_fraction` | 0.177 |
+| `bagging_freq` | 0.037 |
+| `extra_trees` | 0.029 |
+| `bagging_fraction` | 0.024 |
+| `num_leaves` | 0.015 |
+| `max_depth` | 0.010 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 36 | 0.0097 | 0.0000 | 0.0097 |
+| True | 264 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0144] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 60.0] |
+| `max_depth` | — | — | 0.0097 | 0.0097 | **Q3** [3.0, 4.25] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 89.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.518] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.8957] |
+
+#### E. Slice plot
+
+![sp500_basic@s44/naive-lightgbm](slice_sp500_basic@s44_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.01101** (winner retrained in 0.09s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.049s/fold, mean 0.055s, p90 0.070s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.733 |
+| `extra_trees` | 0.068 |
+| `bagging_fraction` | 0.057 |
+| `learning_rate` | 0.052 |
+| `lambda_l2` | 0.032 |
+| `feature_fraction` | 0.018 |
+| `num_leaves` | 0.017 |
+| `bagging_freq` | 0.015 |
+| `n_models` | 0.004 |
+| `max_depth` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0097 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0552] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 62.0] |
+| `max_depth` | 0.0097 | — | 0.0097 | 0.0097 | **Q1** [None, 10.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 64.0] |
+| `lambda_l1` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.0002] |
+| `feature_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.52] |
+| `bagging_fraction` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.6034] |
+
+#### E. Slice plot
+
+![sp500_basic@s44/naive-ensemble](slice_sp500_basic@s44_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01101** (winner retrained in 0.37s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0097, p10: 0.0097
+- train: median 0.180s/fold, mean 0.252s, p90 0.268s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.308 |
+| `bagging_fraction` | 0.129 |
+| `mixture_balance_factor` | 0.101 |
+| `num_leaves` | 0.084 |
+| `mixture_diversity_lambda` | 0.073 |
+| `learning_rate` | 0.064 |
+| `extra_trees` | 0.064 |
+| `feature_fraction` | 0.046 |
+| `max_depth` | 0.036 |
+| `mixture_warmup_iters` | 0.025 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 0.0097 (n=125) | expert_choice | Δ +0.0000 | p=0.00e+00 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 220 | 0.0097 | 0.0000 | 0.0097 |
+| none | 16 | 0.0097 | 0.0000 | 0.0097 |
+| leaf_reuse | 64 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 125 | 0.0097 | 0.0000 | 0.0097 |
+| expert_choice | 175 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 20 | 0.0097 | 0.0000 | 0.0097 |
+| em | 48 | 0.0097 | 0.0000 | 0.0097 |
+| loss_only | 232 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 22 | 0.0097 | 0.0000 | 0.0097 |
+| tree_hierarchical | 216 | 0.0097 | 0.0000 | 0.0097 |
+| random | 48 | 0.0097 | 0.0000 | 0.0097 |
+| gmm | 14 | 0.0097 | 0.0000 | 0.0097 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 23 | 0.0097 | 0.0000 | 0.0097 |
+| ema | 232 | 0.0097 | 0.0000 | 0.0097 |
+| markov | 45 | 0.0098 | 0.0001 | 0.0097 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 272 | 0.0097 | 0.0000 | 0.0097 |
+| True | 28 | 0.0098 | 0.0001 | 0.0097 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.0097 | 0.0000 | 0.0097 |
+| False | 21 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 0.0097 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.1929] |
+| `mixture_warmup_iters` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 37.0] |
+| `mixture_balance_factor` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 6.0] |
+| `learning_rate` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 0.015] |
+| `num_leaves` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 87.0] |
+| `max_depth` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 6.0] |
+| `min_data_in_leaf` | 0.0097 | 0.0097 | 0.0097 | 0.0097 | **Q1** [None, 55.0] |
+
+#### E. Slice plot
+
+![sp500_basic@s44/moe](slice_sp500_basic@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| sp500_basic@s42 | `mixture_routing_mode` | **token_choice** | +0.0000 | 0.00e+00 |
+| sp500_basic@s42 | `mixture_e_step_mode` | **loss_only** | +0.0000 | 0.00e+00 |
+| sp500_basic@s43 | `mixture_r_smoothing` | **ema** | +0.0001 | 4.30e-05 |
+| sp500_basic@s44 | `mixture_routing_mode` | **token_choice** | +0.0000 | 0.00e+00 |

--- a/bench_results/meth2_v081/ds_sp500_basic_summary.json
+++ b/bench_results/meth2_v081/ds_sp500_basic_summary.json
@@ -1,0 +1,3819 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "sp500_basic"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "d25c06cf3b8656e8f80fec7ac7bf0ccf6a1f07a1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "sp500_basic": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011032468776415732,
+      "cv_best": 0.009686834601527007,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0304
+     },
+     "43": {
+      "holdout_rmse": 0.01105462873690217,
+      "cv_best": 0.009684240261748616,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0382
+     },
+     "44": {
+      "holdout_rmse": 0.011024791982365001,
+      "cv_best": 0.009706063069291908,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0323
+     }
+    },
+    "holdout_mean": 0.011037,
+    "holdout_std": 1.3e-05,
+    "cv_best_mean": 0.009692
+   },
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011029353828386145,
+      "cv_best": 0.009699283409956025,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0737
+     },
+     "43": {
+      "holdout_rmse": 0.011039076353787185,
+      "cv_best": 0.009694947123893119,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1033
+     },
+     "44": {
+      "holdout_rmse": 0.011007979532106398,
+      "cv_best": 0.009693399087831716,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0878
+     }
+    },
+    "holdout_mean": 0.011025,
+    "holdout_std": 1.3e-05,
+    "cv_best_mean": 0.009696
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011014523945121561,
+      "cv_best": 0.009691646166165779,
+      "crash_rate": 0.0,
+      "retrain_s": 0.188
+     },
+     "43": {
+      "holdout_rmse": 0.011020645497890039,
+      "cv_best": 0.00970059011996136,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1849
+     },
+     "44": {
+      "holdout_rmse": 0.011011391900521044,
+      "cv_best": 0.00970324871506328,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3724
+     }
+    },
+    "holdout_mean": 0.011016,
+    "holdout_std": 4e-06,
+    "cv_best_mean": 0.009698
+   }
+  }
+ },
+ "runs": {
+  "sp500_basic@s42": {
+   "dataset": "sp500_basic",
+   "seed": 42,
+   "X_search_shape": [
+    3010,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 0.0004722868029789814,
+    "std": 0.010864405234015438
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009686834601527007,
+    "rmse_p10": 0.009705640923933742,
+    "rmse_median": 0.009714640148453652,
+    "train_s_median": 0.021547155641019344,
+    "train_s_mean": 0.022158349058280388,
+    "train_s_p90": 0.02826629735529423,
+    "best_params": {
+     "learning_rate": 0.11807474627436634,
+     "num_leaves": 20,
+     "max_depth": 4,
+     "min_data_in_leaf": 49,
+     "lambda_l1": 2.6767473618736457e-05,
+     "lambda_l2": 6.200110175719046e-08,
+     "feature_fraction": 0.8499685159410041,
+     "bagging_fraction": 0.7129282300264405,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5613,
+     "learning_rate": 0.1838,
+     "lambda_l2": 0.0987,
+     "feature_fraction": 0.082,
+     "extra_trees": 0.0311,
+     "bagging_fraction": 0.0202,
+     "num_leaves": 0.0109,
+     "bagging_freq": 0.0103,
+     "max_depth": 0.0015,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 280,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 20,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0464
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0464,
+        0.1187
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.1187,
+        0.1711
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1711,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        30.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        54.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        54.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 31,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 97,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 105,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        59.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        59.0,
+        71.5
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        71.5,
+        78.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        78.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.0021
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0021,
+        0.0131
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0131,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0012
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0012,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6917
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.6917,
+        0.8451
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.8451,
+        0.8824
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.8824,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6112
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.6112,
+        0.7185
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.7185,
+        0.7824
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.7824,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 38.1,
+    "holdout": {
+     "holdout_rmse": 0.011032468776415732,
+     "retrain_s": 0.0304,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.009686834601527007
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009699283409956025,
+    "rmse_p10": 0.0097053230522539,
+    "rmse_median": 0.009710181969205048,
+    "train_s_median": 0.05323538091033697,
+    "train_s_mean": 0.05640326907982429,
+    "train_s_p90": 0.07448499038815502,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.10841444365727546,
+     "num_leaves": 33,
+     "max_depth": 11,
+     "min_data_in_leaf": 72,
+     "lambda_l1": 3.8504211348417985e-06,
+     "lambda_l2": 1.3503889208271556e-05,
+     "feature_fraction": 0.6279374348768275,
+     "bagging_fraction": 0.8308711904776711,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.4596,
+     "min_data_in_leaf": 0.2211,
+     "extra_trees": 0.1469,
+     "bagging_fraction": 0.0516,
+     "feature_fraction": 0.0477,
+     "num_leaves": 0.0386,
+     "bagging_freq": 0.0208,
+     "max_depth": 0.0113,
+     "lambda_l2": 0.0013,
+     "n_models": 0.0008,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 22,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 278,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0327
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0327,
+        0.0614
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0614,
+        0.1283
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1283,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        43.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        43.0,
+        61.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        61.0,
+        75.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        75.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 48,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 116,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        76.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        76.0,
+        87.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        87.0,
+        93.25
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        93.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0016
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0016,
+        0.0116
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0116,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0006
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0006,
+        0.0731
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0731,
+        0.4842
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.4842,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6492
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.6492,
+        0.6905
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.6905,
+        0.7363
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.7363,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8138
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.8138,
+        0.8441
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.8441,
+        0.8823
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.8823,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 90.0,
+    "holdout": {
+     "holdout_rmse": 0.011029353828386145,
+     "retrain_s": 0.0737,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.009699283409956025
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009691646166165779,
+    "rmse_p10": 0.009703250554584892,
+    "rmse_median": 0.009715186045134407,
+    "train_s_median": 0.14653436802327635,
+    "train_s_mean": 0.20007533924157422,
+    "train_s_p90": 0.29647429395467045,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.08493802132647053,
+     "num_leaves": 67,
+     "max_depth": 9,
+     "min_data_in_leaf": 69,
+     "lambda_l1": 1.7241067505801357e-06,
+     "lambda_l2": 3.465388163409776e-08,
+     "feature_fraction": 0.8019635285354904,
+     "bagging_fraction": 0.8001178740050201,
+     "bagging_freq": 3,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 43,
+     "mixture_balance_factor": 10,
+     "mixture_diversity_lambda": 0.4529232112680135,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 50,
+     "mixture_gate_learning_rate": 0.3647512423863952,
+     "mixture_gate_lambda_l2": 0.8091068414047068,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "feature_fraction": 0.2345,
+     "extra_trees": 0.2299,
+     "mixture_hard_m_step": 0.0813,
+     "bagging_fraction": 0.0746,
+     "mixture_warmup_iters": 0.0526,
+     "mixture_gate_type": 0.048,
+     "mixture_num_experts": 0.0411,
+     "lambda_l2": 0.0348,
+     "bagging_freq": 0.0292,
+     "min_data_in_leaf": 0.0272,
+     "mixture_e_step_mode": 0.0246,
+     "mixture_r_smoothing": 0.0235,
+     "num_leaves": 0.021,
+     "mixture_routing_mode": 0.0175,
+     "mixture_init": 0.0141,
+     "learning_rate": 0.0132,
+     "mixture_balance_factor": 0.0131,
+     "mixture_diversity_lambda": 0.0079,
+     "max_depth": 0.0063,
+     "mixture_refit_leaves": 0.0054,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 36,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gbdt": {
+        "n": 248,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.262245,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 226,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "expert_choice": {
+        "n": 74,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 69,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gate_only": {
+        "n": 215,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gmm": {
+        "n": 254,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "gmm",
+       "delta_mean": 0.0,
+       "p_value": 0.02886,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 36,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "markov": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0001,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 248,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0,
+       "p_value": 0.193869,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 17,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 283,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3292
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.3292,
+        0.374
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.374,
+        0.422
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.422,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        24.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        24.0,
+        31.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        31.0,
+        37.25
+       ],
+       "n": 84,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        37.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 49,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 112,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0462
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0462,
+        0.0643
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0643,
+        0.1055
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1055,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        67.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        67.0,
+        101.5
+       ],
+       "n": 85,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        101.5,
+        121.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 58,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        64.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        64.0,
+        70.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        70.0,
+        78.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        78.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 311.9,
+    "holdout": {
+     "holdout_rmse": 0.011014523945121561,
+     "retrain_s": 0.188,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 0.009691646166165779
+    }
+   }
+  },
+  "sp500_basic@s43": {
+   "dataset": "sp500_basic",
+   "seed": 43,
+   "X_search_shape": [
+    3010,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 0.0004722868029789814,
+    "std": 0.010864405234015438
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009684240261748616,
+    "rmse_p10": 0.009697805716752004,
+    "rmse_median": 0.009709819936674111,
+    "train_s_median": 0.020636392571032048,
+    "train_s_mean": 0.021708805086712045,
+    "train_s_p90": 0.027335662059485916,
+    "best_params": {
+     "learning_rate": 0.15189857204203183,
+     "num_leaves": 113,
+     "max_depth": 12,
+     "min_data_in_leaf": 79,
+     "lambda_l1": 6.478986147979264e-06,
+     "lambda_l2": 5.562212448046289e-08,
+     "feature_fraction": 0.5877067507153831,
+     "bagging_fraction": 0.615292804232275,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.5083,
+     "min_data_in_leaf": 0.2748,
+     "learning_rate": 0.0782,
+     "bagging_fraction": 0.0462,
+     "feature_fraction": 0.0318,
+     "num_leaves": 0.0302,
+     "max_depth": 0.0144,
+     "bagging_freq": 0.0126,
+     "lambda_l2": 0.0032,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1027
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1027,
+        0.1296
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.1296,
+        0.1564
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.1564,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        87.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        87.5,
+        112.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        112.0,
+        119.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        119.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 59,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 177,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        66.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        66.0,
+        76.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        76.0,
+        82.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        82.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5668
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.5668,
+        0.5899
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5899,
+        0.6138
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6138,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5882
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.5882,
+        0.6082
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.6082,
+        0.6324
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6324,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 37.7,
+    "holdout": {
+     "holdout_rmse": 0.01105462873690217,
+     "retrain_s": 0.0382,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.009684240261748616
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009694947123893119,
+    "rmse_p10": 0.009701809489382228,
+    "rmse_median": 0.009710170965827495,
+    "train_s_median": 0.06870360989123583,
+    "train_s_mean": 0.0707664777226746,
+    "train_s_p90": 0.08844078522175551,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.17837303659489098,
+     "num_leaves": 104,
+     "max_depth": 10,
+     "min_data_in_leaf": 66,
+     "lambda_l1": 0.009158454381299003,
+     "lambda_l2": 5.698645786704146e-05,
+     "feature_fraction": 0.6164026431144493,
+     "bagging_fraction": 0.630539388825845,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.3393,
+     "bagging_fraction": 0.3331,
+     "feature_fraction": 0.1644,
+     "min_data_in_leaf": 0.0895,
+     "learning_rate": 0.0217,
+     "num_leaves": 0.0203,
+     "max_depth": 0.0131,
+     "bagging_freq": 0.0113,
+     "n_models": 0.0044,
+     "lambda_l2": 0.002,
+     "lambda_l1": 0.001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 21,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1532
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1532,
+        0.186
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.186,
+        0.2083
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.2083,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        32.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        32.5,
+        95.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        95.5,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 42,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 93,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 165,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        57.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        57.0,
+        62.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        62.0,
+        67.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        67.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.0024
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0024,
+        0.0115
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0115,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0003,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5239
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.5239,
+        0.5466
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5466,
+        0.6119
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6119,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5522
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.5522,
+        0.5849
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5849,
+        0.6192
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6192,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 111.7,
+    "holdout": {
+     "holdout_rmse": 0.011039076353787185,
+     "retrain_s": 0.1033,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.009694947123893119
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00970059011996136,
+    "rmse_p10": 0.00971573540471941,
+    "rmse_median": 0.009728093459795095,
+    "train_s_median": 0.103078518435359,
+    "train_s_mean": 0.14001042544220885,
+    "train_s_p90": 0.23540124218910977,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.095462948347027,
+     "num_leaves": 83,
+     "max_depth": 11,
+     "min_data_in_leaf": 85,
+     "lambda_l1": 9.710476206892883e-05,
+     "lambda_l2": 2.615186624660568,
+     "feature_fraction": 0.8471844013136373,
+     "bagging_fraction": 0.7455897607881053,
+     "bagging_freq": 3,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 48,
+     "mixture_balance_factor": 4,
+     "mixture_smoothing_lambda": 0.616195636044156,
+     "mixture_diversity_lambda": 0.09719188242903816,
+     "mixture_hard_m_step": true,
+     "mixture_expert_capacity_factor": 1.2177969420722767,
+     "mixture_expert_choice_boost": 15.689710909400482,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.18264516107645987,
+     "mixture_elbo_drop_threshold": 0.0062060204090500426,
+     "mixture_elbo_plateau_threshold": 0.0002201443666023572,
+     "mixture_elbo_window": 5,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "max_depth": 0.1922,
+     "num_leaves": 0.1444,
+     "mixture_r_smoothing": 0.1324,
+     "mixture_balance_factor": 0.0957,
+     "mixture_refit_leaves": 0.0895,
+     "mixture_routing_mode": 0.0881,
+     "learning_rate": 0.0391,
+     "mixture_diversity_lambda": 0.0352,
+     "feature_fraction": 0.0229,
+     "mixture_warmup_iters": 0.0225,
+     "bagging_fraction": 0.0223,
+     "lambda_l2": 0.0205,
+     "min_data_in_leaf": 0.019,
+     "mixture_gate_type": 0.0156,
+     "mixture_init": 0.0143,
+     "extra_trees": 0.0135,
+     "mixture_num_experts": 0.0121,
+     "mixture_e_step_mode": 0.0107,
+     "bagging_freq": 0.0081,
+     "mixture_hard_m_step": 0.0016,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 49,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 235,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "leaf_reuse": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.041833,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "token_choice": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0001,
+       "p_value": 0.02825,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 49,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 235,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gate_only": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0,
+       "p_value": 0.29423,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 24,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "tree_hierarchical": {
+        "n": 240,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "random": {
+        "n": 15,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "uniform": {
+        "n": 21,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.700105,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 240,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 44,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "markov": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.0001,
+       "p_value": 4.3e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 258,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 42,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 23,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 277,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 240,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0668
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0668,
+        0.091
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.091,
+        0.2146
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.2146,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        43.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        43.0,
+        45.0
+       ],
+       "n": 47,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        45.0,
+        48.0
+       ],
+       "n": 105,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        4.75,
+        8.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 23,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0706
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0706,
+        0.0837
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0837,
+        0.0993
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0993,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        52.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        52.5,
+        85.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        85.0,
+        92.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        92.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 52,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        76.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        76.0,
+        81.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        81.0,
+        86.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        86.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 222.1,
+    "holdout": {
+     "holdout_rmse": 0.011020645497890039,
+     "retrain_s": 0.1849,
+     "predict_s": 0.0011,
+     "cv_rmse_of_winner": 0.00970059011996136
+    }
+   }
+  },
+  "sp500_basic@s44": {
+   "dataset": "sp500_basic",
+   "seed": 44,
+   "X_search_shape": [
+    3010,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 0.0004722868029789814,
+    "std": 0.010864405234015438
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009706063069291908,
+    "rmse_p10": 0.009708561266976171,
+    "rmse_median": 0.009712304447526974,
+    "train_s_median": 0.02457985281944275,
+    "train_s_mean": 0.024930580454568068,
+    "train_s_p90": 0.0299397773295641,
+    "best_params": {
+     "learning_rate": 0.016232402169128753,
+     "num_leaves": 56,
+     "max_depth": 3,
+     "min_data_in_leaf": 94,
+     "lambda_l1": 3.176343674604407e-06,
+     "lambda_l2": 2.382224760072087e-05,
+     "feature_fraction": 0.535190958185494,
+     "bagging_fraction": 0.9027915868211681,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.3992,
+     "min_data_in_leaf": 0.3074,
+     "feature_fraction": 0.1773,
+     "bagging_freq": 0.0367,
+     "extra_trees": 0.029,
+     "bagging_fraction": 0.0243,
+     "num_leaves": 0.0146,
+     "max_depth": 0.0103,
+     "lambda_l2": 0.0011,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 36,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 264,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0144
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0144,
+        0.0177
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0177,
+        0.0241
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0241,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        60.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        60.0,
+        105.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        105.0,
+        121.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.25
+       ],
+       "n": 225,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        4.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        89.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        89.0,
+        94.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        94.5,
+        97.25
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        97.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.518
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.518,
+        0.5333
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5333,
+        0.5616
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.5616,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8957
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.8957,
+        0.9272
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.9272,
+        0.9514
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.9514,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 42.7,
+    "holdout": {
+     "holdout_rmse": 0.011024791982365001,
+     "retrain_s": 0.0323,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 0.009706063069291908
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009693399087831716,
+    "rmse_p10": 0.00970221440913782,
+    "rmse_median": 0.009708584261067382,
+    "train_s_median": 0.04936529044061899,
+    "train_s_mean": 0.05454357293372353,
+    "train_s_p90": 0.06981757052242758,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.08297286208521908,
+     "num_leaves": 74,
+     "max_depth": 10,
+     "min_data_in_leaf": 67,
+     "lambda_l1": 2.1629341948471876e-07,
+     "lambda_l2": 0.0014128197107919358,
+     "feature_fraction": 0.5320999155665527,
+     "bagging_fraction": 0.6168895221710307,
+     "bagging_freq": 2,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.7333,
+     "extra_trees": 0.0677,
+     "bagging_fraction": 0.0573,
+     "learning_rate": 0.0522,
+     "lambda_l2": 0.0318,
+     "feature_fraction": 0.0183,
+     "num_leaves": 0.017,
+     "bagging_freq": 0.015,
+     "n_models": 0.004,
+     "max_depth": 0.0035,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0552
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0552,
+        0.0696
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0696,
+        0.0883
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0883,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        62.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        62.0,
+        73.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        73.5,
+        81.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        81.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 101,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        64.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        64.0,
+        68.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        68.0,
+        73.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        73.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0017
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0017,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.0014
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0014,
+        0.0051
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0051,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.52
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.52,
+        0.5384
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.5384,
+        0.579
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.579,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6034
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.6034,
+        0.6215
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.6215,
+        0.6511
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.6511,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 87.2,
+    "holdout": {
+     "holdout_rmse": 0.011007979532106398,
+     "retrain_s": 0.0878,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.009693399087831716
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00970324871506328,
+    "rmse_p10": 0.009708074982092715,
+    "rmse_median": 0.009720408522493687,
+    "train_s_median": 0.180388630181551,
+    "train_s_mean": 0.25214195019627617,
+    "train_s_p90": 0.2684771767631178,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.1906559510124777,
+     "num_leaves": 113,
+     "max_depth": 10,
+     "min_data_in_leaf": 24,
+     "lambda_l1": 0.000840439973602131,
+     "lambda_l2": 1.0356672440702933e-05,
+     "feature_fraction": 0.5973201212240083,
+     "bagging_fraction": 0.9368781801703181,
+     "bagging_freq": 1,
+     "extra_trees": true,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 41,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.6551573099255166,
+     "mixture_diversity_lambda": 0.19405489490587166,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 13,
+     "mixture_gate_learning_rate": 0.06063954926654856,
+     "mixture_gate_lambda_l2": 0.14651023648127057,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 26,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.3078289604814017,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 5,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.3077,
+     "bagging_fraction": 0.1291,
+     "mixture_balance_factor": 0.1005,
+     "num_leaves": 0.0839,
+     "mixture_diversity_lambda": 0.0728,
+     "learning_rate": 0.0642,
+     "extra_trees": 0.0636,
+     "feature_fraction": 0.0458,
+     "max_depth": 0.0364,
+     "mixture_warmup_iters": 0.0248,
+     "mixture_num_experts": 0.0165,
+     "mixture_gate_type": 0.0133,
+     "bagging_freq": 0.0132,
+     "mixture_hard_m_step": 0.0104,
+     "mixture_init": 0.0089,
+     "mixture_r_smoothing": 0.0041,
+     "lambda_l2": 0.002,
+     "mixture_e_step_mode": 0.0015,
+     "mixture_refit_leaves": 0.0009,
+     "mixture_routing_mode": 0.0004,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 220,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "leaf_reuse": {
+        "n": 64,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.011936,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 125,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "expert_choice": {
+        "n": 175,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 20,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "em": {
+        "n": 48,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "loss_only": {
+        "n": 232,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 0.255472,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 22,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "tree_hierarchical": {
+        "n": 216,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "random": {
+        "n": 48,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.692509,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 23,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "ema": {
+        "n": 232,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "markov": {
+        "n": 45,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0,
+       "p_value": 0.015429,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 28,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 272,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.0097,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "False": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0001,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1929
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.1929,
+        0.2916
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.2916,
+        0.3335
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.3335,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        37.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        37.0,
+        40.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        40.0,
+        43.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 89,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 35,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 47,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 137,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.015
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        0.015,
+        0.0197
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        0.0197,
+        0.0878
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        0.0878,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        87.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        87.0,
+        95.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        95.0,
+        112.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        112.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 47,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 93,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        55.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0097
+      },
+      "Q2": {
+       "range": [
+        55.0,
+        90.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0097
+      },
+      "Q3": {
+       "range": [
+        90.0,
+        96.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0097
+      },
+      "Q4": {
+       "range": [
+        96.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.0097
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 389.6,
+    "holdout": {
+     "holdout_rmse": 0.011011391900521044,
+     "retrain_s": 0.3724,
+     "predict_s": 0.0002,
+     "cv_rmse_of_winner": 0.00970324871506328
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_sp500_report.md
+++ b/bench_results/meth2_v081/ds_sp500_report.md
@@ -1,0 +1,672 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['sp500'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `d25c06cf3b86`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| sp500 | naive-lightgbm | **0.01105** ± 0.00001 | 0.00975 | 0.0% | 0.04 |
+| sp500 | naive-ensemble | **0.01105** ± 0.00000 | 0.00974 | 0.0% | 0.15 |
+| sp500 | moe | **0.01108** ± 0.00004 | 0.00976 | 0.0% | 0.20 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| sp500@s42 | naive-lightgbm | 0.0098 | 0.0098 | 0.022 | 39 |
+| sp500@s42 | naive-ensemble | 0.0097 | 0.0098 | 0.199 | 334 |
+| sp500@s42 | moe | 0.0098 | 0.0098 | 0.079 | 298 |
+| sp500@s43 | naive-lightgbm | 0.0097 | 0.0098 | 0.022 | 44 |
+| sp500@s43 | naive-ensemble | 0.0098 | 0.0098 | 0.073 | 116 |
+| sp500@s43 | moe | 0.0098 | 0.0098 | 0.063 | 152 |
+| sp500@s44 | naive-lightgbm | 0.0097 | 0.0098 | 0.025 | 45 |
+| sp500@s44 | naive-ensemble | 0.0097 | 0.0098 | 0.128 | 202 |
+| sp500@s44 | moe | 0.0098 | 0.0098 | 0.166 | 282 |
+
+
+
+---
+
+## sp500@s42  (search X=[2969, 28], holdout n=742)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01103** (winner retrained in 0.07s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.022s/fold, mean 0.023s, p90 0.029s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.434 |
+| `num_leaves` | 0.259 |
+| `min_data_in_leaf` | 0.127 |
+| `max_depth` | 0.101 |
+| `extra_trees` | 0.031 |
+| `bagging_fraction` | 0.022 |
+| `bagging_freq` | 0.015 |
+| `feature_fraction` | 0.010 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 280 | 0.0098 | 0.0000 | 0.0098 |
+| False | 20 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0459] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 17.0] |
+| `max_depth` | 0.0098 | 0.0098 | — | 0.0098 | **Q1** [None, 6.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 82.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.6921] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.6104] |
+
+#### E. Slice plot
+
+![sp500@s42/naive-lightgbm](slice_sp500@s42_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.01105** (winner retrained in 0.24s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0097
+- train: median 0.199s/fold, mean 0.219s, p90 0.374s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.840 |
+| `min_data_in_leaf` | 0.053 |
+| `lambda_l2` | 0.022 |
+| `num_leaves` | 0.019 |
+| `feature_fraction` | 0.017 |
+| `n_models` | 0.013 |
+| `max_depth` | 0.011 |
+| `bagging_fraction` | 0.011 |
+| `bagging_freq` | 0.007 |
+| `extra_trees` | 0.006 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.0098 | 0.0000 | 0.0097 |
+| True | 20 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0116] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 25.75] |
+| `max_depth` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 7.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 6.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0019] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.7093] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.9263] |
+
+#### E. Slice plot
+
+![sp500@s42/naive-ensemble](slice_sp500@s42_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01113** (winner retrained in 0.24s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.079s/fold, mean 0.191s, p90 0.435s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.397 |
+| `mixture_diversity_lambda` | 0.243 |
+| `min_data_in_leaf` | 0.075 |
+| `bagging_fraction` | 0.069 |
+| `learning_rate` | 0.049 |
+| `mixture_gate_type` | 0.029 |
+| `mixture_warmup_iters` | 0.027 |
+| `feature_fraction` | 0.026 |
+| `bagging_freq` | 0.016 |
+| `num_leaves` | 0.012 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 0.0098 (n=17) | none | Δ +0.0000 | p=5.49e-03 |
+| `mixture_routing_mode` | **token_choice** | 0.0098 (n=104) | expert_choice | Δ +0.0000 | p=3.20e-05 |
+| `mixture_r_smoothing` | **ema** | 0.0098 (n=88) | markov | Δ +0.0000 | p=2.40e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 17 | 0.0098 | 0.0000 | 0.0098 |
+| none | 214 | 0.0098 | 0.0000 | 0.0098 |
+| gbdt | 69 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 104 | 0.0098 | 0.0000 | 0.0098 |
+| expert_choice | 196 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 103 | 0.0098 | 0.0000 | 0.0098 |
+| gate_only | 52 | 0.0098 | 0.0000 | 0.0098 |
+| em | 145 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 16 | 0.0098 | 0.0000 | 0.0098 |
+| gmm | 14 | 0.0098 | 0.0000 | 0.0098 |
+| tree_hierarchical | 28 | 0.0098 | 0.0000 | 0.0098 |
+| uniform | 242 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 88 | 0.0098 | 0.0000 | 0.0098 |
+| markov | 120 | 0.0098 | 0.0000 | 0.0098 |
+| none | 92 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 278 | 0.0098 | 0.0000 | 0.0098 |
+| False | 22 | 0.0098 | 0.0000 | 0.0098 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 278 | 0.0098 | 0.0000 | 0.0098 |
+| False | 22 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0098 | — | — | 0.0098 | **Q1** [None, 4.0] |
+| `mixture_diversity_lambda` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.1744] |
+| `mixture_warmup_iters` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 32.0] |
+| `mixture_balance_factor` | — | — | 0.0098 | 0.0098 | **Q3** [2.0, 3.0] |
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.123] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 96.75] |
+| `max_depth` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 5.75] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 46.0] |
+
+#### E. Slice plot
+
+![sp500@s42/moe](slice_sp500@s42_moe.png)
+
+
+---
+
+## sp500@s43  (search X=[2969, 28], holdout n=742)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01105** (winner retrained in 0.03s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0098
+- train: median 0.022s/fold, mean 0.026s, p90 0.039s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `bagging_fraction` | 0.512 |
+| `learning_rate` | 0.214 |
+| `feature_fraction` | 0.060 |
+| `min_data_in_leaf` | 0.049 |
+| `num_leaves` | 0.044 |
+| `max_depth` | 0.044 |
+| `bagging_freq` | 0.036 |
+| `lambda_l2` | 0.022 |
+| `lambda_l1` | 0.015 |
+| `extra_trees` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 21 | 0.0098 | 0.0000 | 0.0098 |
+| False | 279 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0873] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 12.0] |
+| `max_depth` | — | — | 0.0098 | 0.0098 | **Q3** [3.0, 6.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 34.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0001] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.9045] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.8034] |
+
+#### E. Slice plot
+
+![sp500@s43/naive-lightgbm](slice_sp500@s43_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.01104** (winner retrained in 0.13s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.073s/fold, mean 0.074s, p90 0.093s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.429 |
+| `learning_rate` | 0.156 |
+| `feature_fraction` | 0.112 |
+| `num_leaves` | 0.106 |
+| `bagging_fraction` | 0.092 |
+| `max_depth` | 0.070 |
+| `bagging_freq` | 0.018 |
+| `n_models` | 0.011 |
+| `extra_trees` | 0.004 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 20 | 0.0098 | 0.0000 | 0.0098 |
+| True | 280 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0541] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 85.75] |
+| `max_depth` | — | 0.0098 | 0.0098 | 0.0098 | **Q2** [3.0, 4.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 91.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.5203] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.684] |
+
+#### E. Slice plot
+
+![sp500@s43/naive-ensemble](slice_sp500@s43_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01103** (winner retrained in 0.09s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.063s/fold, mean 0.095s, p90 0.152s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.300 |
+| `mixture_init` | 0.252 |
+| `mixture_balance_factor` | 0.099 |
+| `learning_rate` | 0.085 |
+| `bagging_fraction` | 0.058 |
+| `min_data_in_leaf` | 0.042 |
+| `mixture_warmup_iters` | 0.039 |
+| `feature_fraction` | 0.027 |
+| `num_leaves` | 0.024 |
+| `mixture_num_experts` | 0.014 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 30 | 0.0098 | 0.0000 | 0.0098 |
+| none | 254 | 0.0098 | 0.0000 | 0.0098 |
+| leaf_reuse | 16 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 212 | 0.0098 | 0.0000 | 0.0098 |
+| token_choice | 88 | 0.0098 | 0.0001 | 0.0098 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 99 | 0.0098 | 0.0000 | 0.0098 |
+| em | 166 | 0.0098 | 0.0000 | 0.0098 |
+| gate_only | 35 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 14 | 0.0098 | 0.0000 | 0.0098 |
+| tree_hierarchical | 15 | 0.0098 | 0.0001 | 0.0098 |
+| random | 162 | 0.0098 | 0.0000 | 0.0098 |
+| uniform | 109 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 219 | 0.0098 | 0.0000 | 0.0098 |
+| none | 57 | 0.0098 | 0.0001 | 0.0098 |
+| markov | 24 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 220 | 0.0098 | 0.0000 | 0.0098 |
+| False | 80 | 0.0098 | 0.0001 | 0.0098 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 23 | 0.0098 | 0.0000 | 0.0098 |
+| True | 277 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0098 | — | — | 0.0098 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.2049] |
+| `mixture_warmup_iters` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 9.0] |
+| `mixture_balance_factor` | 0.0098 | — | 0.0098 | 0.0098 | **Q1** [None, 3.0] |
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.1629] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 51.75] |
+| `max_depth` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 7.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 87.0] |
+
+#### E. Slice plot
+
+![sp500@s43/moe](slice_sp500@s43_moe.png)
+
+
+---
+
+## sp500@s44  (search X=[2969, 28], holdout n=742)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.01106** (winner retrained in 0.02s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0097
+- train: median 0.025s/fold, mean 0.027s, p90 0.033s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.742 |
+| `min_data_in_leaf` | 0.098 |
+| `num_leaves` | 0.077 |
+| `feature_fraction` | 0.030 |
+| `bagging_fraction` | 0.019 |
+| `max_depth` | 0.014 |
+| `extra_trees` | 0.013 |
+| `bagging_freq` | 0.007 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.0098 | 0.0000 | 0.0097 |
+| True | 20 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0152] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 39.0] |
+| `max_depth` | 0.0098 | — | — | 0.0098 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 8.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0001] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.65] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.5556] |
+
+#### E. Slice plot
+
+![sp500@s44/naive-lightgbm](slice_sp500@s44_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.01105** (winner retrained in 0.09s, cv score of winner: 0.0097)
+- cv best RMSE: 0.0097, median: 0.0098, p10: 0.0097
+- train: median 0.128s/fold, mean 0.131s, p90 0.188s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.471 |
+| `min_data_in_leaf` | 0.195 |
+| `bagging_fraction` | 0.092 |
+| `lambda_l2` | 0.081 |
+| `num_leaves` | 0.043 |
+| `bagging_freq` | 0.041 |
+| `feature_fraction` | 0.033 |
+| `max_depth` | 0.022 |
+| `n_models` | 0.012 |
+| `extra_trees` | 0.010 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 21 | 0.0098 | 0.0000 | 0.0098 |
+| False | 279 | 0.0098 | 0.0000 | 0.0097 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0198] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 53.0] |
+| `max_depth` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 7.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 7.0] |
+| `lambda_l1` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.9703] |
+| `feature_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.7247] |
+| `bagging_fraction` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.6824] |
+
+#### E. Slice plot
+
+![sp500@s44/naive-ensemble](slice_sp500@s44_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 0.01107** (winner retrained in 0.27s, cv score of winner: 0.0098)
+- cv best RMSE: 0.0098, median: 0.0098, p10: 0.0098
+- train: median 0.166s/fold, mean 0.181s, p90 0.232s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.535 |
+| `learning_rate` | 0.259 |
+| `mixture_diversity_lambda` | 0.050 |
+| `extra_trees` | 0.039 |
+| `num_leaves` | 0.027 |
+| `mixture_e_step_mode` | 0.021 |
+| `min_data_in_leaf` | 0.017 |
+| `feature_fraction` | 0.008 |
+| `max_depth` | 0.007 |
+| `mixture_gate_type` | 0.007 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_init` | **uniform** | 0.0098 (n=24) | tree_hierarchical | Δ +0.0000 | p=1.14e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 27 | 0.0098 | 0.0000 | 0.0098 |
+| none | 16 | 0.0098 | 0.0000 | 0.0098 |
+| leaf_reuse | 257 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 171 | 0.0098 | 0.0000 | 0.0098 |
+| expert_choice | 129 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 15 | 0.0098 | 0.0000 | 0.0098 |
+| em | 134 | 0.0098 | 0.0000 | 0.0098 |
+| loss_only | 151 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 24 | 0.0098 | 0.0000 | 0.0098 |
+| tree_hierarchical | 14 | 0.0098 | 0.0000 | 0.0098 |
+| random | 15 | 0.0098 | 0.0000 | 0.0098 |
+| gmm | 247 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 101 | 0.0098 | 0.0000 | 0.0098 |
+| ema | 17 | 0.0098 | 0.0000 | 0.0098 |
+| markov | 182 | 0.0098 | 0.0000 | 0.0098 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 28 | 0.0098 | 0.0000 | 0.0098 |
+| False | 272 | 0.0098 | 0.0000 | 0.0098 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 28 | 0.0098 | 0.0000 | 0.0098 |
+| False | 272 | 0.0098 | 0.0000 | 0.0098 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0098 | — | — | 0.0098 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.1507] |
+| `mixture_warmup_iters` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 42.0] |
+| `mixture_balance_factor` | 0.0098 | 0.0098 | — | 0.0098 | **Q1** [None, 6.0] |
+| `learning_rate` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 0.0124] |
+| `num_leaves` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 24.75] |
+| `max_depth` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 0.0098 | 0.0098 | 0.0098 | 0.0098 | **Q1** [None, 83.0] |
+
+#### E. Slice plot
+
+![sp500@s44/moe](slice_sp500@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| sp500@s42 | `mixture_gate_type` | **leaf_reuse** | +0.0000 | 5.49e-03 |
+| sp500@s42 | `mixture_routing_mode` | **token_choice** | +0.0000 | 3.20e-05 |
+| sp500@s42 | `mixture_r_smoothing` | **ema** | +0.0000 | 2.40e-05 |
+| sp500@s44 | `mixture_init` | **uniform** | +0.0000 | 1.14e-03 |

--- a/bench_results/meth2_v081/ds_sp500_summary.json
+++ b/bench_results/meth2_v081/ds_sp500_summary.json
@@ -1,0 +1,3795 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "sp500"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "d25c06cf3b8656e8f80fec7ac7bf0ccf6a1f07a1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "sp500": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011028538111712062,
+      "cv_best": 0.00976344388074939,
+      "crash_rate": 0.0,
+      "retrain_s": 0.066
+     },
+     "43": {
+      "holdout_rmse": 0.011050137943706165,
+      "cv_best": 0.009745865977441242,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0251
+     },
+     "44": {
+      "holdout_rmse": 0.011058687134332574,
+      "cv_best": 0.009739215992744327,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0207
+     }
+    },
+    "holdout_mean": 0.011046,
+    "holdout_std": 1.3e-05,
+    "cv_best_mean": 0.00975
+   },
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011051366662029952,
+      "cv_best": 0.00972624852962063,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2425
+     },
+     "43": {
+      "holdout_rmse": 0.011044361599448679,
+      "cv_best": 0.00976343663125188,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1309
+     },
+     "44": {
+      "holdout_rmse": 0.011049856045698457,
+      "cv_best": 0.009729521996752944,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0912
+     }
+    },
+    "holdout_mean": 0.011049,
+    "holdout_std": 3e-06,
+    "cv_best_mean": 0.00974
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.011132609311400409,
+      "cv_best": 0.009760577108170649,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2426
+     },
+     "43": {
+      "holdout_rmse": 0.011029725509647212,
+      "cv_best": 0.009773961119726844,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0898
+     },
+     "44": {
+      "holdout_rmse": 0.011068834624155532,
+      "cv_best": 0.009761518674436236,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2716
+     }
+    },
+    "holdout_mean": 0.011077,
+    "holdout_std": 4.2e-05,
+    "cv_best_mean": 0.009765
+   }
+  }
+ },
+ "runs": {
+  "sp500@s42": {
+   "dataset": "sp500",
+   "seed": 42,
+   "X_search_shape": [
+    2969,
+    28
+   ],
+   "n_holdout": 742,
+   "y_stats": {
+    "mean": 0.00046336272131137016,
+    "std": 0.010883884492578235
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00976344388074939,
+    "rmse_p10": 0.009767962228564443,
+    "rmse_median": 0.009773511085124573,
+    "train_s_median": 0.02190238144248724,
+    "train_s_mean": 0.022694559457401436,
+    "train_s_p90": 0.02879957653582096,
+    "best_params": {
+     "learning_rate": 0.04895596520583819,
+     "num_leaves": 22,
+     "max_depth": 8,
+     "min_data_in_leaf": 93,
+     "lambda_l1": 4.077405201786748e-07,
+     "lambda_l2": 0.0003592995087490544,
+     "feature_fraction": 0.7266048013790695,
+     "bagging_fraction": 0.6331779201740483,
+     "bagging_freq": 3,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.4344,
+     "num_leaves": 0.2586,
+     "min_data_in_leaf": 0.1273,
+     "max_depth": 0.1014,
+     "extra_trees": 0.0311,
+     "bagging_fraction": 0.0218,
+     "bagging_freq": 0.0151,
+     "feature_fraction": 0.0101,
+     "lambda_l2": 0.0001,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0459
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0459,
+        0.0595
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0595,
+        0.0711
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0711,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        22.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        31.0
+       ],
+       "n": 89,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 162,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        82.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        82.0,
+        90.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        90.0,
+        94.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        94.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0005
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0005,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6921
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.6921,
+        0.7195
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.7195,
+        0.745
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.745,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6104
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.6104,
+        0.63
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.63,
+        0.6577
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.6577,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 38.9,
+    "holdout": {
+     "holdout_rmse": 0.011028538111712062,
+     "retrain_s": 0.066,
+     "predict_s": 0.0004,
+     "cv_rmse_of_winner": 0.00976344388074939
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00972624852962063,
+    "rmse_p10": 0.009749188982497617,
+    "rmse_median": 0.009765344081983237,
+    "train_s_median": 0.19861440714448692,
+    "train_s_mean": 0.2189602559270958,
+    "train_s_p90": 0.37363592647016053,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.01009107430156864,
+     "num_leaves": 119,
+     "max_depth": 8,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.029153701696505944,
+     "lambda_l2": 9.462900542269795e-06,
+     "feature_fraction": 0.7281725632486841,
+     "bagging_fraction": 0.9981770399581381,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.8397,
+     "min_data_in_leaf": 0.0526,
+     "lambda_l2": 0.0222,
+     "num_leaves": 0.0194,
+     "feature_fraction": 0.0169,
+     "n_models": 0.013,
+     "max_depth": 0.0108,
+     "bagging_fraction": 0.0107,
+     "bagging_freq": 0.0073,
+     "extra_trees": 0.0062,
+     "lambda_l1": 0.0012
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0116
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0116,
+        0.0158
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0158,
+        0.0495
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0495,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        25.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        25.75,
+        97.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        97.0,
+        113.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        113.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 22,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 131,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0019
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0019,
+        0.0072
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0072,
+        0.0315
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0315,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0205
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0205,
+        0.8844
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.8844,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7093
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.7093,
+        0.7316
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.7316,
+        0.8011
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.8011,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9263
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.9263,
+        0.961
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.961,
+        0.9862
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9862,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 333.8,
+    "holdout": {
+     "holdout_rmse": 0.011051366662029952,
+     "retrain_s": 0.2425,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.00972624852962063
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009760577108170649,
+    "rmse_p10": 0.009769063295797478,
+    "rmse_median": 0.009777807441999756,
+    "train_s_median": 0.07871761228889226,
+    "train_s_mean": 0.19110788264373937,
+    "train_s_p90": 0.4350716592743994,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.24880081698238846,
+     "num_leaves": 116,
+     "max_depth": 9,
+     "min_data_in_leaf": 50,
+     "lambda_l1": 9.66199156575197e-05,
+     "lambda_l2": 0.18140525550997702,
+     "feature_fraction": 0.791759604101212,
+     "bagging_fraction": 0.761058666405858,
+     "bagging_freq": 2,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 40,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.4455175448291843,
+     "mixture_diversity_lambda": 0.23642255868856496,
+     "mixture_hard_m_step": true,
+     "mixture_expert_capacity_factor": 0.8392955989571543,
+     "mixture_expert_choice_boost": 15.80433341445114,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.197182057978644,
+     "mixture_elbo_drop_threshold": 0.0035253090133993983,
+     "mixture_elbo_plateau_threshold": 0.00043617813271180873,
+     "mixture_elbo_window": 16,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 2,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "mixture_init": 0.3973,
+     "mixture_diversity_lambda": 0.2429,
+     "min_data_in_leaf": 0.0754,
+     "bagging_fraction": 0.0694,
+     "learning_rate": 0.0488,
+     "mixture_gate_type": 0.0291,
+     "mixture_warmup_iters": 0.0273,
+     "feature_fraction": 0.0259,
+     "bagging_freq": 0.0156,
+     "num_leaves": 0.0118,
+     "mixture_num_experts": 0.0094,
+     "extra_trees": 0.0085,
+     "mixture_e_step_mode": 0.0085,
+     "max_depth": 0.0077,
+     "mixture_hard_m_step": 0.0073,
+     "mixture_balance_factor": 0.006,
+     "lambda_l2": 0.0055,
+     "mixture_r_smoothing": 0.0025,
+     "mixture_routing_mode": 0.0005,
+     "mixture_refit_leaves": 0.0003,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 17,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 214,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gbdt": {
+        "n": 69,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.005494,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 104,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "expert_choice": {
+        "n": 196,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 3.2e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 103,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gate_only": {
+        "n": 52,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "em": {
+        "n": 145,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0,
+       "p_value": 0.067062,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "tree_hierarchical": {
+        "n": 28,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "uniform": {
+        "n": 242,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "gmm",
+       "delta_mean": 0.0,
+       "p_value": 0.092795,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 88,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "markov": {
+        "n": 120,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 92,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0,
+       "p_value": 2.4e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 278,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 22,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 278,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 22,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 26,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 274,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1744
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.1744,
+        0.225
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.225,
+        0.2654
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2654,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        32.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        32.0,
+        35.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        35.0,
+        39.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        39.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 186,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 114,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.123
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.123,
+        0.2069
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.2069,
+        0.2437
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2437,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        96.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        96.75,
+        112.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        112.0,
+        118.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        118.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        5.75,
+        9.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        46.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        46.0,
+        50.0
+       ],
+       "n": 56,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        50.0,
+        54.0
+       ],
+       "n": 84,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        54.0,
+        null
+       ],
+       "n": 90,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 298.2,
+    "holdout": {
+     "holdout_rmse": 0.011132609311400409,
+     "retrain_s": 0.2426,
+     "predict_s": 0.0018,
+     "cv_rmse_of_winner": 0.009760577108170649
+    }
+   }
+  },
+  "sp500@s43": {
+   "dataset": "sp500",
+   "seed": 43,
+   "X_search_shape": [
+    2969,
+    28
+   ],
+   "n_holdout": 742,
+   "y_stats": {
+    "mean": 0.00046336272131137016,
+    "std": 0.010883884492578235
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009745865977441242,
+    "rmse_p10": 0.0097517442602634,
+    "rmse_median": 0.009774288082855097,
+    "train_s_median": 0.022291291318833825,
+    "train_s_mean": 0.025549849034597477,
+    "train_s_p90": 0.03862824268639089,
+    "best_params": {
+     "learning_rate": 0.2614268943050323,
+     "num_leaves": 24,
+     "max_depth": 3,
+     "min_data_in_leaf": 34,
+     "lambda_l1": 0.003175726071744946,
+     "lambda_l2": 5.8130045289794776e-08,
+     "feature_fraction": 0.9739263503911815,
+     "bagging_fraction": 0.9723000906314205,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "bagging_fraction": 0.5125,
+     "learning_rate": 0.2139,
+     "feature_fraction": 0.0597,
+     "min_data_in_leaf": 0.0488,
+     "num_leaves": 0.0442,
+     "max_depth": 0.0441,
+     "bagging_freq": 0.0358,
+     "lambda_l2": 0.022,
+     "lambda_l1": 0.0148,
+     "extra_trees": 0.0042
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0873
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0873,
+        0.2328
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.2328,
+        0.2758
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2758,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        20.0
+       ],
+       "n": 84,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        20.0,
+        54.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        54.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        6.0
+       ],
+       "n": 209,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 91,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        34.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        34.0,
+        42.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        42.0,
+        49.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0006
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0006,
+        0.0021
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0021,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0008
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0008,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9045
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.9045,
+        0.9662
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.9662,
+        0.9839
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9839,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8034
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.8034,
+        0.927
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.927,
+        0.9584
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9584,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 43.5,
+    "holdout": {
+     "holdout_rmse": 0.011050137943706165,
+     "retrain_s": 0.0251,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.009745865977441242
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.00976343663125188,
+    "rmse_p10": 0.009766696555823684,
+    "rmse_median": 0.009770413515206498,
+    "train_s_median": 0.07341883797198534,
+    "train_s_mean": 0.07367812355980277,
+    "train_s_p90": 0.0925523353368044,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.1070793039835829,
+     "num_leaves": 94,
+     "max_depth": 3,
+     "min_data_in_leaf": 98,
+     "lambda_l1": 1.0104919403457047e-08,
+     "lambda_l2": 5.0984679971364505e-05,
+     "feature_fraction": 0.5226173690321387,
+     "bagging_fraction": 0.7020017993531364,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.429,
+     "learning_rate": 0.156,
+     "feature_fraction": 0.1119,
+     "num_leaves": 0.1065,
+     "bagging_fraction": 0.0918,
+     "max_depth": 0.0703,
+     "bagging_freq": 0.0184,
+     "n_models": 0.0107,
+     "extra_trees": 0.0036,
+     "lambda_l2": 0.0011,
+     "lambda_l1": 0.0007
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "True": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0541
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0541,
+        0.0767
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0767,
+        0.0928
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0928,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        85.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        85.75,
+        100.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        100.0,
+        108.25
+       ],
+       "n": 79,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        108.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 113,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        7.0
+       ],
+       "n": 95,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 92,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        91.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        91.0,
+        96.0
+       ],
+       "n": 56,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        96.0,
+        98.0
+       ],
+       "n": 47,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        98.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0003,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0002,
+        0.0051
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0051,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5203
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.5203,
+        0.5473
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.5473,
+        0.7897
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.7897,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.684
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.684,
+        0.7073
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.7073,
+        0.7473
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.7473,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 116.0,
+    "holdout": {
+     "holdout_rmse": 0.011044361599448679,
+     "retrain_s": 0.1309,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.00976343663125188
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009773961119726844,
+    "rmse_p10": 0.009778081370032183,
+    "rmse_median": 0.0097840061525906,
+    "train_s_median": 0.06272578239440918,
+    "train_s_mean": 0.09454741482188304,
+    "train_s_p90": 0.15196620821952833,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.24574750730747302,
+     "num_leaves": 112,
+     "max_depth": 10,
+     "min_data_in_leaf": 96,
+     "lambda_l1": 7.21171306244084e-05,
+     "lambda_l2": 1.577958701422743e-05,
+     "feature_fraction": 0.9286729561409764,
+     "bagging_fraction": 0.5225532274554584,
+     "bagging_freq": 1,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 29,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.48562260726973894,
+     "mixture_diversity_lambda": 0.26668878208792157,
+     "mixture_hard_m_step": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.22387137480563601,
+     "mixture_elbo_drop_threshold": 0.014995457007909996,
+     "mixture_elbo_plateau_threshold": 0.0018828368953353997,
+     "mixture_elbo_window": 13,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 1,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "lambda_l2": 0.3001,
+     "mixture_init": 0.2517,
+     "mixture_balance_factor": 0.0987,
+     "learning_rate": 0.0848,
+     "bagging_fraction": 0.0583,
+     "min_data_in_leaf": 0.0415,
+     "mixture_warmup_iters": 0.0391,
+     "feature_fraction": 0.027,
+     "num_leaves": 0.0235,
+     "mixture_num_experts": 0.0142,
+     "mixture_r_smoothing": 0.0138,
+     "extra_trees": 0.0116,
+     "mixture_hard_m_step": 0.01,
+     "mixture_routing_mode": 0.0091,
+     "mixture_diversity_lambda": 0.0075,
+     "mixture_refit_leaves": 0.0032,
+     "mixture_gate_type": 0.0028,
+     "max_depth": 0.0017,
+     "bagging_freq": 0.0012,
+     "mixture_e_step_mode": 0.0002,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 30,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 254,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "leaf_reuse": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.79226,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 212,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "token_choice": {
+        "n": 88,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.162919,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 99,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "em": {
+        "n": 166,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gate_only": {
+        "n": 35,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 0.018454,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 14,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "random": {
+        "n": 162,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "uniform": {
+        "n": 109,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.206498,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 219,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 57,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       },
+       "markov": {
+        "n": 24,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.172808,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 220,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 80,
+        "mean": 0.0098,
+        "std": 0.0001,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 23,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "True": {
+        "n": 277,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 12,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 288,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2049
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.2049,
+        0.2376
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.2376,
+        0.2767
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2767,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 55,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        15.0
+       ],
+       "n": 93,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        30.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 91,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 41,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 139,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 120,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1629
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.1629,
+        0.2042
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.2042,
+        0.2403
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2403,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        51.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        51.75,
+        71.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        71.0,
+        96.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        96.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 37,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 39,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 104,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        87.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        87.0,
+        94.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        94.0,
+        97.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        97.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 152.2,
+    "holdout": {
+     "holdout_rmse": 0.011029725509647212,
+     "retrain_s": 0.0898,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.009773961119726844
+    }
+   }
+  },
+  "sp500@s44": {
+   "dataset": "sp500",
+   "seed": 44,
+   "X_search_shape": [
+    2969,
+    28
+   ],
+   "n_holdout": 742,
+   "y_stats": {
+    "mean": 0.00046336272131137016,
+    "std": 0.010883884492578235
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009739215992744327,
+    "rmse_p10": 0.00974452012556568,
+    "rmse_median": 0.009768822756168041,
+    "train_s_median": 0.025300966575741768,
+    "train_s_mean": 0.02673785665879647,
+    "train_s_p90": 0.03311645198613407,
+    "best_params": {
+     "learning_rate": 0.031405431231896,
+     "num_leaves": 42,
+     "max_depth": 4,
+     "min_data_in_leaf": 8,
+     "lambda_l1": 0.00017586878336817366,
+     "lambda_l2": 2.4278998842963964e-06,
+     "feature_fraction": 0.6938019580482039,
+     "bagging_fraction": 0.516535726456921,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.7418,
+     "min_data_in_leaf": 0.0977,
+     "num_leaves": 0.0772,
+     "feature_fraction": 0.03,
+     "bagging_fraction": 0.0187,
+     "max_depth": 0.0144,
+     "extra_trees": 0.0125,
+     "bagging_freq": 0.0068,
+     "lambda_l2": 0.0006,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       },
+       "True": {
+        "n": 20,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0152
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0152,
+        0.0241
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0241,
+        0.0301
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0301,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        39.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        39.0,
+        45.0
+       ],
+       "n": 79,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        45.0,
+        71.25
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        71.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 48,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 252,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        15.25
+       ],
+       "n": 81,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        15.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0011
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0011,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.65
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.65,
+        0.6756
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.6756,
+        0.6979
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.6979,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5556
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.5556,
+        0.6236
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.6236,
+        0.9115
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9115,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 44.9,
+    "holdout": {
+     "holdout_rmse": 0.011058687134332574,
+     "retrain_s": 0.0207,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.009739215992744327
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009729521996752944,
+    "rmse_p10": 0.009746499186098238,
+    "rmse_median": 0.00976403349112636,
+    "train_s_median": 0.12814226504415274,
+    "train_s_mean": 0.13130611241608856,
+    "train_s_p90": 0.18837933499366047,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.021415971918467093,
+     "num_leaves": 62,
+     "max_depth": 7,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 2.1138974687247156e-07,
+     "lambda_l2": 4.1737586864152,
+     "feature_fraction": 0.7752448967204362,
+     "bagging_fraction": 0.9747274374610011,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.4714,
+     "min_data_in_leaf": 0.1948,
+     "bagging_fraction": 0.0919,
+     "lambda_l2": 0.0809,
+     "num_leaves": 0.0428,
+     "bagging_freq": 0.0414,
+     "feature_fraction": 0.0329,
+     "max_depth": 0.022,
+     "n_models": 0.0117,
+     "extra_trees": 0.0102,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0097
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0198
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0198,
+        0.0231
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0231,
+        0.027
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.027,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        53.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        53.0,
+        59.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        59.0,
+        65.25
+       ],
+       "n": 84,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        65.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 39,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 110,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        16.0
+       ],
+       "n": 88,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.9703
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.9703,
+        3.1461
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        3.1461,
+        4.7549
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        4.7549,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7247
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.7247,
+        0.7711
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.7711,
+        0.7968
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.7968,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6824
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.6824,
+        0.9496
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.9496,
+        0.9773
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.9773,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 201.9,
+    "holdout": {
+     "holdout_rmse": 0.011049856045698457,
+     "retrain_s": 0.0912,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.009729521996752944
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.009761518674436236,
+    "rmse_p10": 0.009769252515905507,
+    "rmse_median": 0.009774853714664017,
+    "train_s_median": 0.16618994027376177,
+    "train_s_mean": 0.1813950354208549,
+    "train_s_p90": 0.23222035821527248,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.013816787664985763,
+     "num_leaves": 71,
+     "max_depth": 4,
+     "min_data_in_leaf": 76,
+     "lambda_l1": 1.550728504257365e-06,
+     "lambda_l2": 1.079415288096462,
+     "feature_fraction": 0.9746879408342737,
+     "bagging_fraction": 0.5377629976322855,
+     "bagging_freq": 3,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 46,
+     "mixture_balance_factor": 9,
+     "mixture_diversity_lambda": 0.20961398277295112,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 41,
+     "mixture_gate_learning_rate": 0.0619137727042339,
+     "mixture_gate_lambda_l2": 0.0031325870196239228,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 16,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.5348,
+     "learning_rate": 0.2591,
+     "mixture_diversity_lambda": 0.0501,
+     "extra_trees": 0.0392,
+     "num_leaves": 0.0266,
+     "mixture_e_step_mode": 0.0207,
+     "min_data_in_leaf": 0.0165,
+     "feature_fraction": 0.0076,
+     "max_depth": 0.0071,
+     "mixture_gate_type": 0.0068,
+     "mixture_r_smoothing": 0.0065,
+     "mixture_routing_mode": 0.0056,
+     "bagging_freq": 0.0048,
+     "bagging_fraction": 0.0044,
+     "mixture_warmup_iters": 0.0041,
+     "lambda_l2": 0.0027,
+     "mixture_num_experts": 0.0021,
+     "mixture_balance_factor": 0.0007,
+     "mixture_hard_m_step": 0.0006,
+     "mixture_refit_leaves": 0.0,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 27,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "none": {
+        "n": 16,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "leaf_reuse": {
+        "n": 257,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0,
+       "p_value": 0.927319,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 171,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "expert_choice": {
+        "n": 129,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0,
+       "p_value": 0.180419,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 15,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "em": {
+        "n": 134,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "loss_only": {
+        "n": 151,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0,
+       "p_value": 0.014735,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 24,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "random": {
+        "n": 15,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "gmm": {
+        "n": 247,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0,
+       "p_value": 0.001145,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 101,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "ema": {
+        "n": 17,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "markov": {
+        "n": 182,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0,
+       "p_value": 0.224051,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 28,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 272,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 28,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       },
+       "False": {
+        "n": 272,
+        "mean": 0.0098,
+        "std": 0.0,
+        "min": 0.0098
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 15,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 285,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1507
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.1507,
+        0.1717
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.1717,
+        0.2019
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.2019,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        42.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        42.0,
+        46.0
+       ],
+       "n": 82,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        46.0,
+        48.0
+       ],
+       "n": 53,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 103,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 27,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 94,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 179,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0124
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        0.0124,
+        0.015
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        0.015,
+        0.0179
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        0.0179,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        24.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        24.75,
+        54.5
+       ],
+       "n": 75,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        54.5,
+        68.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        68.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 22,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 38,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 119,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        83.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0098
+      },
+      "Q2": {
+       "range": [
+        83.0,
+        88.0
+       ],
+       "n": 71,
+       "mean_rmse": 0.0098
+      },
+      "Q3": {
+       "range": [
+        88.0,
+        95.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.0098
+      },
+      "Q4": {
+       "range": [
+        95.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.0098
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 282.3,
+    "holdout": {
+     "holdout_rmse": 0.011068834624155532,
+     "retrain_s": 0.2716,
+     "predict_s": 0.001,
+     "cv_rmse_of_winner": 0.009761518674436236
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_synthetic_report.md
+++ b/bench_results/meth2_v081/ds_synthetic_report.md
@@ -1,0 +1,689 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['synthetic'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `0cf3634c544c`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| synthetic | naive-lightgbm | **4.81200** ± 0.33985 | 5.55933 | 0.0% | 0.20 |
+| synthetic | naive-ensemble | **4.70621** ± 0.37221 | 5.46794 | 0.0% | 0.53 |
+| synthetic | moe | **3.84145** ± 0.28986 | 4.44212 | 0.0% | 0.32 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| synthetic@s42 | naive-lightgbm | 5.3381 | 5.5618 | 0.137 | 196 |
+| synthetic@s42 | naive-ensemble | 5.3266 | 5.6435 | 0.234 | 368 |
+| synthetic@s42 | moe | 4.4217 | 5.0414 | 0.565 | 1392 |
+| synthetic@s43 | naive-lightgbm | 5.5380 | 5.8312 | 0.099 | 147 |
+| synthetic@s43 | naive-ensemble | 5.4878 | 5.7482 | 0.452 | 617 |
+| synthetic@s43 | moe | 4.3519 | 5.1719 | 0.189 | 381 |
+| synthetic@s44 | naive-lightgbm | 5.8019 | 6.1616 | 0.093 | 139 |
+| synthetic@s44 | naive-ensemble | 5.5894 | 5.8602 | 0.276 | 398 |
+| synthetic@s44 | moe | 4.5527 | 4.9532 | 0.226 | 434 |
+
+
+
+---
+
+## synthetic@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 4.34766** (winner retrained in 0.18s, cv score of winner: 5.3381)
+- cv best RMSE: 5.3381, median: 5.5618, p10: 5.4179
+- train: median 0.137s/fold, mean 0.127s, p90 0.172s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.557 |
+| `learning_rate` | 0.306 |
+| `feature_fraction` | 0.072 |
+| `extra_trees` | 0.038 |
+| `bagging_fraction` | 0.012 |
+| `bagging_freq` | 0.007 |
+| `num_leaves` | 0.006 |
+| `max_depth` | 0.001 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 5.7325 | 0.4837 | 5.3381 |
+| True | 22 | 7.1469 | 1.5229 | 5.6091 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.1776 | 5.6327 | 5.6468 | 5.8878 | **Q2** [0.0423, 0.0493] |
+| `num_leaves` | 5.6674 | 5.7401 | 5.6393 | 6.3012 | **Q3** [33.0, 50.25] |
+| `max_depth` | 6.5140 | 5.7722 | — | 5.7153 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | 5.5472 | 5.5529 | 5.6386 | 6.5512 | **Q1** [None, 6.0] |
+| `lambda_l1` | 6.3199 | 5.7260 | 5.6546 | 5.6443 | **Q4** [2.3125, ∞) |
+| `lambda_l2` | 5.7133 | 5.6388 | 5.9086 | 6.0841 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.3681 | 5.6852 | 5.6903 | 5.6013 | **Q4** [0.9868, ∞) |
+| `bagging_fraction` | 5.7752 | 5.6650 | 5.8987 | 6.0060 | **Q2** [0.6994, 0.7301] |
+
+#### E. Slice plot
+
+![synthetic@s42/naive-lightgbm](slice_synthetic@s42_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 4.82120** (winner retrained in 0.25s, cv score of winner: 5.3266)
+- cv best RMSE: 5.3266, median: 5.6435, p10: 5.4218
+- train: median 0.234s/fold, mean 0.241s, p90 0.361s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.771 |
+| `learning_rate` | 0.167 |
+| `bagging_fraction` | 0.018 |
+| `bagging_freq` | 0.014 |
+| `feature_fraction` | 0.013 |
+| `max_depth` | 0.007 |
+| `extra_trees` | 0.004 |
+| `num_leaves` | 0.004 |
+| `lambda_l1` | 0.002 |
+| `n_models` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 250 | 5.8537 | 0.7006 | 5.3266 |
+| False | 50 | 6.1501 | 0.6342 | 5.3736 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.3160 | 5.5465 | 5.8407 | 5.9091 | **Q2** [0.1005, 0.1213] |
+| `num_leaves` | 5.6761 | 5.9371 | 6.0086 | 5.9610 | **Q1** [None, 29.0] |
+| `max_depth` | 6.1669 | 5.9259 | — | 5.7924 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | — | 5.5474 | 5.7937 | 6.6627 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 6.0419 | 5.8762 | 5.9732 | 5.7211 | **Q4** [0.0141, ∞) |
+| `lambda_l2` | 6.0263 | 5.5534 | 5.9131 | 6.1196 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.3067 | 5.7731 | 5.9482 | 5.5844 | **Q4** [0.974, ∞) |
+| `bagging_fraction` | 6.1215 | 5.8272 | 5.5425 | 6.1212 | **Q3** [0.7698, 0.7935] |
+
+#### E. Slice plot
+
+![synthetic@s42/naive-ensemble](slice_synthetic@s42_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 3.55247** (winner retrained in 0.45s, cv score of winner: 4.4217)
+- cv best RMSE: 4.4217, median: 5.0414, p10: 4.6087
+- train: median 0.565s/fold, mean 0.918s, p90 2.310s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.570 |
+| `feature_fraction` | 0.112 |
+| `learning_rate` | 0.110 |
+| `mixture_r_smoothing` | 0.038 |
+| `mixture_diversity_lambda` | 0.033 |
+| `min_data_in_leaf` | 0.032 |
+| `num_leaves` | 0.016 |
+| `mixture_e_step_mode` | 0.016 |
+| `max_depth` | 0.016 |
+| `mixture_init` | 0.014 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.2636 (n=262) | leaf_reuse | Δ +2.7178 | p=0.00e+00 |
+| `mixture_routing_mode` | **token_choice** | 5.5149 (n=251) | expert_choice | Δ +0.8190 | p=2.20e-05 |
+| `mixture_e_step_mode` | **em** | 5.2991 (n=202) | loss_only | Δ +0.8846 | p=0.00e+00 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 262 | 5.2636 | 0.9013 | 4.4217 |
+| leaf_reuse | 19 | 7.9814 | 1.2613 | 5.7873 |
+| none | 19 | 8.6258 | 2.0513 | 6.0807 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 251 | 5.5149 | 1.4782 | 4.4217 |
+| expert_choice | 49 | 6.3339 | 1.0856 | 4.5473 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 202 | 5.2991 | 1.3582 | 4.4217 |
+| loss_only | 84 | 6.1837 | 1.2667 | 4.9817 |
+| gate_only | 14 | 7.4824 | 1.4744 | 5.5663 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 86 | 5.3702 | 1.4434 | 4.4594 |
+| gmm | 171 | 5.5640 | 1.4785 | 4.4217 |
+| uniform | 29 | 6.4585 | 0.9675 | 5.5425 |
+| random | 14 | 6.7165 | 0.8732 | 5.4890 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 174 | 5.3828 | 1.4454 | 4.4217 |
+| none | 69 | 5.8352 | 1.4815 | 4.4607 |
+| ema | 57 | 6.2344 | 1.2172 | 5.0315 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 220 | 5.5453 | 1.4356 | 4.4217 |
+| False | 80 | 5.9329 | 1.4638 | 4.4607 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 198 | 5.3223 | 1.4170 | 4.4217 |
+| False | 102 | 6.2821 | 1.3065 | 4.9817 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 5.7359 | — | 5.5829 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 5.3194 | 5.3261 | 5.6359 | 6.3133 | **Q1** [None, 0.1011] |
+| `mixture_warmup_iters` | 6.1503 | 5.9056 | 5.3849 | 5.2377 | **Q4** [44.0, ∞) |
+| `mixture_balance_factor` | 5.8508 | 6.3514 | 5.4501 | 5.2388 | **Q4** [9.0, ∞) |
+| `learning_rate` | 6.5120 | 5.3879 | 5.2027 | 5.4921 | **Q3** [0.2279, 0.2575] |
+| `num_leaves` | 6.3066 | 5.3795 | 5.3044 | 5.5983 | **Q3** [73.0, 82.0] |
+| `max_depth` | 6.3585 | 6.1610 | 5.2843 | 5.3388 | **Q3** [11.0, 12.0] |
+| `min_data_in_leaf` | 5.1412 | 5.3353 | 5.4514 | 6.6116 | **Q1** [None, 8.0] |
+
+#### E. Slice plot
+
+![synthetic@s42/moe](slice_synthetic@s42_moe.png)
+
+
+---
+
+## synthetic@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 5.15155** (winner retrained in 0.18s, cv score of winner: 5.5380)
+- cv best RMSE: 5.5380, median: 5.8312, p10: 5.6698
+- train: median 0.099s/fold, mean 0.095s, p90 0.139s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.699 |
+| `learning_rate` | 0.153 |
+| `bagging_fraction` | 0.059 |
+| `feature_fraction` | 0.042 |
+| `bagging_freq` | 0.021 |
+| `max_depth` | 0.011 |
+| `num_leaves` | 0.007 |
+| `extra_trees` | 0.003 |
+| `lambda_l1` | 0.002 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 256 | 5.9714 | 0.4971 | 5.5380 |
+| False | 44 | 6.4221 | 0.7100 | 5.7045 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.4069 | 5.8382 | 5.9328 | 5.9722 | **Q2** [0.1026, 0.1194] |
+| `num_leaves` | 6.3075 | 5.9478 | 5.9577 | 5.9388 | **Q4** [121.0, ∞) |
+| `max_depth` | 6.2932 | — | — | 5.9612 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | — | 5.7937 | 5.9089 | 6.5790 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 6.2461 | 5.9448 | 5.9221 | 6.0371 | **Q3** [0.0012, 0.0059] |
+| `lambda_l2` | 6.0309 | 5.9283 | 5.8122 | 6.3787 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 6.4122 | 5.9660 | 5.8785 | 5.8934 | **Q3** [0.9478, 0.969] |
+| `bagging_fraction` | 6.1562 | 5.9145 | 6.0390 | 6.0404 | **Q2** [0.8748, 0.9009] |
+
+#### E. Slice plot
+
+![synthetic@s43/naive-lightgbm](slice_synthetic@s43_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 4.20386** (winner retrained in 0.77s, cv score of winner: 5.4878)
+- cv best RMSE: 5.4878, median: 5.7482, p10: 5.5967
+- train: median 0.452s/fold, mean 0.408s, p90 0.613s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.815 |
+| `feature_fraction` | 0.066 |
+| `bagging_fraction` | 0.040 |
+| `max_depth` | 0.028 |
+| `learning_rate` | 0.017 |
+| `bagging_freq` | 0.011 |
+| `extra_trees` | 0.011 |
+| `num_leaves` | 0.005 |
+| `n_models` | 0.004 |
+| `lambda_l2` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 5.9243 | 0.4901 | 5.4878 |
+| True | 22 | 6.8062 | 1.0188 | 5.8158 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.1657 | 5.8619 | 5.8495 | 6.0787 | **Q3** [0.0386, 0.0479] |
+| `num_leaves` | 6.0424 | 5.7672 | 5.9783 | 6.1498 | **Q2** [45.0, 50.0] |
+| `max_depth` | 6.5915 | — | 5.9116 | 5.9378 | **Q3** [7.0, 10.0] |
+| `min_data_in_leaf` | — | 5.7720 | 5.8312 | 6.5518 | **Q2** [5.0, 7.5] |
+| `lambda_l1` | 6.1045 | 5.9138 | 6.0027 | 5.9347 | **Q2** [0.0036, 0.0555] |
+| `lambda_l2` | 6.0069 | 5.8189 | 6.0567 | 6.0732 | **Q2** [0.0001, 0.0009] |
+| `feature_fraction` | 6.4252 | 5.7921 | 5.7286 | 6.0099 | **Q3** [0.9296, 0.9526] |
+| `bagging_fraction` | 6.1859 | 5.8332 | 5.8762 | 6.0605 | **Q2** [0.8334, 0.8678] |
+
+#### E. Slice plot
+
+![synthetic@s43/naive-ensemble](slice_synthetic@s43_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 3.73416** (winner retrained in 0.24s, cv score of winner: 4.3519)
+- cv best RMSE: 4.3519, median: 5.1719, p10: 4.6125
+- train: median 0.189s/fold, mean 0.247s, p90 0.331s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.694 |
+| `mixture_r_smoothing` | 0.091 |
+| `feature_fraction` | 0.040 |
+| `learning_rate` | 0.034 |
+| `mixture_e_step_mode` | 0.025 |
+| `lambda_l2` | 0.022 |
+| `mixture_init` | 0.020 |
+| `mixture_diversity_lambda` | 0.019 |
+| `bagging_fraction` | 0.014 |
+| `num_leaves` | 0.007 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.2965 (n=268) | leaf_reuse | Δ +2.1759 | p=2.00e-06 |
+| `mixture_routing_mode` | **token_choice** | 5.5015 (n=257) | expert_choice | Δ +1.0540 | p=9.00e-06 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 268 | 5.2965 | 0.7643 | 4.3519 |
+| leaf_reuse | 16 | 7.4724 | 1.1596 | 6.1096 |
+| none | 16 | 9.7962 | 1.7112 | 6.9344 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 257 | 5.5015 | 1.3577 | 4.3519 |
+| expert_choice | 43 | 6.5555 | 1.2935 | 5.3140 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 158 | 5.4934 | 1.4800 | 4.3519 |
+| gate_only | 107 | 5.6985 | 1.2310 | 4.6636 |
+| em | 35 | 6.2308 | 1.3358 | 4.9673 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 256 | 5.4714 | 1.3354 | 4.3519 |
+| tree_hierarchical | 15 | 6.4194 | 1.8426 | 4.7199 |
+| random | 15 | 6.8514 | 1.0270 | 5.6138 |
+| uniform | 14 | 6.8599 | 0.5419 | 5.9351 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 202 | 5.4849 | 1.4818 | 4.4695 |
+| ema | 52 | 5.9132 | 1.0276 | 4.9673 |
+| markov | 46 | 6.0941 | 1.2334 | 4.3519 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 253 | 5.5443 | 1.4285 | 4.3519 |
+| False | 47 | 6.2356 | 1.0454 | 4.9673 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 242 | 5.4907 | 1.3538 | 4.3519 |
+| False | 58 | 6.3279 | 1.3788 | 4.9673 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 5.4289 | 6.0378 | 5.7574 | **Q2** [2.0, 3.0] |
+| `mixture_diversity_lambda` | 5.5879 | 5.4439 | 5.4403 | 6.1381 | **Q3** [0.1756, 0.2369] |
+| `mixture_warmup_iters` | 5.8324 | 5.6598 | 5.5643 | 5.5588 | **Q4** [47.0, ∞) |
+| `mixture_balance_factor` | 6.0687 | 5.8410 | 5.5705 | 5.3730 | **Q4** [8.0, ∞) |
+| `learning_rate` | 6.2725 | 5.4645 | 5.4221 | 5.4511 | **Q3** [0.1913, 0.2321] |
+| `num_leaves` | 5.9291 | 5.5109 | 5.5470 | 5.6210 | **Q2** [87.0, 107.0] |
+| `max_depth` | 5.9318 | 5.6242 | — | 5.5781 | **Q4** [7.0, ∞) |
+| `min_data_in_leaf` | 5.2794 | 5.4864 | 5.5128 | 6.2745 | **Q1** [None, 9.0] |
+
+#### E. Slice plot
+
+![synthetic@s43/moe](slice_synthetic@s43_moe.png)
+
+
+---
+
+## synthetic@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 4.93679** (winner retrained in 0.24s, cv score of winner: 5.8019)
+- cv best RMSE: 5.8019, median: 6.1616, p10: 5.9403
+- train: median 0.093s/fold, mean 0.090s, p90 0.142s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.883 |
+| `learning_rate` | 0.061 |
+| `feature_fraction` | 0.015 |
+| `extra_trees` | 0.012 |
+| `bagging_fraction` | 0.010 |
+| `max_depth` | 0.007 |
+| `num_leaves` | 0.005 |
+| `lambda_l2` | 0.003 |
+| `lambda_l1` | 0.002 |
+| `bagging_freq` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 6.3322 | 0.5460 | 5.8019 |
+| True | 20 | 7.2502 | 0.9051 | 6.1956 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.6490 | 6.1474 | 6.2803 | 6.4967 | **Q2** [0.04, 0.0469] |
+| `num_leaves` | 6.8672 | 6.1468 | 6.3410 | 6.2123 | **Q2** [84.75, 98.0] |
+| `max_depth` | 6.8683 | 6.4367 | — | 6.2094 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 6.1255 | 6.1508 | 6.1991 | 7.0654 | **Q1** [None, 7.0] |
+| `lambda_l1` | 6.8510 | 6.3558 | 6.1514 | 6.2152 | **Q3** [1.2129, 3.1615] |
+| `lambda_l2` | 6.2652 | 6.2468 | 6.4952 | 6.5662 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.8683 | 6.2573 | 6.2016 | 6.2462 | **Q3** [0.9281, 0.955] |
+| `bagging_fraction` | 6.3800 | 6.2264 | 6.3471 | 6.6200 | **Q2** [0.5741, 0.6123] |
+
+#### E. Slice plot
+
+![synthetic@s44/naive-lightgbm](slice_synthetic@s44_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 5.09358** (winner retrained in 0.57s, cv score of winner: 5.5894)
+- cv best RMSE: 5.5894, median: 5.8602, p10: 5.6519
+- train: median 0.276s/fold, mean 0.263s, p90 0.434s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.573 |
+| `learning_rate` | 0.279 |
+| `feature_fraction` | 0.070 |
+| `bagging_fraction` | 0.021 |
+| `max_depth` | 0.016 |
+| `extra_trees` | 0.012 |
+| `n_models` | 0.012 |
+| `num_leaves` | 0.011 |
+| `bagging_freq` | 0.006 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 216 | 5.9411 | 0.5217 | 5.5894 |
+| True | 84 | 6.4898 | 0.6846 | 5.8148 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.3443 | 5.8764 | 6.0718 | 6.0864 | **Q2** [0.0808, 0.1071] |
+| `num_leaves` | 6.5896 | 6.1207 | 5.8756 | 5.8012 | **Q4** [123.0, ∞) |
+| `max_depth` | 6.7148 | 5.9937 | — | 5.9191 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 5.8144 | 5.7974 | 5.9017 | 6.7552 | **Q2** [7.0, 8.0] |
+| `lambda_l1` | 6.3266 | 5.9704 | 5.9226 | 6.1592 | **Q3** [0.0001, 0.0022] |
+| `lambda_l2` | 6.0433 | 5.9823 | 6.0762 | 6.2772 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.6091 | 5.8285 | 5.9776 | 5.9637 | **Q2** [0.9032, 0.9279] |
+| `bagging_fraction` | 6.4481 | 5.9652 | 5.8783 | 6.0873 | **Q3** [0.8834, 0.9219] |
+
+#### E. Slice plot
+
+![synthetic@s44/naive-ensemble](slice_synthetic@s44_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 4.23773** (winner retrained in 0.26s, cv score of winner: 4.5527)
+- cv best RMSE: 4.5527, median: 4.9532, p10: 4.6572
+- train: median 0.226s/fold, mean 0.283s, p90 0.383s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.577 |
+| `learning_rate` | 0.105 |
+| `mixture_init` | 0.066 |
+| `min_data_in_leaf` | 0.051 |
+| `extra_trees` | 0.035 |
+| `mixture_warmup_iters` | 0.034 |
+| `mixture_diversity_lambda` | 0.031 |
+| `num_leaves` | 0.013 |
+| `lambda_l2` | 0.013 |
+| `max_depth` | 0.012 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.2099 (n=266) | leaf_reuse | Δ +2.3475 | p=0.00e+00 |
+| `mixture_routing_mode` | **expert_choice** | 5.3759 (n=262) | token_choice | Δ +1.4336 | p=0.00e+00 |
+| `mixture_e_step_mode` | **em** | 5.2375 (n=209) | loss_only | Δ +0.8062 | p=2.23e-04 |
+| `mixture_init` | **gmm** | 5.2887 (n=243) | tree_hierarchical | Δ +1.2040 | p=1.00e-06 |
+| `mixture_r_smoothing` | **markov** | 5.2904 (n=207) | none | Δ +0.6017 | p=1.41e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 266 | 5.2099 | 0.7610 | 4.5527 |
+| leaf_reuse | 17 | 7.5574 | 1.1510 | 5.8350 |
+| none | 17 | 8.9971 | 1.6482 | 6.0393 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 262 | 5.3759 | 1.2128 | 4.5527 |
+| token_choice | 38 | 6.8095 | 1.3616 | 4.6746 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 209 | 5.2375 | 1.1417 | 4.5527 |
+| loss_only | 59 | 6.0437 | 1.4674 | 4.8819 |
+| gate_only | 32 | 6.7515 | 1.1670 | 4.6687 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 243 | 5.2887 | 1.2267 | 4.5527 |
+| tree_hierarchical | 28 | 6.4927 | 0.9653 | 4.8765 |
+| random | 15 | 6.8086 | 0.9539 | 5.9806 |
+| uniform | 14 | 7.0125 | 1.2947 | 5.8111 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 207 | 5.2904 | 1.2501 | 4.5527 |
+| none | 63 | 5.8921 | 1.2692 | 4.8819 |
+| ema | 30 | 6.6982 | 1.1284 | 4.8327 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 264 | 5.3551 | 1.1660 | 4.5527 |
+| True | 36 | 7.0418 | 1.4433 | 4.7372 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 264 | 5.3828 | 1.2507 | 4.5527 |
+| True | 36 | 6.8388 | 1.1043 | 4.7632 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 6.8096 | — | — | 5.4486 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 5.6744 | 5.3777 | 5.4219 | 5.7560 | **Q2** [0.1999, 0.233] |
+| `mixture_warmup_iters` | 6.3596 | 5.6476 | 5.3026 | 5.0661 | **Q4** [48.0, ∞) |
+| `mixture_balance_factor` | — | — | 5.2479 | 6.1768 | **Q3** [2.0, 3.0] |
+| `learning_rate` | 5.8129 | 5.2172 | 5.2922 | 5.9078 | **Q2** [0.0645, 0.0761] |
+| `num_leaves` | 5.0925 | 5.2305 | 5.7727 | 6.1188 | **Q1** [None, 12.0] |
+| `max_depth` | 5.8415 | 6.1093 | 5.4593 | 5.1543 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 5.7206 | 5.3179 | 5.2960 | 5.8497 | **Q3** [22.0, 29.0] |
+
+#### E. Slice plot
+
+![synthetic@s44/moe](slice_synthetic@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| synthetic@s42 | `mixture_gate_type` | **gbdt** | +2.7178 | 0.00e+00 |
+| synthetic@s42 | `mixture_routing_mode` | **token_choice** | +0.8190 | 2.20e-05 |
+| synthetic@s42 | `mixture_e_step_mode` | **em** | +0.8846 | 0.00e+00 |
+| synthetic@s43 | `mixture_gate_type` | **gbdt** | +2.1759 | 2.00e-06 |
+| synthetic@s43 | `mixture_routing_mode` | **token_choice** | +1.0540 | 9.00e-06 |
+| synthetic@s44 | `mixture_gate_type` | **gbdt** | +2.3475 | 0.00e+00 |
+| synthetic@s44 | `mixture_routing_mode` | **expert_choice** | +1.4336 | 0.00e+00 |
+| synthetic@s44 | `mixture_e_step_mode` | **em** | +0.8062 | 2.23e-04 |
+| synthetic@s44 | `mixture_init` | **gmm** | +1.2040 | 1.00e-06 |
+| synthetic@s44 | `mixture_r_smoothing` | **markov** | +0.6017 | 1.41e-03 |

--- a/bench_results/meth2_v081/ds_synthetic_summary.json
+++ b/bench_results/meth2_v081/ds_synthetic_summary.json
@@ -1,0 +1,3801 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "synthetic"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "0cf3634c544c8f91ada2261bdf448aad9bd4b491",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "synthetic": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 4.347658266639995,
+      "cv_best": 5.3380991356020875,
+      "crash_rate": 0.0,
+      "retrain_s": 0.18
+     },
+     "43": {
+      "holdout_rmse": 5.15155263864032,
+      "cv_best": 5.538030049821659,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1765
+     },
+     "44": {
+      "holdout_rmse": 4.936794793854299,
+      "cv_best": 5.801861659134396,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2427
+     }
+    },
+    "holdout_mean": 4.812002,
+    "holdout_std": 0.339845,
+    "cv_best_mean": 5.55933
+   },
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 4.821196721709856,
+      "cv_best": 5.326624341812762,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2529
+     },
+     "43": {
+      "holdout_rmse": 4.203863002044247,
+      "cv_best": 5.487799793636554,
+      "crash_rate": 0.0,
+      "retrain_s": 0.7659
+     },
+     "44": {
+      "holdout_rmse": 5.093577629961736,
+      "cv_best": 5.589397099049719,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5676
+     }
+    },
+    "holdout_mean": 4.706212,
+    "holdout_std": 0.372213,
+    "cv_best_mean": 5.46794
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 3.5524698013242006,
+      "cv_best": 4.421711535281688,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4468
+     },
+     "43": {
+      "holdout_rmse": 3.734158192240332,
+      "cv_best": 4.351931974318985,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2427
+     },
+     "44": {
+      "holdout_rmse": 4.237730513105575,
+      "cv_best": 4.55270834426117,
+      "crash_rate": 0.0,
+      "retrain_s": 0.264
+     }
+    },
+    "holdout_mean": 3.841453,
+    "holdout_std": 0.289862,
+    "cv_best_mean": 4.442117
+   }
+  }
+ },
+ "runs": {
+  "synthetic@s42": {
+   "dataset": "synthetic",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -1.1238261010719193,
+    "std": 12.024415840059472
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.3380991356020875,
+    "rmse_p10": 5.417855251283722,
+    "rmse_median": 5.561809105917167,
+    "train_s_median": 0.1369840048253536,
+    "train_s_mean": 0.12659160814061762,
+    "train_s_p90": 0.17215026464313268,
+    "best_params": {
+     "learning_rate": 0.05929790561270315,
+     "num_leaves": 36,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.16280342621975077,
+     "lambda_l2": 0.0005784736031637255,
+     "feature_fraction": 0.966030446363386,
+     "bagging_fraction": 0.6679177387820032,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5575,
+     "learning_rate": 0.306,
+     "feature_fraction": 0.0721,
+     "extra_trees": 0.0379,
+     "bagging_fraction": 0.012,
+     "bagging_freq": 0.0072,
+     "num_leaves": 0.0058,
+     "max_depth": 0.0011,
+     "lambda_l1": 0.0005,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 7.1469,
+        "std": 1.5229,
+        "min": 5.6091
+       },
+       "False": {
+        "n": 278,
+        "mean": 5.7325,
+        "std": 0.4837,
+        "min": 5.3381
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.4144,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0423
+       ],
+       "n": 75,
+       "mean_rmse": 6.1776
+      },
+      "Q2": {
+       "range": [
+        0.0423,
+        0.0493
+       ],
+       "n": 75,
+       "mean_rmse": 5.6327
+      },
+      "Q3": {
+       "range": [
+        0.0493,
+        0.0602
+       ],
+       "n": 75,
+       "mean_rmse": 5.6468
+      },
+      "Q4": {
+       "range": [
+        0.0602,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.8878
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 67,
+       "mean_rmse": 5.6674
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        33.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.7401
+      },
+      "Q3": {
+       "range": [
+        33.0,
+        50.25
+       ],
+       "n": 83,
+       "mean_rmse": 5.6393
+      },
+      "Q4": {
+       "range": [
+        50.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.3012
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 42,
+       "mean_rmse": 6.514
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 48,
+       "mean_rmse": 5.7722
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 210,
+       "mean_rmse": 5.7153
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 72,
+       "mean_rmse": 5.5472
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 5.5529
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 88,
+       "mean_rmse": 5.6386
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 6.5512
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0095
+       ],
+       "n": 75,
+       "mean_rmse": 6.3199
+      },
+      "Q2": {
+       "range": [
+        0.0095,
+        0.4952
+       ],
+       "n": 75,
+       "mean_rmse": 5.726
+      },
+      "Q3": {
+       "range": [
+        0.4952,
+        2.3125
+       ],
+       "n": 75,
+       "mean_rmse": 5.6546
+      },
+      "Q4": {
+       "range": [
+        2.3125,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.6443
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.7133
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.6388
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.9086
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0841
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9316
+       ],
+       "n": 75,
+       "mean_rmse": 6.3681
+      },
+      "Q2": {
+       "range": [
+        0.9316,
+        0.9681
+       ],
+       "n": 75,
+       "mean_rmse": 5.6852
+      },
+      "Q3": {
+       "range": [
+        0.9681,
+        0.9868
+       ],
+       "n": 75,
+       "mean_rmse": 5.6903
+      },
+      "Q4": {
+       "range": [
+        0.9868,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.6013
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6994
+       ],
+       "n": 75,
+       "mean_rmse": 5.7752
+      },
+      "Q2": {
+       "range": [
+        0.6994,
+        0.7301
+       ],
+       "n": 75,
+       "mean_rmse": 5.665
+      },
+      "Q3": {
+       "range": [
+        0.7301,
+        0.8577
+       ],
+       "n": 75,
+       "mean_rmse": 5.8987
+      },
+      "Q4": {
+       "range": [
+        0.8577,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.006
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 196.1,
+    "holdout": {
+     "holdout_rmse": 4.347658266639995,
+     "retrain_s": 0.18,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 5.3380991356020875
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.326624341812762,
+    "rmse_p10": 5.421818930493713,
+    "rmse_median": 5.643503477090741,
+    "train_s_median": 0.23400812707841395,
+    "train_s_mean": 0.24149472016096116,
+    "train_s_p90": 0.36093783572316174,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.11090639893191091,
+     "num_leaves": 27,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.019884080879387818,
+     "lambda_l2": 2.189834573881939e-06,
+     "feature_fraction": 0.9888469815051854,
+     "bagging_fraction": 0.7806767932682953,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.7714,
+     "learning_rate": 0.1674,
+     "bagging_fraction": 0.0179,
+     "bagging_freq": 0.014,
+     "feature_fraction": 0.0131,
+     "max_depth": 0.0066,
+     "extra_trees": 0.0042,
+     "num_leaves": 0.0035,
+     "lambda_l1": 0.0016,
+     "n_models": 0.0003,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 50,
+        "mean": 6.1501,
+        "std": 0.6342,
+        "min": 5.3736
+       },
+       "True": {
+        "n": 250,
+        "mean": 5.8537,
+        "std": 0.7006,
+        "min": 5.3266
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.2964,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1005
+       ],
+       "n": 75,
+       "mean_rmse": 6.316
+      },
+      "Q2": {
+       "range": [
+        0.1005,
+        0.1213
+       ],
+       "n": 75,
+       "mean_rmse": 5.5465
+      },
+      "Q3": {
+       "range": [
+        0.1213,
+        0.1675
+       ],
+       "n": 75,
+       "mean_rmse": 5.8407
+      },
+      "Q4": {
+       "range": [
+        0.1675,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.9091
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        29.0
+       ],
+       "n": 67,
+       "mean_rmse": 5.6761
+      },
+      "Q2": {
+       "range": [
+        29.0,
+        68.0
+       ],
+       "n": 81,
+       "mean_rmse": 5.9371
+      },
+      "Q3": {
+       "range": [
+        68.0,
+        102.25
+       ],
+       "n": 77,
+       "mean_rmse": 6.0086
+      },
+      "Q4": {
+       "range": [
+        102.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.961
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 73,
+       "mean_rmse": 6.1669
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 44,
+       "mean_rmse": 5.9259
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 183,
+       "mean_rmse": 5.7924
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 149,
+       "mean_rmse": 5.5474
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.7937
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 6.6627
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.0419
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.8762
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0141
+       ],
+       "n": 75,
+       "mean_rmse": 5.9732
+      },
+      "Q4": {
+       "range": [
+        0.0141,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.7211
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.0263
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.5534
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.9131
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.1196
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9013
+       ],
+       "n": 75,
+       "mean_rmse": 6.3067
+      },
+      "Q2": {
+       "range": [
+        0.9013,
+        0.9355
+       ],
+       "n": 75,
+       "mean_rmse": 5.7731
+      },
+      "Q3": {
+       "range": [
+        0.9355,
+        0.974
+       ],
+       "n": 75,
+       "mean_rmse": 5.9482
+      },
+      "Q4": {
+       "range": [
+        0.974,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.5844
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6595
+       ],
+       "n": 75,
+       "mean_rmse": 6.1215
+      },
+      "Q2": {
+       "range": [
+        0.6595,
+        0.7698
+       ],
+       "n": 75,
+       "mean_rmse": 5.8272
+      },
+      "Q3": {
+       "range": [
+        0.7698,
+        0.7935
+       ],
+       "n": 75,
+       "mean_rmse": 5.5425
+      },
+      "Q4": {
+       "range": [
+        0.7935,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.1212
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 368.3,
+    "holdout": {
+     "holdout_rmse": 4.821196721709856,
+     "retrain_s": 0.2529,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 5.326624341812762
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 4.421711535281688,
+    "rmse_p10": 4.608747957480441,
+    "rmse_median": 5.041448653492553,
+    "train_s_median": 0.5647465808317065,
+    "train_s_mean": 0.9180965382729968,
+    "train_s_p90": 2.3098322222381835,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.2436959190899921,
+     "num_leaves": 77,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 6.969409575319894e-07,
+     "lambda_l2": 2.3504709268365284e-06,
+     "feature_fraction": 0.6223393186558759,
+     "bagging_fraction": 0.5969904682370601,
+     "bagging_freq": 6,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 49,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.20057972496169563,
+     "mixture_diversity_lambda": 0.06926041310550907,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 5,
+     "mixture_gate_learning_rate": 0.130472888618824,
+     "mixture_gate_lambda_l2": 1.8386634258409689,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.4571367221867447,
+     "mixture_refit_every_n": 17,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.5703,
+     "feature_fraction": 0.1115,
+     "learning_rate": 0.1097,
+     "mixture_r_smoothing": 0.0384,
+     "mixture_diversity_lambda": 0.0326,
+     "min_data_in_leaf": 0.032,
+     "num_leaves": 0.0164,
+     "mixture_e_step_mode": 0.016,
+     "max_depth": 0.0159,
+     "mixture_init": 0.0144,
+     "bagging_freq": 0.0111,
+     "mixture_balance_factor": 0.0087,
+     "mixture_warmup_iters": 0.0082,
+     "bagging_fraction": 0.0056,
+     "mixture_hard_m_step": 0.0055,
+     "mixture_routing_mode": 0.0009,
+     "lambda_l2": 0.0009,
+     "mixture_num_experts": 0.0007,
+     "mixture_refit_leaves": 0.0005,
+     "lambda_l1": 0.0004,
+     "extra_trees": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 19,
+        "mean": 7.9814,
+        "std": 1.2613,
+        "min": 5.7873
+       },
+       "none": {
+        "n": 19,
+        "mean": 8.6258,
+        "std": 2.0513,
+        "min": 6.0807
+       },
+       "gbdt": {
+        "n": 262,
+        "mean": 5.2636,
+        "std": 0.9013,
+        "min": 4.4217
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 2.7178,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 251,
+        "mean": 5.5149,
+        "std": 1.4782,
+        "min": 4.4217
+       },
+       "expert_choice": {
+        "n": 49,
+        "mean": 6.3339,
+        "std": 1.0856,
+        "min": 4.5473
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.819,
+       "p_value": 2.2e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 84,
+        "mean": 6.1837,
+        "std": 1.2667,
+        "min": 4.9817
+       },
+       "gate_only": {
+        "n": 14,
+        "mean": 7.4824,
+        "std": 1.4744,
+        "min": 5.5663
+       },
+       "em": {
+        "n": 202,
+        "mean": 5.2991,
+        "std": 1.3582,
+        "min": 4.4217
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.8846,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 14,
+        "mean": 6.7165,
+        "std": 0.8732,
+        "min": 5.489
+       },
+       "gmm": {
+        "n": 171,
+        "mean": 5.564,
+        "std": 1.4785,
+        "min": 4.4217
+       },
+       "tree_hierarchical": {
+        "n": 86,
+        "mean": 5.3702,
+        "std": 1.4434,
+        "min": 4.4594
+       },
+       "uniform": {
+        "n": 29,
+        "mean": 6.4585,
+        "std": 0.9675,
+        "min": 5.5425
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "gmm",
+       "delta_mean": 0.1938,
+       "p_value": 0.317567,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 57,
+        "mean": 6.2344,
+        "std": 1.2172,
+        "min": 5.0315
+       },
+       "markov": {
+        "n": 174,
+        "mean": 5.3828,
+        "std": 1.4454,
+        "min": 4.4217
+       },
+       "none": {
+        "n": 69,
+        "mean": 5.8352,
+        "std": 1.4815,
+        "min": 4.4607
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.4524,
+       "p_value": 0.033715,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 220,
+        "mean": 5.5453,
+        "std": 1.4356,
+        "min": 4.4217
+       },
+       "False": {
+        "n": 80,
+        "mean": 5.9329,
+        "std": 1.4638,
+        "min": 4.4607
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.3876,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 198,
+        "mean": 5.3223,
+        "std": 1.417,
+        "min": 4.4217
+       },
+       "False": {
+        "n": 102,
+        "mean": 6.2821,
+        "std": 1.3065,
+        "min": 4.9817
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.9598,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        4.0
+       ],
+       "n": 129,
+       "mean_rmse": 5.7359
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 171,
+       "mean_rmse": 5.5829
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1011
+       ],
+       "n": 75,
+       "mean_rmse": 5.3194
+      },
+      "Q2": {
+       "range": [
+        0.1011,
+        0.1325
+       ],
+       "n": 75,
+       "mean_rmse": 5.3261
+      },
+      "Q3": {
+       "range": [
+        0.1325,
+        0.239
+       ],
+       "n": 75,
+       "mean_rmse": 5.6359
+      },
+      "Q4": {
+       "range": [
+        0.239,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.3133
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 73,
+       "mean_rmse": 6.1503
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        32.0
+       ],
+       "n": 67,
+       "mean_rmse": 5.9056
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        44.0
+       ],
+       "n": 81,
+       "mean_rmse": 5.3849
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 5.2377
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 61,
+       "mean_rmse": 5.8508
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        8.0
+       ],
+       "n": 65,
+       "mean_rmse": 6.3514
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 63,
+       "mean_rmse": 5.4501
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 111,
+       "mean_rmse": 5.2388
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.181
+       ],
+       "n": 75,
+       "mean_rmse": 6.512
+      },
+      "Q2": {
+       "range": [
+        0.181,
+        0.2279
+       ],
+       "n": 75,
+       "mean_rmse": 5.3879
+      },
+      "Q3": {
+       "range": [
+        0.2279,
+        0.2575
+       ],
+       "n": 75,
+       "mean_rmse": 5.2027
+      },
+      "Q4": {
+       "range": [
+        0.2575,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.4921
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        57.75
+       ],
+       "n": 75,
+       "mean_rmse": 6.3066
+      },
+      "Q2": {
+       "range": [
+        57.75,
+        73.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.3795
+      },
+      "Q3": {
+       "range": [
+        73.0,
+        82.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.3044
+      },
+      "Q4": {
+       "range": [
+        82.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 5.5983
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 67,
+       "mean_rmse": 6.3585
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 36,
+       "mean_rmse": 6.161
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 91,
+       "mean_rmse": 5.2843
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 106,
+       "mean_rmse": 5.3388
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 68,
+       "mean_rmse": 5.1412
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 68,
+       "mean_rmse": 5.3353
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        24.0
+       ],
+       "n": 88,
+       "mean_rmse": 5.4514
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 6.6116
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 1391.9,
+    "holdout": {
+     "holdout_rmse": 3.5524698013242006,
+     "retrain_s": 0.4468,
+     "predict_s": 0.0028,
+     "cv_rmse_of_winner": 4.421711535281688
+    }
+   }
+  },
+  "synthetic@s43": {
+   "dataset": "synthetic",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.875910802699441,
+    "std": 11.885024346049207
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.538030049821659,
+    "rmse_p10": 5.6697810332661875,
+    "rmse_median": 5.831239336433313,
+    "train_s_median": 0.0988443261012435,
+    "train_s_mean": 0.0948454379575948,
+    "train_s_p90": 0.13932523675262934,
+    "best_params": {
+     "learning_rate": 0.11323766572590263,
+     "num_leaves": 126,
+     "max_depth": 8,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.0543552575190996e-05,
+     "lambda_l2": 3.2699268648303626e-08,
+     "feature_fraction": 0.916284747594103,
+     "bagging_fraction": 0.9452386259835922,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6991,
+     "learning_rate": 0.1534,
+     "bagging_fraction": 0.0586,
+     "feature_fraction": 0.0417,
+     "bagging_freq": 0.021,
+     "max_depth": 0.0115,
+     "num_leaves": 0.0074,
+     "extra_trees": 0.0034,
+     "lambda_l1": 0.0022,
+     "lambda_l2": 0.0017
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 256,
+        "mean": 5.9714,
+        "std": 0.4971,
+        "min": 5.538
+       },
+       "False": {
+        "n": 44,
+        "mean": 6.4221,
+        "std": 0.71,
+        "min": 5.7045
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.4507,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1026
+       ],
+       "n": 75,
+       "mean_rmse": 6.4069
+      },
+      "Q2": {
+       "range": [
+        0.1026,
+        0.1194
+       ],
+       "n": 75,
+       "mean_rmse": 5.8382
+      },
+      "Q3": {
+       "range": [
+        0.1194,
+        0.1399
+       ],
+       "n": 75,
+       "mean_rmse": 5.9328
+      },
+      "Q4": {
+       "range": [
+        0.1399,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.9722
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        97.75
+       ],
+       "n": 75,
+       "mean_rmse": 6.3075
+      },
+      "Q2": {
+       "range": [
+        97.75,
+        116.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.9478
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        121.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.9577
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 84,
+       "mean_rmse": 5.9388
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 69,
+       "mean_rmse": 6.2932
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 231,
+       "mean_rmse": 5.9612
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 142,
+       "mean_rmse": 5.7937
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 76,
+       "mean_rmse": 5.9089
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 6.579
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.2461
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0012
+       ],
+       "n": 75,
+       "mean_rmse": 5.9448
+      },
+      "Q3": {
+       "range": [
+        0.0012,
+        0.0059
+       ],
+       "n": 75,
+       "mean_rmse": 5.9221
+      },
+      "Q4": {
+       "range": [
+        0.0059,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0371
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.0309
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.9283
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.8122
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.3787
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.917
+       ],
+       "n": 75,
+       "mean_rmse": 6.4122
+      },
+      "Q2": {
+       "range": [
+        0.917,
+        0.9478
+       ],
+       "n": 75,
+       "mean_rmse": 5.966
+      },
+      "Q3": {
+       "range": [
+        0.9478,
+        0.969
+       ],
+       "n": 75,
+       "mean_rmse": 5.8785
+      },
+      "Q4": {
+       "range": [
+        0.969,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.8934
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8748
+       ],
+       "n": 75,
+       "mean_rmse": 6.1562
+      },
+      "Q2": {
+       "range": [
+        0.8748,
+        0.9009
+       ],
+       "n": 75,
+       "mean_rmse": 5.9145
+      },
+      "Q3": {
+       "range": [
+        0.9009,
+        0.9357
+       ],
+       "n": 75,
+       "mean_rmse": 6.039
+      },
+      "Q4": {
+       "range": [
+        0.9357,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0404
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 147.2,
+    "holdout": {
+     "holdout_rmse": 5.15155263864032,
+     "retrain_s": 0.1765,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 5.538030049821659
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.487799793636554,
+    "rmse_p10": 5.5966590728488885,
+    "rmse_median": 5.748201186872147,
+    "train_s_median": 0.45162642300128936,
+    "train_s_mean": 0.40807837056368595,
+    "train_s_p90": 0.6125712765753268,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.05072168938433422,
+     "num_leaves": 47,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.003783811973721335,
+     "lambda_l2": 1.2750912118501454e-05,
+     "feature_fraction": 0.9622267725060656,
+     "bagging_fraction": 0.8483559151256423,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8147,
+     "feature_fraction": 0.0658,
+     "bagging_fraction": 0.0402,
+     "max_depth": 0.0275,
+     "learning_rate": 0.017,
+     "bagging_freq": 0.0108,
+     "extra_trees": 0.0105,
+     "num_leaves": 0.0055,
+     "n_models": 0.004,
+     "lambda_l2": 0.0028,
+     "lambda_l1": 0.0011
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 5.9243,
+        "std": 0.4901,
+        "min": 5.4878
+       },
+       "True": {
+        "n": 22,
+        "mean": 6.8062,
+        "std": 1.0188,
+        "min": 5.8158
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.8819,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0335
+       ],
+       "n": 75,
+       "mean_rmse": 6.1657
+      },
+      "Q2": {
+       "range": [
+        0.0335,
+        0.0386
+       ],
+       "n": 75,
+       "mean_rmse": 5.8619
+      },
+      "Q3": {
+       "range": [
+        0.0386,
+        0.0479
+       ],
+       "n": 75,
+       "mean_rmse": 5.8495
+      },
+      "Q4": {
+       "range": [
+        0.0479,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0787
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        45.0
+       ],
+       "n": 73,
+       "mean_rmse": 6.0424
+      },
+      "Q2": {
+       "range": [
+        45.0,
+        50.0
+       ],
+       "n": 68,
+       "mean_rmse": 5.7672
+      },
+      "Q3": {
+       "range": [
+        50.0,
+        64.25
+       ],
+       "n": 84,
+       "mean_rmse": 5.9783
+      },
+      "Q4": {
+       "range": [
+        64.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.1498
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 31,
+       "mean_rmse": 6.5915
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 188,
+       "mean_rmse": 5.9116
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 5.9378
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.5
+       ],
+       "n": 150,
+       "mean_rmse": 5.772
+      },
+      "Q3": {
+       "range": [
+        7.5,
+        12.0
+       ],
+       "n": 72,
+       "mean_rmse": 5.8312
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 6.5518
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0036
+       ],
+       "n": 75,
+       "mean_rmse": 6.1045
+      },
+      "Q2": {
+       "range": [
+        0.0036,
+        0.0555
+       ],
+       "n": 75,
+       "mean_rmse": 5.9138
+      },
+      "Q3": {
+       "range": [
+        0.0555,
+        0.5546
+       ],
+       "n": 75,
+       "mean_rmse": 6.0027
+      },
+      "Q4": {
+       "range": [
+        0.5546,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.9347
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 6.0069
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0009
+       ],
+       "n": 75,
+       "mean_rmse": 5.8189
+      },
+      "Q3": {
+       "range": [
+        0.0009,
+        0.1593
+       ],
+       "n": 75,
+       "mean_rmse": 6.0567
+      },
+      "Q4": {
+       "range": [
+        0.1593,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0732
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9075
+       ],
+       "n": 75,
+       "mean_rmse": 6.4252
+      },
+      "Q2": {
+       "range": [
+        0.9075,
+        0.9296
+       ],
+       "n": 75,
+       "mean_rmse": 5.7921
+      },
+      "Q3": {
+       "range": [
+        0.9296,
+        0.9526
+       ],
+       "n": 75,
+       "mean_rmse": 5.7286
+      },
+      "Q4": {
+       "range": [
+        0.9526,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0099
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8334
+       ],
+       "n": 75,
+       "mean_rmse": 6.1859
+      },
+      "Q2": {
+       "range": [
+        0.8334,
+        0.8678
+       ],
+       "n": 75,
+       "mean_rmse": 5.8332
+      },
+      "Q3": {
+       "range": [
+        0.8678,
+        0.9141
+       ],
+       "n": 75,
+       "mean_rmse": 5.8762
+      },
+      "Q4": {
+       "range": [
+        0.9141,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0605
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 616.6,
+    "holdout": {
+     "holdout_rmse": 4.203863002044247,
+     "retrain_s": 0.7659,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 5.487799793636554
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 4.351931974318985,
+    "rmse_p10": 4.612497505771552,
+    "rmse_median": 5.171947768038198,
+    "train_s_median": 0.1886811813339591,
+    "train_s_mean": 0.24705465456843376,
+    "train_s_p90": 0.3307588834688068,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.15371908425878616,
+     "num_leaves": 80,
+     "max_depth": 5,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 0.0003942991016239768,
+     "lambda_l2": 9.986281346156969e-07,
+     "feature_fraction": 0.5784948319515553,
+     "bagging_fraction": 0.8759350553218791,
+     "bagging_freq": 3,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 18,
+     "mixture_balance_factor": 8,
+     "mixture_smoothing_lambda": 0.2545177783913543,
+     "mixture_diversity_lambda": 0.2409281785136666,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 18,
+     "mixture_gate_learning_rate": 0.2756069754750692,
+     "mixture_gate_lambda_l2": 0.0026277170595441373,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.6944,
+     "mixture_r_smoothing": 0.0914,
+     "feature_fraction": 0.0399,
+     "learning_rate": 0.0335,
+     "mixture_e_step_mode": 0.0245,
+     "lambda_l2": 0.0218,
+     "mixture_init": 0.0198,
+     "mixture_diversity_lambda": 0.0194,
+     "bagging_fraction": 0.014,
+     "num_leaves": 0.0069,
+     "mixture_num_experts": 0.0059,
+     "mixture_warmup_iters": 0.0057,
+     "min_data_in_leaf": 0.0046,
+     "bagging_freq": 0.0044,
+     "max_depth": 0.0041,
+     "mixture_balance_factor": 0.0033,
+     "mixture_routing_mode": 0.0019,
+     "extra_trees": 0.0017,
+     "mixture_hard_m_step": 0.0015,
+     "mixture_refit_leaves": 0.0009,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 268,
+        "mean": 5.2965,
+        "std": 0.7643,
+        "min": 4.3519
+       },
+       "none": {
+        "n": 16,
+        "mean": 9.7962,
+        "std": 1.7112,
+        "min": 6.9344
+       },
+       "leaf_reuse": {
+        "n": 16,
+        "mean": 7.4724,
+        "std": 1.1596,
+        "min": 6.1096
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 2.1759,
+       "p_value": 2e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 43,
+        "mean": 6.5555,
+        "std": 1.2935,
+        "min": 5.314
+       },
+       "token_choice": {
+        "n": 257,
+        "mean": 5.5015,
+        "std": 1.3577,
+        "min": 4.3519
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 1.054,
+       "p_value": 9e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 158,
+        "mean": 5.4934,
+        "std": 1.48,
+        "min": 4.3519
+       },
+       "em": {
+        "n": 35,
+        "mean": 6.2308,
+        "std": 1.3358,
+        "min": 4.9673
+       },
+       "gate_only": {
+        "n": 107,
+        "mean": 5.6985,
+        "std": 1.231,
+        "min": 4.6636
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.2051,
+       "p_value": 0.223392,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 256,
+        "mean": 5.4714,
+        "std": 1.3354,
+        "min": 4.3519
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 6.4194,
+        "std": 1.8426,
+        "min": 4.7199
+       },
+       "random": {
+        "n": 15,
+        "mean": 6.8514,
+        "std": 1.027,
+        "min": 5.6138
+       },
+       "uniform": {
+        "n": 14,
+        "mean": 6.8599,
+        "std": 0.5419,
+        "min": 5.9351
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.948,
+       "p_value": 0.077369,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 52,
+        "mean": 5.9132,
+        "std": 1.0276,
+        "min": 4.9673
+       },
+       "none": {
+        "n": 202,
+        "mean": 5.4849,
+        "std": 1.4818,
+        "min": 4.4695
+       },
+       "markov": {
+        "n": 46,
+        "mean": 6.0941,
+        "std": 1.2334,
+        "min": 4.3519
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.4283,
+       "p_value": 0.017688,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 253,
+        "mean": 5.5443,
+        "std": 1.4285,
+        "min": 4.3519
+       },
+       "False": {
+        "n": 47,
+        "mean": 6.2356,
+        "std": 1.0454,
+        "min": 4.9673
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.6913,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 58,
+        "mean": 6.3279,
+        "std": 1.3788,
+        "min": 4.9673
+       },
+       "True": {
+        "n": 242,
+        "mean": 5.4907,
+        "std": 1.3538,
+        "min": 4.3519
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.8372,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 141,
+       "mean_rmse": 5.4289
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 53,
+       "mean_rmse": 6.0378
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 106,
+       "mean_rmse": 5.7574
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0681
+       ],
+       "n": 75,
+       "mean_rmse": 5.5879
+      },
+      "Q2": {
+       "range": [
+        0.0681,
+        0.1756
+       ],
+       "n": 75,
+       "mean_rmse": 5.4439
+      },
+      "Q3": {
+       "range": [
+        0.1756,
+        0.2369
+       ],
+       "n": 75,
+       "mean_rmse": 5.4403
+      },
+      "Q4": {
+       "range": [
+        0.2369,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.1381
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        32.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.8324
+      },
+      "Q2": {
+       "range": [
+        32.0,
+        44.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.6598
+      },
+      "Q3": {
+       "range": [
+        44.0,
+        47.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.5643
+      },
+      "Q4": {
+       "range": [
+        47.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 5.5588
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 45,
+       "mean_rmse": 6.0687
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        6.0
+       ],
+       "n": 87,
+       "mean_rmse": 5.841
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 60,
+       "mean_rmse": 5.5705
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 108,
+       "mean_rmse": 5.373
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1485
+       ],
+       "n": 75,
+       "mean_rmse": 6.2725
+      },
+      "Q2": {
+       "range": [
+        0.1485,
+        0.1913
+       ],
+       "n": 75,
+       "mean_rmse": 5.4645
+      },
+      "Q3": {
+       "range": [
+        0.1913,
+        0.2321
+       ],
+       "n": 75,
+       "mean_rmse": 5.4221
+      },
+      "Q4": {
+       "range": [
+        0.2321,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.4511
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        87.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.9291
+      },
+      "Q2": {
+       "range": [
+        87.0,
+        107.0
+       ],
+       "n": 72,
+       "mean_rmse": 5.5109
+      },
+      "Q3": {
+       "range": [
+        107.0,
+        117.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.547
+      },
+      "Q4": {
+       "range": [
+        117.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 5.621
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 59,
+       "mean_rmse": 5.9318
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 32,
+       "mean_rmse": 5.6242
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 209,
+       "mean_rmse": 5.5781
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 70,
+       "mean_rmse": 5.2794
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 72,
+       "mean_rmse": 5.4864
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        23.0
+       ],
+       "n": 79,
+       "mean_rmse": 5.5128
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 6.2745
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 380.8,
+    "holdout": {
+     "holdout_rmse": 3.734158192240332,
+     "retrain_s": 0.2427,
+     "predict_s": 0.0018,
+     "cv_rmse_of_winner": 4.351931974318985
+    }
+   }
+  },
+  "synthetic@s44": {
+   "dataset": "synthetic",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.8513872282377526,
+    "std": 12.522023281908787
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.801861659134396,
+    "rmse_p10": 5.940281846725884,
+    "rmse_median": 6.161574685902847,
+    "train_s_median": 0.0930600618943572,
+    "train_s_mean": 0.08980351427942514,
+    "train_s_p90": 0.142481280118227,
+    "best_params": {
+     "learning_rate": 0.04041929816413736,
+     "num_leaves": 90,
+     "max_depth": 12,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 1.2253123595844413,
+     "lambda_l2": 3.3666154467191345,
+     "feature_fraction": 0.9740594797703594,
+     "bagging_fraction": 0.909025436817853,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8831,
+     "learning_rate": 0.0615,
+     "feature_fraction": 0.0147,
+     "extra_trees": 0.012,
+     "bagging_fraction": 0.0097,
+     "max_depth": 0.0071,
+     "num_leaves": 0.0054,
+     "lambda_l2": 0.0031,
+     "lambda_l1": 0.0022,
+     "bagging_freq": 0.0012
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 6.3322,
+        "std": 0.546,
+        "min": 5.8019
+       },
+       "True": {
+        "n": 20,
+        "mean": 7.2502,
+        "std": 0.9051,
+        "min": 6.1956
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.918,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.04
+       ],
+       "n": 75,
+       "mean_rmse": 6.649
+      },
+      "Q2": {
+       "range": [
+        0.04,
+        0.0469
+       ],
+       "n": 75,
+       "mean_rmse": 6.1474
+      },
+      "Q3": {
+       "range": [
+        0.0469,
+        0.0562
+       ],
+       "n": 75,
+       "mean_rmse": 6.2803
+      },
+      "Q4": {
+       "range": [
+        0.0562,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.4967
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        84.75
+       ],
+       "n": 75,
+       "mean_rmse": 6.8672
+      },
+      "Q2": {
+       "range": [
+        84.75,
+        98.0
+       ],
+       "n": 70,
+       "mean_rmse": 6.1468
+      },
+      "Q3": {
+       "range": [
+        98.0,
+        121.0
+       ],
+       "n": 76,
+       "mean_rmse": 6.341
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 6.2123
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 71,
+       "mean_rmse": 6.8683
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 37,
+       "mean_rmse": 6.4367
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 192,
+       "mean_rmse": 6.2094
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.1255
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 65,
+       "mean_rmse": 6.1508
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 86,
+       "mean_rmse": 6.1991
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 7.0654
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0041
+       ],
+       "n": 75,
+       "mean_rmse": 6.851
+      },
+      "Q2": {
+       "range": [
+        0.0041,
+        1.2129
+       ],
+       "n": 75,
+       "mean_rmse": 6.3558
+      },
+      "Q3": {
+       "range": [
+        1.2129,
+        3.1615
+       ],
+       "n": 75,
+       "mean_rmse": 6.1514
+      },
+      "Q4": {
+       "range": [
+        3.1615,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.2152
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.2652
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.2468
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 6.4952
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.5662
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8372
+       ],
+       "n": 75,
+       "mean_rmse": 6.8683
+      },
+      "Q2": {
+       "range": [
+        0.8372,
+        0.9281
+       ],
+       "n": 75,
+       "mean_rmse": 6.2573
+      },
+      "Q3": {
+       "range": [
+        0.9281,
+        0.955
+       ],
+       "n": 75,
+       "mean_rmse": 6.2016
+      },
+      "Q4": {
+       "range": [
+        0.955,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.2462
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5741
+       ],
+       "n": 75,
+       "mean_rmse": 6.38
+      },
+      "Q2": {
+       "range": [
+        0.5741,
+        0.6123
+       ],
+       "n": 75,
+       "mean_rmse": 6.2264
+      },
+      "Q3": {
+       "range": [
+        0.6123,
+        0.6768
+       ],
+       "n": 75,
+       "mean_rmse": 6.3471
+      },
+      "Q4": {
+       "range": [
+        0.6768,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.62
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 138.9,
+    "holdout": {
+     "holdout_rmse": 4.936794793854299,
+     "retrain_s": 0.2427,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 5.801861659134396
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 5.589397099049719,
+    "rmse_p10": 5.651868592567765,
+    "rmse_median": 5.860240539825158,
+    "train_s_median": 0.27603003866970544,
+    "train_s_mean": 0.26267612005646035,
+    "train_s_p90": 0.4337491904944182,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.1068506405505078,
+     "num_leaves": 126,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0001505961450700371,
+     "lambda_l2": 3.3684037870468566e-07,
+     "feature_fraction": 0.9279374581822402,
+     "bagging_fraction": 0.8715870171684187,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5727,
+     "learning_rate": 0.2791,
+     "feature_fraction": 0.0695,
+     "bagging_fraction": 0.0208,
+     "max_depth": 0.016,
+     "extra_trees": 0.012,
+     "n_models": 0.0117,
+     "num_leaves": 0.0108,
+     "bagging_freq": 0.0056,
+     "lambda_l2": 0.0017,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 84,
+        "mean": 6.4898,
+        "std": 0.6846,
+        "min": 5.8148
+       },
+       "False": {
+        "n": 216,
+        "mean": 5.9411,
+        "std": 0.5217,
+        "min": 5.5894
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5487,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0808
+       ],
+       "n": 75,
+       "mean_rmse": 6.3443
+      },
+      "Q2": {
+       "range": [
+        0.0808,
+        0.1071
+       ],
+       "n": 75,
+       "mean_rmse": 5.8764
+      },
+      "Q3": {
+       "range": [
+        0.1071,
+        0.1799
+       ],
+       "n": 75,
+       "mean_rmse": 6.0718
+      },
+      "Q4": {
+       "range": [
+        0.1799,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0864
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        63.75
+       ],
+       "n": 75,
+       "mean_rmse": 6.5896
+      },
+      "Q2": {
+       "range": [
+        63.75,
+        107.0
+       ],
+       "n": 74,
+       "mean_rmse": 6.1207
+      },
+      "Q3": {
+       "range": [
+        107.0,
+        123.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.8756
+      },
+      "Q4": {
+       "range": [
+        123.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 5.8012
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 59,
+       "mean_rmse": 6.7148
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 77,
+       "mean_rmse": 5.9937
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 164,
+       "mean_rmse": 5.9191
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 74,
+       "mean_rmse": 5.8144
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 62,
+       "mean_rmse": 5.7974
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 81,
+       "mean_rmse": 5.9017
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 6.7552
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.3266
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 5.9704
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0022
+       ],
+       "n": 75,
+       "mean_rmse": 5.9226
+      },
+      "Q4": {
+       "range": [
+        0.0022,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.1592
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.0433
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.9823
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 6.0762
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.2772
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9032
+       ],
+       "n": 75,
+       "mean_rmse": 6.6091
+      },
+      "Q2": {
+       "range": [
+        0.9032,
+        0.9279
+       ],
+       "n": 75,
+       "mean_rmse": 5.8285
+      },
+      "Q3": {
+       "range": [
+        0.9279,
+        0.9555
+       ],
+       "n": 75,
+       "mean_rmse": 5.9776
+      },
+      "Q4": {
+       "range": [
+        0.9555,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.9637
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8468
+       ],
+       "n": 75,
+       "mean_rmse": 6.4481
+      },
+      "Q2": {
+       "range": [
+        0.8468,
+        0.8834
+       ],
+       "n": 75,
+       "mean_rmse": 5.9652
+      },
+      "Q3": {
+       "range": [
+        0.8834,
+        0.9219
+       ],
+       "n": 75,
+       "mean_rmse": 5.8783
+      },
+      "Q4": {
+       "range": [
+        0.9219,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 6.0873
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 397.7,
+    "holdout": {
+     "holdout_rmse": 5.093577629961736,
+     "retrain_s": 0.5676,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 5.589397099049719
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 4.55270834426117,
+    "rmse_p10": 4.657248832876258,
+    "rmse_median": 4.95323392463412,
+    "train_s_median": 0.2262598307803273,
+    "train_s_mean": 0.2826392185079554,
+    "train_s_p90": 0.3833281154558065,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.06652182098457517,
+     "num_leaves": 10,
+     "max_depth": 6,
+     "min_data_in_leaf": 19,
+     "lambda_l1": 3.3826529305479264e-08,
+     "lambda_l2": 0.007581230079495823,
+     "feature_fraction": 0.9766050147465438,
+     "bagging_fraction": 0.745895598297999,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 48,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.002416703158728568,
+     "mixture_diversity_lambda": 0.22806982180497368,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 59,
+     "mixture_gate_learning_rate": 0.2974497952614197,
+     "mixture_gate_lambda_l2": 8.298884652496447,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_expert_capacity_factor": 1.4744189792044409,
+     "mixture_expert_choice_boost": 25.244499498089493,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.48240445819530847,
+     "mixture_elbo_drop_threshold": 0.036948453933317436,
+     "mixture_elbo_plateau_threshold": 0.008040600592514933,
+     "mixture_elbo_window": 10,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 1,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "mixture_gate_type": 0.5771,
+     "learning_rate": 0.1048,
+     "mixture_init": 0.066,
+     "min_data_in_leaf": 0.0515,
+     "extra_trees": 0.0346,
+     "mixture_warmup_iters": 0.0337,
+     "mixture_diversity_lambda": 0.0306,
+     "num_leaves": 0.0131,
+     "lambda_l2": 0.0129,
+     "max_depth": 0.0117,
+     "mixture_refit_leaves": 0.0104,
+     "mixture_balance_factor": 0.0099,
+     "bagging_fraction": 0.009,
+     "feature_fraction": 0.0087,
+     "mixture_e_step_mode": 0.0049,
+     "mixture_r_smoothing": 0.0042,
+     "mixture_num_experts": 0.004,
+     "bagging_freq": 0.0038,
+     "lambda_l1": 0.0033,
+     "mixture_routing_mode": 0.0032,
+     "mixture_hard_m_step": 0.0027
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 266,
+        "mean": 5.2099,
+        "std": 0.761,
+        "min": 4.5527
+       },
+       "none": {
+        "n": 17,
+        "mean": 8.9971,
+        "std": 1.6482,
+        "min": 6.0393
+       },
+       "leaf_reuse": {
+        "n": 17,
+        "mean": 7.5574,
+        "std": 1.151,
+        "min": 5.835
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 2.3475,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 38,
+        "mean": 6.8095,
+        "std": 1.3616,
+        "min": 4.6746
+       },
+       "expert_choice": {
+        "n": 262,
+        "mean": 5.3759,
+        "std": 1.2128,
+        "min": 4.5527
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 1.4336,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 32,
+        "mean": 6.7515,
+        "std": 1.167,
+        "min": 4.6687
+       },
+       "em": {
+        "n": 209,
+        "mean": 5.2375,
+        "std": 1.1417,
+        "min": 4.5527
+       },
+       "loss_only": {
+        "n": 59,
+        "mean": 6.0437,
+        "std": 1.4674,
+        "min": 4.8819
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.8062,
+       "p_value": 0.000223,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 14,
+        "mean": 7.0125,
+        "std": 1.2947,
+        "min": 5.8111
+       },
+       "tree_hierarchical": {
+        "n": 28,
+        "mean": 6.4927,
+        "std": 0.9653,
+        "min": 4.8765
+       },
+       "random": {
+        "n": 15,
+        "mean": 6.8086,
+        "std": 0.9539,
+        "min": 5.9806
+       },
+       "gmm": {
+        "n": 243,
+        "mean": 5.2887,
+        "std": 1.2267,
+        "min": 4.5527
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 1.204,
+       "p_value": 1e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 63,
+        "mean": 5.8921,
+        "std": 1.2692,
+        "min": 4.8819
+       },
+       "ema": {
+        "n": 30,
+        "mean": 6.6982,
+        "std": 1.1284,
+        "min": 4.8327
+       },
+       "markov": {
+        "n": 207,
+        "mean": 5.2904,
+        "std": 1.2501,
+        "min": 4.5527
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.6017,
+       "p_value": 0.001407,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 36,
+        "mean": 7.0418,
+        "std": 1.4433,
+        "min": 4.7372
+       },
+       "False": {
+        "n": 264,
+        "mean": 5.3551,
+        "std": 1.166,
+        "min": 4.5527
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.6867,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 36,
+        "mean": 6.8388,
+        "std": 1.1043,
+        "min": 4.7632
+       },
+       "False": {
+        "n": 264,
+        "mean": 5.3828,
+        "std": 1.2507,
+        "min": 4.5527
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.456,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 24,
+       "mean_rmse": 6.8096
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 276,
+       "mean_rmse": 5.4486
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1999
+       ],
+       "n": 75,
+       "mean_rmse": 5.6744
+      },
+      "Q2": {
+       "range": [
+        0.1999,
+        0.233
+       ],
+       "n": 75,
+       "mean_rmse": 5.3777
+      },
+      "Q3": {
+       "range": [
+        0.233,
+        0.2796
+       ],
+       "n": 75,
+       "mean_rmse": 5.4219
+      },
+      "Q4": {
+       "range": [
+        0.2796,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.756
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        28.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.3596
+      },
+      "Q2": {
+       "range": [
+        28.0,
+        46.0
+       ],
+       "n": 71,
+       "mean_rmse": 5.6476
+      },
+      "Q3": {
+       "range": [
+        46.0,
+        48.0
+       ],
+       "n": 55,
+       "mean_rmse": 5.3026
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 102,
+       "mean_rmse": 5.0661
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 200,
+       "mean_rmse": 5.2479
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 100,
+       "mean_rmse": 6.1768
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0645
+       ],
+       "n": 75,
+       "mean_rmse": 5.8129
+      },
+      "Q2": {
+       "range": [
+        0.0645,
+        0.0761
+       ],
+       "n": 75,
+       "mean_rmse": 5.2172
+      },
+      "Q3": {
+       "range": [
+        0.0761,
+        0.1319
+       ],
+       "n": 75,
+       "mean_rmse": 5.2922
+      },
+      "Q4": {
+       "range": [
+        0.1319,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 5.9078
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.0925
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        18.0
+       ],
+       "n": 76,
+       "mean_rmse": 5.2305
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        40.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.7727
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 6.1188
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 60,
+       "mean_rmse": 5.8415
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        11.0
+       ],
+       "n": 72,
+       "mean_rmse": 6.1093
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 36,
+       "mean_rmse": 5.4593
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 5.1543
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 73,
+       "mean_rmse": 5.7206
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        22.0
+       ],
+       "n": 69,
+       "mean_rmse": 5.3179
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        29.0
+       ],
+       "n": 75,
+       "mean_rmse": 5.296
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 5.8497
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 433.8,
+    "holdout": {
+     "holdout_rmse": 4.237730513105575,
+     "retrain_s": 0.264,
+     "predict_s": 0.0012,
+     "cv_rmse_of_winner": 4.55270834426117
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_vix_report.md
+++ b/bench_results/meth2_v081/ds_vix_report.md
@@ -1,0 +1,661 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['vix'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `d25c06cf3b86`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| vix | naive-lightgbm | **1.79451** ± 0.06340 | 2.64148 | 0.0% | 0.07 |
+| vix | naive-ensemble | **1.75169** ± 0.04369 | 2.64838 | 0.0% | 0.19 |
+| vix | moe | **1.85384** ± 0.17309 | 2.45968 | 0.0% | 0.40 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| vix@s42 | naive-lightgbm | 2.6702 | 2.7291 | 0.069 | 110 |
+| vix@s42 | naive-ensemble | 2.6694 | 2.7246 | 0.072 | 156 |
+| vix@s42 | moe | 2.4575 | 2.6208 | 0.231 | 486 |
+| vix@s43 | naive-lightgbm | 2.5971 | 2.7157 | 0.035 | 70 |
+| vix@s43 | naive-ensemble | 2.6426 | 2.7076 | 0.169 | 305 |
+| vix@s43 | moe | 2.4029 | 2.5871 | 0.237 | 776 |
+| vix@s44 | naive-lightgbm | 2.6572 | 2.7332 | 0.042 | 74 |
+| vix@s44 | naive-ensemble | 2.6331 | 2.7123 | 0.206 | 361 |
+| vix@s44 | moe | 2.5186 | 2.6282 | 0.388 | 654 |
+
+
+
+---
+
+## vix@s42  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.76644** (winner retrained in 0.08s, cv score of winner: 2.6702)
+- cv best RMSE: 2.6702, median: 2.7291, p10: 2.6885
+- train: median 0.069s/fold, mean 0.069s, p90 0.092s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.742 |
+| `min_data_in_leaf` | 0.111 |
+| `bagging_fraction` | 0.074 |
+| `extra_trees` | 0.046 |
+| `feature_fraction` | 0.009 |
+| `bagging_freq` | 0.008 |
+| `num_leaves` | 0.005 |
+| `max_depth` | 0.004 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 2.7555 | 0.1312 | 2.6702 |
+| True | 22 | 3.2067 | 0.5093 | 2.7210 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8875 | 2.7324 | 2.7454 | 2.7890 | **Q2** [0.039, 0.0468] |
+| `num_leaves` | 2.7864 | 2.8612 | 2.7577 | 2.7486 | **Q4** [124.0, ∞) |
+| `max_depth` | 2.8009 | — | 2.7644 | 2.8274 | **Q3** [5.0, 7.0] |
+| `min_data_in_leaf` | 2.8082 | 2.7191 | 2.7264 | 2.9041 | **Q2** [24.0, 28.0] |
+| `lambda_l1` | 2.7204 | 2.7450 | 2.8155 | 2.8734 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.8117 | 2.8035 | 2.7477 | 2.7914 | **Q3** [0.0724, 0.9155] |
+| `feature_fraction` | 2.8579 | 2.7613 | 2.7567 | 2.7784 | **Q3** [0.7364, 0.7762] |
+| `bagging_fraction` | 2.8140 | 2.7434 | 2.7894 | 2.8075 | **Q2** [0.6679, 0.7205] |
+
+#### E. Slice plot
+
+![vix@s42/naive-lightgbm](slice_vix@s42_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.73520** (winner retrained in 0.10s, cv score of winner: 2.6694)
+- cv best RMSE: 2.6694, median: 2.7246, p10: 2.6883
+- train: median 0.072s/fold, mean 0.100s, p90 0.184s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.557 |
+| `min_data_in_leaf` | 0.341 |
+| `bagging_fraction` | 0.034 |
+| `feature_fraction` | 0.022 |
+| `bagging_freq` | 0.018 |
+| `extra_trees` | 0.016 |
+| `num_leaves` | 0.006 |
+| `max_depth` | 0.003 |
+| `n_models` | 0.003 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7538 | 0.1593 | 2.6694 |
+| True | 20 | 3.1217 | 0.4447 | 2.7360 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.9236 | 2.7169 | 2.7156 | 2.7571 | **Q3** [0.0958, 0.1072] |
+| `num_leaves` | 2.8675 | 2.7371 | 2.7487 | 2.7604 | **Q2** [69.0, 86.0] |
+| `max_depth` | — | — | 2.7340 | 2.8670 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.7496 | 2.7137 | 2.7324 | 2.9106 | **Q2** [24.0, 27.0] |
+| `lambda_l1` | 2.7855 | 2.7187 | 2.8151 | 2.7939 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 2.7695 | 2.7474 | 2.7828 | 2.8135 | **Q2** [0.0, 0.0001] |
+| `feature_fraction` | 2.8079 | 2.7473 | 2.7531 | 2.8050 | **Q2** [0.6806, 0.753] |
+| `bagging_fraction` | 2.8593 | 2.7812 | 2.7394 | 2.7334 | **Q4** [0.9751, ∞) |
+
+#### E. Slice plot
+
+![vix@s42/naive-ensemble](slice_vix@s42_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 2.01304** (winner retrained in 0.25s, cv score of winner: 2.4575)
+- cv best RMSE: 2.4575, median: 2.6208, p10: 2.5246
+- train: median 0.231s/fold, mean 0.316s, p90 0.434s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.419 |
+| `bagging_fraction` | 0.346 |
+| `mixture_num_experts` | 0.058 |
+| `mixture_diversity_lambda` | 0.041 |
+| `num_leaves` | 0.040 |
+| `mixture_init` | 0.031 |
+| `lambda_l2` | 0.016 |
+| `feature_fraction` | 0.010 |
+| `extra_trees` | 0.009 |
+| `mixture_r_smoothing` | 0.008 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 221 | 2.7402 | 0.6849 | 2.4575 |
+| leaf_reuse | 63 | 2.8416 | 0.4593 | 2.5581 |
+| none | 16 | 3.9583 | 3.1082 | 2.6405 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 117 | 2.7606 | 0.6468 | 2.4575 |
+| token_choice | 183 | 2.8686 | 1.1545 | 2.4708 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 251 | 2.7709 | 0.9509 | 2.4575 |
+| em | 27 | 3.0857 | 1.1074 | 2.4802 |
+| gate_only | 22 | 3.1427 | 1.1444 | 2.5192 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 253 | 2.7182 | 0.6058 | 2.4575 |
+| gmm | 14 | 3.0269 | 0.6746 | 2.6045 |
+| tree_hierarchical | 16 | 3.1767 | 0.6285 | 2.5599 |
+| random | 17 | 3.9431 | 3.0820 | 2.5448 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 252 | 2.6810 | 0.4116 | 2.4575 |
+| ema | 18 | 3.5669 | 1.5202 | 2.5696 |
+| markov | 30 | 3.6039 | 2.4226 | 2.5643 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.7712 | 0.9263 | 2.4575 |
+| True | 21 | 3.5610 | 1.4162 | 2.7173 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 2.7401 | 0.5807 | 2.4575 |
+| True | 21 | 3.9737 | 2.8443 | 2.8299 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 2.8265 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 2.9217 | 2.7282 | 2.8943 | 2.7617 | **Q2** [0.3686, 0.3944] |
+| `mixture_warmup_iters` | 2.7492 | 2.6492 | 3.0390 | 2.8881 | **Q2** [10.0, 14.0] |
+| `mixture_balance_factor` | 3.2308 | 2.7611 | — | 2.7280 | **Q4** [8.0, ∞) |
+| `learning_rate` | 3.2176 | 2.7487 | 2.6106 | 2.7290 | **Q3** [0.0747, 0.0863] |
+| `num_leaves` | 2.9507 | 2.7333 | 2.6570 | 2.9734 | **Q3** [92.0, 101.0] |
+| `max_depth` | 2.7307 | 2.6184 | 3.0726 | 2.9495 | **Q2** [4.0, 5.0] |
+| `min_data_in_leaf` | 2.7110 | 2.6714 | 2.9147 | 2.9968 | **Q2** [9.0, 14.0] |
+
+#### E. Slice plot
+
+![vix@s42/moe](slice_vix@s42_moe.png)
+
+
+---
+
+## vix@s43  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.88229** (winner retrained in 0.05s, cv score of winner: 2.5971)
+- cv best RMSE: 2.5971, median: 2.7157, p10: 2.6491
+- train: median 0.035s/fold, mean 0.043s, p90 0.064s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.587 |
+| `min_data_in_leaf` | 0.366 |
+| `feature_fraction` | 0.014 |
+| `bagging_freq` | 0.011 |
+| `max_depth` | 0.006 |
+| `bagging_fraction` | 0.005 |
+| `num_leaves` | 0.005 |
+| `extra_trees` | 0.004 |
+| `lambda_l1` | 0.002 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 259 | 2.7476 | 0.1920 | 2.5971 |
+| False | 41 | 2.8651 | 0.2764 | 2.7016 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8913 | 2.7394 | 2.7050 | 2.7191 | **Q3** [0.1647, 0.2004] |
+| `num_leaves` | 2.8080 | 2.7553 | 2.7171 | 2.7735 | **Q3** [88.0, 97.0] |
+| `max_depth` | — | — | 2.7211 | 2.8585 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.7595 | 2.7150 | 2.7161 | 2.8668 | **Q2** [12.0, 16.0] |
+| `lambda_l1` | 2.8272 | 2.7260 | 2.7374 | 2.7642 | **Q2** [0.0, 0.0003] |
+| `lambda_l2` | 2.7599 | 2.7436 | 2.7289 | 2.8225 | **Q3** [0.0, 0.0002] |
+| `feature_fraction` | 2.7704 | 2.7048 | 2.7763 | 2.8033 | **Q2** [0.6959, 0.7244] |
+| `bagging_fraction` | 2.7301 | 2.7381 | 2.7229 | 2.8637 | **Q3** [0.6232, 0.6579] |
+
+#### E. Slice plot
+
+![vix@s43/naive-lightgbm](slice_vix@s43_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.70837** (winner retrained in 0.14s, cv score of winner: 2.6426)
+- cv best RMSE: 2.6426, median: 2.7076, p10: 2.6683
+- train: median 0.169s/fold, mean 0.200s, p90 0.345s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.476 |
+| `learning_rate` | 0.451 |
+| `feature_fraction` | 0.035 |
+| `extra_trees` | 0.016 |
+| `bagging_fraction` | 0.008 |
+| `num_leaves` | 0.007 |
+| `bagging_freq` | 0.004 |
+| `max_depth` | 0.001 |
+| `n_models` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 277 | 2.7332 | 0.1245 | 2.6426 |
+| True | 23 | 3.0953 | 0.4163 | 2.7385 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8567 | 2.7055 | 2.7182 | 2.7636 | **Q2** [0.0614, 0.0702] |
+| `num_leaves` | 2.7965 | 2.7310 | 2.7236 | 2.7928 | **Q3** [52.5, 62.0] |
+| `max_depth` | 2.7532 | — | 2.7309 | 2.8161 | **Q3** [5.0, 6.0] |
+| `min_data_in_leaf` | 2.7660 | 2.6915 | 2.7024 | 2.8790 | **Q2** [18.0, 21.0] |
+| `lambda_l1` | 2.7301 | 2.7230 | 2.7178 | 2.8730 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 2.8236 | 2.7333 | 2.7388 | 2.7483 | **Q2** [0.001, 0.0285] |
+| `feature_fraction` | 2.8331 | 2.7301 | 2.7250 | 2.7559 | **Q3** [0.8291, 0.8721] |
+| `bagging_fraction` | 2.8113 | 2.7453 | 2.7042 | 2.7831 | **Q3** [0.7712, 0.7968] |
+
+#### E. Slice plot
+
+![vix@s43/naive-ensemble](slice_vix@s43_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 1.61321** (winner retrained in 0.27s, cv score of winner: 2.4029)
+- cv best RMSE: 2.4029, median: 2.5871, p10: 2.4611
+- train: median 0.237s/fold, mean 0.510s, p90 1.043s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.326 |
+| `mixture_init` | 0.129 |
+| `bagging_fraction` | 0.110 |
+| `min_data_in_leaf` | 0.109 |
+| `mixture_diversity_lambda` | 0.101 |
+| `max_depth` | 0.051 |
+| `mixture_balance_factor` | 0.027 |
+| `lambda_l1` | 0.027 |
+| `mixture_gate_type` | 0.026 |
+| `bagging_freq` | 0.022 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 234 | 2.7080 | 0.6543 | 2.4029 |
+| gbdt | 43 | 3.0336 | 1.3336 | 2.4866 |
+| none | 23 | 3.4993 | 2.1521 | 2.4900 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 249 | 2.7458 | 0.9001 | 2.4029 |
+| expert_choice | 51 | 3.1549 | 1.3272 | 2.4866 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 233 | 2.6729 | 0.5688 | 2.4029 |
+| loss_only | 22 | 3.2524 | 1.2024 | 2.5050 |
+| em | 45 | 3.3394 | 1.9448 | 2.4866 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 253 | 2.7227 | 0.8249 | 2.4029 |
+| uniform | 17 | 2.9253 | 0.5368 | 2.5272 |
+| tree_hierarchical | 15 | 3.1823 | 0.9390 | 2.5637 |
+| gmm | 15 | 3.8869 | 2.4049 | 2.6354 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 225 | 2.7115 | 0.8723 | 2.4029 |
+| ema | 27 | 2.8634 | 0.4480 | 2.4913 |
+| none | 48 | 3.2750 | 1.5097 | 2.4550 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 269 | 2.7637 | 0.9724 | 2.4029 |
+| True | 31 | 3.2640 | 1.0978 | 2.5404 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7842 | 0.9952 | 2.4029 |
+| True | 20 | 3.2516 | 0.9291 | 2.7912 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 3.1514 | — | — | 2.7766 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 2.6702 | 2.7124 | 2.6751 | 3.2038 | **Q1** [None, 0.1509] |
+| `mixture_warmup_iters` | 2.7979 | 2.8240 | 2.5700 | 2.9791 | **Q3** [30.0, 33.0] |
+| `mixture_balance_factor` | — | 2.7926 | 2.7485 | 2.8885 | **Q3** [3.0, 4.0] |
+| `learning_rate` | 3.1630 | 2.6069 | 2.5905 | 2.9010 | **Q3** [0.1074, 0.128] |
+| `num_leaves` | 2.6005 | 2.6549 | 2.7516 | 3.2283 | **Q1** [None, 11.0] |
+| `max_depth` | 3.0660 | — | — | 2.7348 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | 2.6570 | 2.6554 | 2.8269 | 3.0834 | **Q2** [12.0, 16.0] |
+
+#### E. Slice plot
+
+![vix@s43/moe](slice_vix@s43_moe.png)
+
+
+---
+
+## vix@s44  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.73480** (winner retrained in 0.07s, cv score of winner: 2.6572)
+- cv best RMSE: 2.6572, median: 2.7332, p10: 2.6860
+- train: median 0.042s/fold, mean 0.047s, p90 0.065s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.687 |
+| `learning_rate` | 0.239 |
+| `max_depth` | 0.018 |
+| `bagging_freq` | 0.012 |
+| `bagging_fraction` | 0.011 |
+| `num_leaves` | 0.011 |
+| `extra_trees` | 0.009 |
+| `lambda_l2` | 0.007 |
+| `feature_fraction` | 0.005 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.7684 | 0.1413 | 2.6572 |
+| True | 20 | 3.0293 | 0.3142 | 2.7179 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8491 | 2.7598 | 2.7368 | 2.7976 | **Q3** [0.064, 0.0859] |
+| `num_leaves` | 2.7942 | 2.7757 | 2.7561 | 2.8183 | **Q3** [66.0, 74.0] |
+| `max_depth` | 2.7874 | 2.8004 | 2.7434 | 2.8354 | **Q3** [5.0, 5.25] |
+| `min_data_in_leaf` | 2.7875 | 2.7352 | 2.7481 | 2.8533 | **Q2** [18.75, 25.0] |
+| `lambda_l1` | 2.7688 | 2.8312 | 2.7583 | 2.7851 | **Q3** [0.0061, 0.0448] |
+| `lambda_l2` | 2.7600 | 2.7385 | 2.7683 | 2.8766 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 2.8228 | 2.7617 | 2.7847 | 2.7742 | **Q2** [0.7432, 0.7862] |
+| `bagging_fraction` | 2.8646 | 2.7674 | 2.7518 | 2.7594 | **Q3** [0.8516, 0.8933] |
+
+#### E. Slice plot
+
+![vix@s44/naive-lightgbm](slice_vix@s44_naive-lightgbm.png)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.81150** (winner retrained in 0.33s, cv score of winner: 2.6331)
+- cv best RMSE: 2.6331, median: 2.7123, p10: 2.6698
+- train: median 0.206s/fold, mean 0.237s, p90 0.372s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.841 |
+| `min_data_in_leaf` | 0.122 |
+| `num_leaves` | 0.014 |
+| `bagging_fraction` | 0.006 |
+| `max_depth` | 0.004 |
+| `extra_trees` | 0.004 |
+| `feature_fraction` | 0.003 |
+| `bagging_freq` | 0.003 |
+| `lambda_l1` | 0.002 |
+| `n_models` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 2.7486 | 0.1730 | 2.6331 |
+| False | 21 | 3.0170 | 0.3273 | 2.7407 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.9011 | 2.7086 | 2.7175 | 2.7424 | **Q2** [0.1508, 0.1777] |
+| `num_leaves` | 2.8192 | 2.7442 | 2.7413 | 2.7680 | **Q3** [67.0, 76.0] |
+| `max_depth` | 2.8581 | 2.7532 | — | 2.7383 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 2.7620 | 2.7153 | 2.7455 | 2.8439 | **Q2** [9.0, 13.0] |
+| `lambda_l1` | 2.8518 | 2.7571 | 2.7160 | 2.7449 | **Q3** [2.0781, 4.0546] |
+| `lambda_l2` | 2.7236 | 2.7407 | 2.7551 | 2.8503 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.8711 | 2.7343 | 2.7093 | 2.7550 | **Q3** [0.96, 0.9797] |
+| `bagging_fraction` | 2.8710 | 2.7310 | 2.7503 | 2.7174 | **Q4** [0.9764, ∞) |
+
+#### E. Slice plot
+
+![vix@s44/naive-ensemble](slice_vix@s44_naive-ensemble.png)
+
+
+### moe
+
+- **holdout RMSE: 1.93526** (winner retrained in 0.68s, cv score of winner: 2.5186)
+- cv best RMSE: 2.5186, median: 2.6282, p10: 2.5371
+- train: median 0.388s/fold, mean 0.426s, p90 0.494s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.342 |
+| `bagging_freq` | 0.160 |
+| `learning_rate` | 0.155 |
+| `feature_fraction` | 0.099 |
+| `mixture_e_step_mode` | 0.063 |
+| `min_data_in_leaf` | 0.051 |
+| `mixture_warmup_iters` | 0.036 |
+| `num_leaves` | 0.023 |
+| `mixture_init` | 0.015 |
+| `max_depth` | 0.014 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 2.7669 (n=264) | gbdt | Δ +0.5501 | p=7.45e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 264 | 2.7669 | 0.4650 | 2.5186 |
+| gbdt | 19 | 3.3170 | 0.5725 | 2.6026 |
+| none | 17 | 4.5876 | 1.5506 | 3.0500 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 274 | 2.8811 | 0.7164 | 2.5186 |
+| expert_choice | 26 | 3.1561 | 0.8361 | 2.6287 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 257 | 2.8192 | 0.5720 | 2.5186 |
+| em | 27 | 3.0624 | 0.6272 | 2.6132 |
+| loss_only | 16 | 4.0156 | 1.6507 | 2.9388 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 247 | 2.7841 | 0.4635 | 2.5186 |
+| random | 24 | 3.0216 | 0.8987 | 2.6132 |
+| uniform | 15 | 3.6802 | 1.1894 | 2.8304 |
+| gmm | 14 | 4.0061 | 1.6254 | 2.7851 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 242 | 2.8395 | 0.5604 | 2.5195 |
+| none | 33 | 3.0264 | 1.1362 | 2.5186 |
+| ema | 25 | 3.3775 | 1.1813 | 2.5274 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 278 | 2.8656 | 0.6054 | 2.5186 |
+| False | 22 | 3.4015 | 1.5497 | 2.5771 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 2.8827 | 0.7362 | 2.5186 |
+| True | 20 | 3.2157 | 0.5805 | 2.6522 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.7937 | — | — | 2.9120 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 3.1626 | 2.8165 | 2.7584 | 2.8821 | **Q3** [0.2126, 0.2541] |
+| `mixture_warmup_iters` | 2.9818 | 2.7749 | 2.8441 | 3.0293 | **Q2** [20.0, 22.0] |
+| `mixture_balance_factor` | 2.8761 | 3.2873 | 2.8182 | 2.7786 | **Q4** [10.0, ∞) |
+| `learning_rate` | 3.0810 | 2.8310 | 2.7171 | 2.9905 | **Q3** [0.089, 0.11] |
+| `num_leaves` | 3.0294 | 2.7675 | 2.9939 | 2.8293 | **Q2** [61.0, 68.0] |
+| `max_depth` | 3.1370 | — | 2.7727 | 3.0056 | **Q3** [8.0, 9.0] |
+| `min_data_in_leaf` | 2.9616 | 2.7632 | 2.7724 | 3.0858 | **Q2** [33.0, 36.0] |
+
+#### E. Slice plot
+
+![vix@s44/moe](slice_vix@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| vix@s44 | `mixture_gate_type` | **leaf_reuse** | +0.5501 | 7.45e-04 |

--- a/bench_results/meth2_v081/ds_vix_summary.json
+++ b/bench_results/meth2_v081/ds_vix_summary.json
@@ -1,0 +1,3765 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "vix"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "d25c06cf3b8656e8f80fec7ac7bf0ccf6a1f07a1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "vix": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.7664386562996477,
+      "cv_best": 2.670171239836421,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0786
+     },
+     "43": {
+      "holdout_rmse": 1.8822932958707213,
+      "cv_best": 2.5970787740095105,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0503
+     },
+     "44": {
+      "holdout_rmse": 1.7348027059232993,
+      "cv_best": 2.6571905806562492,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0669
+     }
+    },
+    "holdout_mean": 1.794512,
+    "holdout_std": 0.0634,
+    "cv_best_mean": 2.64148
+   },
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.7351988995840049,
+      "cv_best": 2.669407470914156,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1046
+     },
+     "43": {
+      "holdout_rmse": 1.7083695869096656,
+      "cv_best": 2.6426356542246916,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1436
+     },
+     "44": {
+      "holdout_rmse": 1.811500591733026,
+      "cv_best": 2.633096302256512,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3278
+     }
+    },
+    "holdout_mean": 1.75169,
+    "holdout_std": 0.043688,
+    "cv_best_mean": 2.64838
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.0130447651002856,
+      "cv_best": 2.457471033527799,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2522
+     },
+     "43": {
+      "holdout_rmse": 1.6132095013106202,
+      "cv_best": 2.4029408274210167,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2676
+     },
+     "44": {
+      "holdout_rmse": 1.9352602246147093,
+      "cv_best": 2.5186301556633053,
+      "crash_rate": 0.0,
+      "retrain_s": 0.6756
+     }
+    },
+    "holdout_mean": 1.853838,
+    "holdout_std": 0.173088,
+    "cv_best_mean": 2.459681
+   }
+  }
+ },
+ "runs": {
+  "vix@s42": {
+   "dataset": "vix",
+   "seed": 42,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.670171239836421,
+    "rmse_p10": 2.688531065726293,
+    "rmse_median": 2.7290990394558583,
+    "train_s_median": 0.0689589200541377,
+    "train_s_mean": 0.06924844976266224,
+    "train_s_p90": 0.09212339945137502,
+    "best_params": {
+     "learning_rate": 0.0735706065963684,
+     "num_leaves": 23,
+     "max_depth": 5,
+     "min_data_in_leaf": 27,
+     "lambda_l1": 6.52351819567189e-07,
+     "lambda_l2": 0.023485572598806136,
+     "feature_fraction": 0.6655272959539883,
+     "bagging_fraction": 0.8542387126464255,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.7418,
+     "min_data_in_leaf": 0.1108,
+     "bagging_fraction": 0.0741,
+     "extra_trees": 0.0462,
+     "feature_fraction": 0.0086,
+     "bagging_freq": 0.0083,
+     "num_leaves": 0.0046,
+     "max_depth": 0.0043,
+     "lambda_l2": 0.0011,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 3.2067,
+        "std": 0.5093,
+        "min": 2.721
+       },
+       "False": {
+        "n": 278,
+        "mean": 2.7555,
+        "std": 0.1312,
+        "min": 2.6702
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.4512,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.039
+       ],
+       "n": 75,
+       "mean_rmse": 2.8875
+      },
+      "Q2": {
+       "range": [
+        0.039,
+        0.0468
+       ],
+       "n": 75,
+       "mean_rmse": 2.7324
+      },
+      "Q3": {
+       "range": [
+        0.0468,
+        0.0645
+       ],
+       "n": 75,
+       "mean_rmse": 2.7454
+      },
+      "Q4": {
+       "range": [
+        0.0645,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.789
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        29.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7864
+      },
+      "Q2": {
+       "range": [
+        29.0,
+        99.5
+       ],
+       "n": 76,
+       "mean_rmse": 2.8612
+      },
+      "Q3": {
+       "range": [
+        99.5,
+        124.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.7577
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.7486
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 45,
+       "mean_rmse": 2.8009
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 166,
+       "mean_rmse": 2.7644
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 89,
+       "mean_rmse": 2.8274
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        24.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.8082
+      },
+      "Q2": {
+       "range": [
+        24.0,
+        28.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7191
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        33.0
+       ],
+       "n": 84,
+       "mean_rmse": 2.7264
+      },
+      "Q4": {
+       "range": [
+        33.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.9041
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7204
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.745
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.8155
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8734
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.8117
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0724
+       ],
+       "n": 75,
+       "mean_rmse": 2.8035
+      },
+      "Q3": {
+       "range": [
+        0.0724,
+        0.9155
+       ],
+       "n": 75,
+       "mean_rmse": 2.7477
+      },
+      "Q4": {
+       "range": [
+        0.9155,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7914
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6765
+       ],
+       "n": 75,
+       "mean_rmse": 2.8579
+      },
+      "Q2": {
+       "range": [
+        0.6765,
+        0.7364
+       ],
+       "n": 75,
+       "mean_rmse": 2.7613
+      },
+      "Q3": {
+       "range": [
+        0.7364,
+        0.7762
+       ],
+       "n": 75,
+       "mean_rmse": 2.7567
+      },
+      "Q4": {
+       "range": [
+        0.7762,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7784
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6679
+       ],
+       "n": 75,
+       "mean_rmse": 2.814
+      },
+      "Q2": {
+       "range": [
+        0.6679,
+        0.7205
+       ],
+       "n": 75,
+       "mean_rmse": 2.7434
+      },
+      "Q3": {
+       "range": [
+        0.7205,
+        0.8505
+       ],
+       "n": 75,
+       "mean_rmse": 2.7894
+      },
+      "Q4": {
+       "range": [
+        0.8505,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8075
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 109.5,
+    "holdout": {
+     "holdout_rmse": 1.7664386562996477,
+     "retrain_s": 0.0786,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 2.670171239836421
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.669407470914156,
+    "rmse_p10": 2.6882896300342596,
+    "rmse_median": 2.7246386072050996,
+    "train_s_median": 0.07177053093910217,
+    "train_s_mean": 0.10046254385635256,
+    "train_s_p90": 0.1836731187999249,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.10401649307033928,
+     "num_leaves": 91,
+     "max_depth": 3,
+     "min_data_in_leaf": 27,
+     "lambda_l1": 0.18425254146017955,
+     "lambda_l2": 5.1862328351511554e-05,
+     "feature_fraction": 0.6703961026679717,
+     "bagging_fraction": 0.9780395148315123,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5567,
+     "min_data_in_leaf": 0.341,
+     "bagging_fraction": 0.0344,
+     "feature_fraction": 0.0217,
+     "bagging_freq": 0.0177,
+     "extra_trees": 0.0162,
+     "num_leaves": 0.006,
+     "max_depth": 0.0031,
+     "n_models": 0.0025,
+     "lambda_l2": 0.0005,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7538,
+        "std": 0.1593,
+        "min": 2.6694
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.1217,
+        "std": 0.4447,
+        "min": 2.736
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3679,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0765
+       ],
+       "n": 75,
+       "mean_rmse": 2.9236
+      },
+      "Q2": {
+       "range": [
+        0.0765,
+        0.0958
+       ],
+       "n": 75,
+       "mean_rmse": 2.7169
+      },
+      "Q3": {
+       "range": [
+        0.0958,
+        0.1072
+       ],
+       "n": 75,
+       "mean_rmse": 2.7156
+      },
+      "Q4": {
+       "range": [
+        0.1072,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7571
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        69.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.8675
+      },
+      "Q2": {
+       "range": [
+        69.0,
+        86.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7371
+      },
+      "Q3": {
+       "range": [
+        86.0,
+        93.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.7487
+      },
+      "Q4": {
+       "range": [
+        93.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.7604
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 200,
+       "mean_rmse": 2.734
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 100,
+       "mean_rmse": 2.867
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        24.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7496
+      },
+      "Q2": {
+       "range": [
+        24.0,
+        27.0
+       ],
+       "n": 64,
+       "mean_rmse": 2.7137
+      },
+      "Q3": {
+       "range": [
+        27.0,
+        31.0
+       ],
+       "n": 86,
+       "mean_rmse": 2.7324
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.9106
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7855
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7187
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0079
+       ],
+       "n": 75,
+       "mean_rmse": 2.8151
+      },
+      "Q4": {
+       "range": [
+        0.0079,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7939
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7695
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 2.7474
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 75,
+       "mean_rmse": 2.7828
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8135
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6806
+       ],
+       "n": 75,
+       "mean_rmse": 2.8079
+      },
+      "Q2": {
+       "range": [
+        0.6806,
+        0.753
+       ],
+       "n": 75,
+       "mean_rmse": 2.7473
+      },
+      "Q3": {
+       "range": [
+        0.753,
+        0.8156
+       ],
+       "n": 75,
+       "mean_rmse": 2.7531
+      },
+      "Q4": {
+       "range": [
+        0.8156,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.805
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8884
+       ],
+       "n": 75,
+       "mean_rmse": 2.8593
+      },
+      "Q2": {
+       "range": [
+        0.8884,
+        0.9373
+       ],
+       "n": 75,
+       "mean_rmse": 2.7812
+      },
+      "Q3": {
+       "range": [
+        0.9373,
+        0.9751
+       ],
+       "n": 75,
+       "mean_rmse": 2.7394
+      },
+      "Q4": {
+       "range": [
+        0.9751,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7334
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 156.2,
+    "holdout": {
+     "holdout_rmse": 1.7351988995840049,
+     "retrain_s": 0.1046,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.669407470914156
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.457471033527799,
+    "rmse_p10": 2.5245810636508597,
+    "rmse_median": 2.6207659196196973,
+    "train_s_median": 0.23070755042135715,
+    "train_s_mean": 0.3155773776782056,
+    "train_s_p90": 0.43356827139854437,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.07400551915127201,
+     "num_leaves": 96,
+     "max_depth": 4,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 4.928486936013059,
+     "lambda_l2": 0.3292128480963374,
+     "feature_fraction": 0.8211084301429828,
+     "bagging_fraction": 0.5085822716098463,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 11,
+     "mixture_balance_factor": 8,
+     "mixture_diversity_lambda": 0.3990734503858171,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 25,
+     "mixture_gate_learning_rate": 0.3205411708744647,
+     "mixture_gate_lambda_l2": 0.020290846407637418,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 1.0419561088264637,
+     "mixture_expert_choice_boost": 24.226876092780486,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.4191,
+     "bagging_fraction": 0.3462,
+     "mixture_num_experts": 0.0581,
+     "mixture_diversity_lambda": 0.0407,
+     "num_leaves": 0.0403,
+     "mixture_init": 0.031,
+     "lambda_l2": 0.016,
+     "feature_fraction": 0.0098,
+     "extra_trees": 0.0089,
+     "mixture_r_smoothing": 0.0078,
+     "mixture_gate_type": 0.0049,
+     "min_data_in_leaf": 0.0045,
+     "max_depth": 0.0037,
+     "mixture_hard_m_step": 0.0022,
+     "mixture_warmup_iters": 0.0021,
+     "mixture_routing_mode": 0.002,
+     "mixture_balance_factor": 0.0014,
+     "lambda_l1": 0.0008,
+     "mixture_refit_leaves": 0.0002,
+     "mixture_e_step_mode": 0.0002,
+     "bagging_freq": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 63,
+        "mean": 2.8416,
+        "std": 0.4593,
+        "min": 2.5581
+       },
+       "none": {
+        "n": 16,
+        "mean": 3.9583,
+        "std": 3.1082,
+        "min": 2.6405
+       },
+       "gbdt": {
+        "n": 221,
+        "mean": 2.7402,
+        "std": 0.6849,
+        "min": 2.4575
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.1014,
+       "p_value": 0.174986,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 183,
+        "mean": 2.8686,
+        "std": 1.1545,
+        "min": 2.4708
+       },
+       "expert_choice": {
+        "n": 117,
+        "mean": 2.7606,
+        "std": 0.6468,
+        "min": 2.4575
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.108,
+       "p_value": 0.302639,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 251,
+        "mean": 2.7709,
+        "std": 0.9509,
+        "min": 2.4575
+       },
+       "gate_only": {
+        "n": 22,
+        "mean": 3.1427,
+        "std": 1.1444,
+        "min": 2.5192
+       },
+       "em": {
+        "n": 27,
+        "mean": 3.0857,
+        "std": 1.1074,
+        "min": 2.4802
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.3148,
+       "p_value": 0.172586,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 17,
+        "mean": 3.9431,
+        "std": 3.082,
+        "min": 2.5448
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 3.0269,
+        "std": 0.6746,
+        "min": 2.6045
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 3.1767,
+        "std": 0.6285,
+        "min": 2.5599
+       },
+       "uniform": {
+        "n": 253,
+        "mean": 2.7182,
+        "std": 0.6058,
+        "min": 2.4575
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "gmm",
+       "delta_mean": 0.3087,
+       "p_value": 0.128084,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 18,
+        "mean": 3.5669,
+        "std": 1.5202,
+        "min": 2.5696
+       },
+       "markov": {
+        "n": 30,
+        "mean": 3.6039,
+        "std": 2.4226,
+        "min": 2.5643
+       },
+       "none": {
+        "n": 252,
+        "mean": 2.681,
+        "std": 0.4116,
+        "min": 2.4575
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.8859,
+       "p_value": 0.028189,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 3.561,
+        "std": 1.4162,
+        "min": 2.7173
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.7712,
+        "std": 0.9263,
+        "min": 2.4575
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.7898,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 3.9737,
+        "std": 2.8443,
+        "min": 2.8299
+       },
+       "False": {
+        "n": 279,
+        "mean": 2.7401,
+        "std": 0.5807,
+        "min": 2.4575
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.2336,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 2.8265
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3686
+       ],
+       "n": 75,
+       "mean_rmse": 2.9217
+      },
+      "Q2": {
+       "range": [
+        0.3686,
+        0.3944
+       ],
+       "n": 75,
+       "mean_rmse": 2.7282
+      },
+      "Q3": {
+       "range": [
+        0.3944,
+        0.4258
+       ],
+       "n": 75,
+       "mean_rmse": 2.8943
+      },
+      "Q4": {
+       "range": [
+        0.4258,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7617
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 54,
+       "mean_rmse": 2.7492
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        14.0
+       ],
+       "n": 94,
+       "mean_rmse": 2.6492
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        25.0
+       ],
+       "n": 76,
+       "mean_rmse": 3.039
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.8881
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 57,
+       "mean_rmse": 3.2308
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 27,
+       "mean_rmse": 2.7611
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 216,
+       "mean_rmse": 2.728
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.056
+       ],
+       "n": 75,
+       "mean_rmse": 3.2176
+      },
+      "Q2": {
+       "range": [
+        0.056,
+        0.0747
+       ],
+       "n": 75,
+       "mean_rmse": 2.7487
+      },
+      "Q3": {
+       "range": [
+        0.0747,
+        0.0863
+       ],
+       "n": 75,
+       "mean_rmse": 2.6106
+      },
+      "Q4": {
+       "range": [
+        0.0863,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.729
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        85.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.9507
+      },
+      "Q2": {
+       "range": [
+        85.0,
+        92.0
+       ],
+       "n": 66,
+       "mean_rmse": 2.7333
+      },
+      "Q3": {
+       "range": [
+        92.0,
+        101.0
+       ],
+       "n": 84,
+       "mean_rmse": 2.657
+      },
+      "Q4": {
+       "range": [
+        101.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.9734
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 14,
+       "mean_rmse": 2.7307
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 126,
+       "mean_rmse": 2.6184
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 64,
+       "mean_rmse": 3.0726
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 96,
+       "mean_rmse": 2.9495
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 59,
+       "mean_rmse": 2.711
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 85,
+       "mean_rmse": 2.6714
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        34.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.9147
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.9968
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 486.5,
+    "holdout": {
+     "holdout_rmse": 2.0130447651002856,
+     "retrain_s": 0.2522,
+     "predict_s": 0.001,
+     "cv_rmse_of_winner": 2.457471033527799
+    }
+   }
+  },
+  "vix@s43": {
+   "dataset": "vix",
+   "seed": 43,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.5970787740095105,
+    "rmse_p10": 2.6491217234898046,
+    "rmse_median": 2.7157383565950144,
+    "train_s_median": 0.035061290673911574,
+    "train_s_mean": 0.04264732401072979,
+    "train_s_p90": 0.0637795363366604,
+    "best_params": {
+     "learning_rate": 0.20281037258953272,
+     "num_leaves": 34,
+     "max_depth": 3,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 0.5584858923075698,
+     "lambda_l2": 2.485244401438317e-06,
+     "feature_fraction": 0.6940812157677723,
+     "bagging_fraction": 0.6169902728165328,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.5871,
+     "min_data_in_leaf": 0.3658,
+     "feature_fraction": 0.0138,
+     "bagging_freq": 0.0111,
+     "max_depth": 0.0061,
+     "bagging_fraction": 0.0051,
+     "num_leaves": 0.0051,
+     "extra_trees": 0.0041,
+     "lambda_l1": 0.0015,
+     "lambda_l2": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 259,
+        "mean": 2.7476,
+        "std": 0.192,
+        "min": 2.5971
+       },
+       "False": {
+        "n": 41,
+        "mean": 2.8651,
+        "std": 0.2764,
+        "min": 2.7016
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.1175,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1185
+       ],
+       "n": 75,
+       "mean_rmse": 2.8913
+      },
+      "Q2": {
+       "range": [
+        0.1185,
+        0.1647
+       ],
+       "n": 75,
+       "mean_rmse": 2.7394
+      },
+      "Q3": {
+       "range": [
+        0.1647,
+        0.2004
+       ],
+       "n": 75,
+       "mean_rmse": 2.705
+      },
+      "Q4": {
+       "range": [
+        0.2004,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7191
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        77.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.808
+      },
+      "Q2": {
+       "range": [
+        77.0,
+        88.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7553
+      },
+      "Q3": {
+       "range": [
+        88.0,
+        97.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7171
+      },
+      "Q4": {
+       "range": [
+        97.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.7735
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 207,
+       "mean_rmse": 2.7211
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 2.8585
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 57,
+       "mean_rmse": 2.7595
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 92,
+       "mean_rmse": 2.715
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        21.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.7161
+      },
+      "Q4": {
+       "range": [
+        21.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.8668
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.8272
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 2.726
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0151
+       ],
+       "n": 75,
+       "mean_rmse": 2.7374
+      },
+      "Q4": {
+       "range": [
+        0.0151,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7642
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7599
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7436
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 2.7289
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8225
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6959
+       ],
+       "n": 75,
+       "mean_rmse": 2.7704
+      },
+      "Q2": {
+       "range": [
+        0.6959,
+        0.7244
+       ],
+       "n": 75,
+       "mean_rmse": 2.7048
+      },
+      "Q3": {
+       "range": [
+        0.7244,
+        0.8283
+       ],
+       "n": 75,
+       "mean_rmse": 2.7763
+      },
+      "Q4": {
+       "range": [
+        0.8283,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8033
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6
+       ],
+       "n": 75,
+       "mean_rmse": 2.7301
+      },
+      "Q2": {
+       "range": [
+        0.6,
+        0.6232
+       ],
+       "n": 75,
+       "mean_rmse": 2.7381
+      },
+      "Q3": {
+       "range": [
+        0.6232,
+        0.6579
+       ],
+       "n": 75,
+       "mean_rmse": 2.7229
+      },
+      "Q4": {
+       "range": [
+        0.6579,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8637
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 69.7,
+    "holdout": {
+     "holdout_rmse": 1.8822932958707213,
+     "retrain_s": 0.0503,
+     "predict_s": 0.0004,
+     "cv_rmse_of_winner": 2.5970787740095105
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.6426356542246916,
+    "rmse_p10": 2.668319882474312,
+    "rmse_median": 2.707628778005177,
+    "train_s_median": 0.16921778246760366,
+    "train_s_mean": 0.1998211638368666,
+    "train_s_p90": 0.3449769782647491,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.07188494115759617,
+     "num_leaves": 44,
+     "max_depth": 5,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 1.2582784259121393e-07,
+     "lambda_l2": 0.012262992194084464,
+     "feature_fraction": 0.826655206080592,
+     "bagging_fraction": 0.7673749892067744,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.4756,
+     "learning_rate": 0.4512,
+     "feature_fraction": 0.0355,
+     "extra_trees": 0.0164,
+     "bagging_fraction": 0.0081,
+     "num_leaves": 0.007,
+     "bagging_freq": 0.0043,
+     "max_depth": 0.0014,
+     "n_models": 0.0002,
+     "lambda_l1": 0.0002,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 277,
+        "mean": 2.7332,
+        "std": 0.1245,
+        "min": 2.6426
+       },
+       "True": {
+        "n": 23,
+        "mean": 3.0953,
+        "std": 0.4163,
+        "min": 2.7385
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3621,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0614
+       ],
+       "n": 75,
+       "mean_rmse": 2.8567
+      },
+      "Q2": {
+       "range": [
+        0.0614,
+        0.0702
+       ],
+       "n": 75,
+       "mean_rmse": 2.7055
+      },
+      "Q3": {
+       "range": [
+        0.0702,
+        0.0811
+       ],
+       "n": 75,
+       "mean_rmse": 2.7182
+      },
+      "Q4": {
+       "range": [
+        0.0811,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7636
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        42.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7965
+      },
+      "Q2": {
+       "range": [
+        42.0,
+        52.5
+       ],
+       "n": 76,
+       "mean_rmse": 2.731
+      },
+      "Q3": {
+       "range": [
+        52.5,
+        62.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7236
+      },
+      "Q4": {
+       "range": [
+        62.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.7928
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 57,
+       "mean_rmse": 2.7532
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 152,
+       "mean_rmse": 2.7309
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 91,
+       "mean_rmse": 2.8161
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.766
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        21.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.6915
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        25.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.7024
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 2.879
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7301
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.723
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7178
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.873
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.001
+       ],
+       "n": 75,
+       "mean_rmse": 2.8236
+      },
+      "Q2": {
+       "range": [
+        0.001,
+        0.0285
+       ],
+       "n": 75,
+       "mean_rmse": 2.7333
+      },
+      "Q3": {
+       "range": [
+        0.0285,
+        0.0976
+       ],
+       "n": 75,
+       "mean_rmse": 2.7388
+      },
+      "Q4": {
+       "range": [
+        0.0976,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7483
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7915
+       ],
+       "n": 75,
+       "mean_rmse": 2.8331
+      },
+      "Q2": {
+       "range": [
+        0.7915,
+        0.8291
+       ],
+       "n": 75,
+       "mean_rmse": 2.7301
+      },
+      "Q3": {
+       "range": [
+        0.8291,
+        0.8721
+       ],
+       "n": 75,
+       "mean_rmse": 2.725
+      },
+      "Q4": {
+       "range": [
+        0.8721,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7559
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7357
+       ],
+       "n": 75,
+       "mean_rmse": 2.8113
+      },
+      "Q2": {
+       "range": [
+        0.7357,
+        0.7712
+       ],
+       "n": 75,
+       "mean_rmse": 2.7453
+      },
+      "Q3": {
+       "range": [
+        0.7712,
+        0.7968
+       ],
+       "n": 75,
+       "mean_rmse": 2.7042
+      },
+      "Q4": {
+       "range": [
+        0.7968,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7831
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 304.9,
+    "holdout": {
+     "holdout_rmse": 1.7083695869096656,
+     "retrain_s": 0.1436,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.6426356542246916
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.4029408274210167,
+    "rmse_p10": 2.461062424684341,
+    "rmse_median": 2.5870802649229647,
+    "train_s_median": 0.23730879072099925,
+    "train_s_mean": 0.510074849559615,
+    "train_s_p90": 1.0431231443211468,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.12108261721420413,
+     "num_leaves": 10,
+     "max_depth": 9,
+     "min_data_in_leaf": 18,
+     "lambda_l1": 6.312469569726233,
+     "lambda_l2": 4.245093633862523e-07,
+     "feature_fraction": 0.9652453256274238,
+     "bagging_fraction": 0.6880181899623893,
+     "bagging_freq": 7,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 32,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.6594193922939197,
+     "mixture_diversity_lambda": 0.1582741642848528,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 60,
+     "mixture_gate_learning_rate": 0.04327832904948308,
+     "mixture_gate_lambda_l2": 0.004506716121111,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_retrain_interval": 26,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.3257,
+     "mixture_init": 0.129,
+     "bagging_fraction": 0.1101,
+     "min_data_in_leaf": 0.1087,
+     "mixture_diversity_lambda": 0.101,
+     "max_depth": 0.0507,
+     "mixture_balance_factor": 0.0272,
+     "lambda_l1": 0.0267,
+     "mixture_gate_type": 0.026,
+     "bagging_freq": 0.0225,
+     "mixture_e_step_mode": 0.0194,
+     "num_leaves": 0.0135,
+     "mixture_hard_m_step": 0.0106,
+     "lambda_l2": 0.0081,
+     "extra_trees": 0.0068,
+     "feature_fraction": 0.0059,
+     "mixture_warmup_iters": 0.0042,
+     "mixture_refit_leaves": 0.0026,
+     "mixture_r_smoothing": 0.0009,
+     "mixture_num_experts": 0.0005,
+     "mixture_routing_mode": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 43,
+        "mean": 3.0336,
+        "std": 1.3336,
+        "min": 2.4866
+       },
+       "none": {
+        "n": 23,
+        "mean": 3.4993,
+        "std": 2.1521,
+        "min": 2.49
+       },
+       "leaf_reuse": {
+        "n": 234,
+        "mean": 2.708,
+        "std": 0.6543,
+        "min": 2.4029
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.3256,
+       "p_value": 0.128328,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 51,
+        "mean": 3.1549,
+        "std": 1.3272,
+        "min": 2.4866
+       },
+       "token_choice": {
+        "n": 249,
+        "mean": 2.7458,
+        "std": 0.9001,
+        "min": 2.4029
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.4091,
+       "p_value": 0.041346,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 22,
+        "mean": 3.2524,
+        "std": 1.2024,
+        "min": 2.505
+       },
+       "em": {
+        "n": 45,
+        "mean": 3.3394,
+        "std": 1.9448,
+        "min": 2.4866
+       },
+       "gate_only": {
+        "n": 233,
+        "mean": 2.6729,
+        "std": 0.5688,
+        "min": 2.4029
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.5795,
+       "p_value": 0.039783,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 15,
+        "mean": 3.8869,
+        "std": 2.4049,
+        "min": 2.6354
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 3.1823,
+        "std": 0.939,
+        "min": 2.5637
+       },
+       "random": {
+        "n": 253,
+        "mean": 2.7227,
+        "std": 0.8249,
+        "min": 2.4029
+       },
+       "uniform": {
+        "n": 17,
+        "mean": 2.9253,
+        "std": 0.5368,
+        "min": 2.5272
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.2026,
+       "p_value": 0.173826,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 27,
+        "mean": 2.8634,
+        "std": 0.448,
+        "min": 2.4913
+       },
+       "none": {
+        "n": 48,
+        "mean": 3.275,
+        "std": 1.5097,
+        "min": 2.455
+       },
+       "markov": {
+        "n": 225,
+        "mean": 2.7115,
+        "std": 0.8723,
+        "min": 2.4029
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.1519,
+       "p_value": 0.155723,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 3.264,
+        "std": 1.0978,
+        "min": 2.5404
+       },
+       "False": {
+        "n": 269,
+        "mean": 2.7637,
+        "std": 0.9724,
+        "min": 2.4029
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5003,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7842,
+        "std": 0.9952,
+        "min": 2.4029
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.2516,
+        "std": 0.9291,
+        "min": 2.7912
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.4674,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 31,
+       "mean_rmse": 3.1514
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 269,
+       "mean_rmse": 2.7766
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1509
+       ],
+       "n": 75,
+       "mean_rmse": 2.6702
+      },
+      "Q2": {
+       "range": [
+        0.1509,
+        0.1685
+       ],
+       "n": 75,
+       "mean_rmse": 2.7124
+      },
+      "Q3": {
+       "range": [
+        0.1685,
+        0.206
+       ],
+       "n": 75,
+       "mean_rmse": 2.6751
+      },
+      "Q4": {
+       "range": [
+        0.206,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 3.2038
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.7979
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        30.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.824
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        33.0
+       ],
+       "n": 60,
+       "mean_rmse": 2.57
+      },
+      "Q4": {
+       "range": [
+        33.0,
+        null
+       ],
+       "n": 93,
+       "mean_rmse": 2.9791
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 131,
+       "mean_rmse": 2.7926
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 67,
+       "mean_rmse": 2.7485
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 102,
+       "mean_rmse": 2.8885
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0887
+       ],
+       "n": 75,
+       "mean_rmse": 3.163
+      },
+      "Q2": {
+       "range": [
+        0.0887,
+        0.1074
+       ],
+       "n": 75,
+       "mean_rmse": 2.6069
+      },
+      "Q3": {
+       "range": [
+        0.1074,
+        0.128
+       ],
+       "n": 75,
+       "mean_rmse": 2.5905
+      },
+      "Q4": {
+       "range": [
+        0.128,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.901
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.6005
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        15.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.6549
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        34.0
+       ],
+       "n": 86,
+       "mean_rmse": 2.7516
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 3.2283
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 73,
+       "mean_rmse": 3.066
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 227,
+       "mean_rmse": 2.7348
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.657
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.6554
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        20.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.8269
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 83,
+       "mean_rmse": 3.0834
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 775.7,
+    "holdout": {
+     "holdout_rmse": 1.6132095013106202,
+     "retrain_s": 0.2676,
+     "predict_s": 0.0012,
+     "cv_rmse_of_winner": 2.4029408274210167
+    }
+   }
+  },
+  "vix@s44": {
+   "dataset": "vix",
+   "seed": 44,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "naive-ensemble",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.6571905806562492,
+    "rmse_p10": 2.685984278605875,
+    "rmse_median": 2.733232498819883,
+    "train_s_median": 0.04185473248362541,
+    "train_s_mean": 0.04656745319440961,
+    "train_s_p90": 0.06542774688452482,
+    "best_params": {
+     "learning_rate": 0.045750809758378724,
+     "num_leaves": 68,
+     "max_depth": 5,
+     "min_data_in_leaf": 25,
+     "lambda_l1": 0.0004133519074111703,
+     "lambda_l2": 0.0004262548763200339,
+     "feature_fraction": 0.7079684834994466,
+     "bagging_fraction": 0.8971382833157585,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6867,
+     "learning_rate": 0.2395,
+     "max_depth": 0.0175,
+     "bagging_freq": 0.0117,
+     "bagging_fraction": 0.0115,
+     "num_leaves": 0.0112,
+     "extra_trees": 0.0086,
+     "lambda_l2": 0.0071,
+     "feature_fraction": 0.0055,
+     "lambda_l1": 0.0006
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 2.7684,
+        "std": 0.1413,
+        "min": 2.6572
+       },
+       "True": {
+        "n": 20,
+        "mean": 3.0293,
+        "std": 0.3142,
+        "min": 2.7179
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2609,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0429
+       ],
+       "n": 75,
+       "mean_rmse": 2.8491
+      },
+      "Q2": {
+       "range": [
+        0.0429,
+        0.064
+       ],
+       "n": 75,
+       "mean_rmse": 2.7598
+      },
+      "Q3": {
+       "range": [
+        0.064,
+        0.0859
+       ],
+       "n": 75,
+       "mean_rmse": 2.7368
+      },
+      "Q4": {
+       "range": [
+        0.0859,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7976
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        58.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.7942
+      },
+      "Q2": {
+       "range": [
+        58.0,
+        66.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.7757
+      },
+      "Q3": {
+       "range": [
+        66.0,
+        74.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.7561
+      },
+      "Q4": {
+       "range": [
+        74.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 2.8183
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7874
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 49,
+       "mean_rmse": 2.8004
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        5.25
+       ],
+       "n": 107,
+       "mean_rmse": 2.7434
+      },
+      "Q4": {
+       "range": [
+        5.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8354
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.75
+       ],
+       "n": 75,
+       "mean_rmse": 2.7875
+      },
+      "Q2": {
+       "range": [
+        18.75,
+        25.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7352
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        29.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.7481
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 88,
+       "mean_rmse": 2.8533
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7688
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0061
+       ],
+       "n": 75,
+       "mean_rmse": 2.8312
+      },
+      "Q3": {
+       "range": [
+        0.0061,
+        0.0448
+       ],
+       "n": 75,
+       "mean_rmse": 2.7583
+      },
+      "Q4": {
+       "range": [
+        0.0448,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7851
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.76
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7385
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7683
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8766
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7432
+       ],
+       "n": 75,
+       "mean_rmse": 2.8228
+      },
+      "Q2": {
+       "range": [
+        0.7432,
+        0.7862
+       ],
+       "n": 75,
+       "mean_rmse": 2.7617
+      },
+      "Q3": {
+       "range": [
+        0.7862,
+        0.8743
+       ],
+       "n": 75,
+       "mean_rmse": 2.7847
+      },
+      "Q4": {
+       "range": [
+        0.8743,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7742
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7763
+       ],
+       "n": 75,
+       "mean_rmse": 2.8646
+      },
+      "Q2": {
+       "range": [
+        0.7763,
+        0.8516
+       ],
+       "n": 75,
+       "mean_rmse": 2.7674
+      },
+      "Q3": {
+       "range": [
+        0.8516,
+        0.8933
+       ],
+       "n": 75,
+       "mean_rmse": 2.7518
+      },
+      "Q4": {
+       "range": [
+        0.8933,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7594
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 73.8,
+    "holdout": {
+     "holdout_rmse": 1.7348027059232993,
+     "retrain_s": 0.0669,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 2.6571905806562492
+    }
+   },
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.633096302256512,
+    "rmse_p10": 2.669767863826414,
+    "rmse_median": 2.7123160341311965,
+    "train_s_median": 0.20596742630004883,
+    "train_s_mean": 0.2370846949244539,
+    "train_s_p90": 0.3722211305424571,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.15715626730370527,
+     "num_leaves": 61,
+     "max_depth": 11,
+     "min_data_in_leaf": 13,
+     "lambda_l1": 1.2742683441394453,
+     "lambda_l2": 0.04766302914827998,
+     "feature_fraction": 0.9534069471769491,
+     "bagging_fraction": 0.9801652079707892,
+     "bagging_freq": 4,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.8412,
+     "min_data_in_leaf": 0.1224,
+     "num_leaves": 0.0144,
+     "bagging_fraction": 0.0056,
+     "max_depth": 0.0041,
+     "extra_trees": 0.0035,
+     "feature_fraction": 0.0032,
+     "bagging_freq": 0.0028,
+     "lambda_l1": 0.0015,
+     "n_models": 0.0008,
+     "lambda_l2": 0.0005
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 2.7486,
+        "std": 0.173,
+        "min": 2.6331
+       },
+       "False": {
+        "n": 21,
+        "mean": 3.017,
+        "std": 0.3273,
+        "min": 2.7407
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.2684,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1508
+       ],
+       "n": 75,
+       "mean_rmse": 2.9011
+      },
+      "Q2": {
+       "range": [
+        0.1508,
+        0.1777
+       ],
+       "n": 75,
+       "mean_rmse": 2.7086
+      },
+      "Q3": {
+       "range": [
+        0.1777,
+        0.2149
+       ],
+       "n": 75,
+       "mean_rmse": 2.7175
+      },
+      "Q4": {
+       "range": [
+        0.2149,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7424
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        58.0
+       ],
+       "n": 71,
+       "mean_rmse": 2.8192
+      },
+      "Q2": {
+       "range": [
+        58.0,
+        67.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.7442
+      },
+      "Q3": {
+       "range": [
+        67.0,
+        76.0
+       ],
+       "n": 82,
+       "mean_rmse": 2.7413
+      },
+      "Q4": {
+       "range": [
+        76.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 2.768
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.8581
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.7532
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 157,
+       "mean_rmse": 2.7383
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 63,
+       "mean_rmse": 2.762
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.7153
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        18.0
+       ],
+       "n": 80,
+       "mean_rmse": 2.7455
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 2.8439
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.6003
+       ],
+       "n": 75,
+       "mean_rmse": 2.8518
+      },
+      "Q2": {
+       "range": [
+        0.6003,
+        2.0781
+       ],
+       "n": 75,
+       "mean_rmse": 2.7571
+      },
+      "Q3": {
+       "range": [
+        2.0781,
+        4.0546
+       ],
+       "n": 75,
+       "mean_rmse": 2.716
+      },
+      "Q4": {
+       "range": [
+        4.0546,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7449
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7236
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7407
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 2.7551
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8503
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9187
+       ],
+       "n": 75,
+       "mean_rmse": 2.8711
+      },
+      "Q2": {
+       "range": [
+        0.9187,
+        0.96
+       ],
+       "n": 75,
+       "mean_rmse": 2.7343
+      },
+      "Q3": {
+       "range": [
+        0.96,
+        0.9797
+       ],
+       "n": 75,
+       "mean_rmse": 2.7093
+      },
+      "Q4": {
+       "range": [
+        0.9797,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.755
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9114
+       ],
+       "n": 75,
+       "mean_rmse": 2.871
+      },
+      "Q2": {
+       "range": [
+        0.9114,
+        0.9545
+       ],
+       "n": 75,
+       "mean_rmse": 2.731
+      },
+      "Q3": {
+       "range": [
+        0.9545,
+        0.9764
+       ],
+       "n": 75,
+       "mean_rmse": 2.7503
+      },
+      "Q4": {
+       "range": [
+        0.9764,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.7174
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 360.8,
+    "holdout": {
+     "holdout_rmse": 1.811500591733026,
+     "retrain_s": 0.3278,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.633096302256512
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 2.5186301556633053,
+    "rmse_p10": 2.5370968849932733,
+    "rmse_median": 2.62819888548482,
+    "train_s_median": 0.3881399916484952,
+    "train_s_mean": 0.42566312800968686,
+    "train_s_p90": 0.4943641775846482,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.06903258339604015,
+     "num_leaves": 67,
+     "max_depth": 8,
+     "min_data_in_leaf": 33,
+     "lambda_l1": 0.002567550742447452,
+     "lambda_l2": 3.766928073574093e-05,
+     "feature_fraction": 0.85007507979828,
+     "bagging_fraction": 0.7908153105673956,
+     "bagging_freq": 6,
+     "extra_trees": false,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 24,
+     "mixture_balance_factor": 10,
+     "mixture_diversity_lambda": 0.20654724177617445,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 13,
+     "mixture_gate_learning_rate": 0.013948640569955985,
+     "mixture_gate_lambda_l2": 0.42545717938196104,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_retrain_interval": 19,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.3419,
+     "bagging_freq": 0.16,
+     "learning_rate": 0.155,
+     "feature_fraction": 0.0985,
+     "mixture_e_step_mode": 0.0626,
+     "min_data_in_leaf": 0.0515,
+     "mixture_warmup_iters": 0.0362,
+     "num_leaves": 0.0228,
+     "mixture_init": 0.0145,
+     "max_depth": 0.0144,
+     "mixture_hard_m_step": 0.0142,
+     "bagging_fraction": 0.009,
+     "lambda_l2": 0.0069,
+     "mixture_diversity_lambda": 0.0045,
+     "mixture_r_smoothing": 0.0024,
+     "mixture_balance_factor": 0.0021,
+     "mixture_refit_leaves": 0.0018,
+     "lambda_l1": 0.0008,
+     "mixture_routing_mode": 0.0004,
+     "mixture_num_experts": 0.0003,
+     "extra_trees": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 19,
+        "mean": 3.317,
+        "std": 0.5725,
+        "min": 2.6026
+       },
+       "none": {
+        "n": 17,
+        "mean": 4.5876,
+        "std": 1.5506,
+        "min": 3.05
+       },
+       "leaf_reuse": {
+        "n": 264,
+        "mean": 2.7669,
+        "std": 0.465,
+        "min": 2.5186
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.5501,
+       "p_value": 0.000745,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 274,
+        "mean": 2.8811,
+        "std": 0.7164,
+        "min": 2.5186
+       },
+       "expert_choice": {
+        "n": 26,
+        "mean": 3.1561,
+        "std": 0.8361,
+        "min": 2.6287
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.275,
+       "p_value": 0.122365,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 257,
+        "mean": 2.8192,
+        "std": 0.572,
+        "min": 2.5186
+       },
+       "em": {
+        "n": 27,
+        "mean": 3.0624,
+        "std": 0.6272,
+        "min": 2.6132
+       },
+       "loss_only": {
+        "n": 16,
+        "mean": 4.0156,
+        "std": 1.6507,
+        "min": 2.9388
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.2432,
+       "p_value": 0.067047,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 15,
+        "mean": 3.6802,
+        "std": 1.1894,
+        "min": 2.8304
+       },
+       "tree_hierarchical": {
+        "n": 247,
+        "mean": 2.7841,
+        "std": 0.4635,
+        "min": 2.5186
+       },
+       "random": {
+        "n": 24,
+        "mean": 3.0216,
+        "std": 0.8987,
+        "min": 2.6132
+       },
+       "gmm": {
+        "n": 14,
+        "mean": 4.0061,
+        "std": 1.6254,
+        "min": 2.7851
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "random",
+       "delta_mean": 0.2375,
+       "p_value": 0.222469,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 33,
+        "mean": 3.0264,
+        "std": 1.1362,
+        "min": 2.5186
+       },
+       "ema": {
+        "n": 25,
+        "mean": 3.3775,
+        "std": 1.1813,
+        "min": 2.5274
+       },
+       "markov": {
+        "n": 242,
+        "mean": 2.8395,
+        "std": 0.5604,
+        "min": 2.5195
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.1869,
+       "p_value": 0.366161,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 278,
+        "mean": 2.8656,
+        "std": 0.6054,
+        "min": 2.5186
+       },
+       "False": {
+        "n": 22,
+        "mean": 3.4015,
+        "std": 1.5497,
+        "min": 2.5771
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.5359,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 20,
+        "mean": 3.2157,
+        "std": 0.5805,
+        "min": 2.6522
+       },
+       "False": {
+        "n": 280,
+        "mean": 2.8827,
+        "std": 0.7362,
+        "min": 2.5186
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.333,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 18,
+       "mean_rmse": 2.7937
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 282,
+       "mean_rmse": 2.912
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1459
+       ],
+       "n": 75,
+       "mean_rmse": 3.1626
+      },
+      "Q2": {
+       "range": [
+        0.1459,
+        0.2126
+       ],
+       "n": 75,
+       "mean_rmse": 2.8165
+      },
+      "Q3": {
+       "range": [
+        0.2126,
+        0.2541
+       ],
+       "n": 75,
+       "mean_rmse": 2.7584
+      },
+      "Q4": {
+       "range": [
+        0.2541,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.8821
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 62,
+       "mean_rmse": 2.9818
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        22.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7749
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        25.0
+       ],
+       "n": 84,
+       "mean_rmse": 2.8441
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 3.0293
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 59,
+       "mean_rmse": 2.8761
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        6.0
+       ],
+       "n": 55,
+       "mean_rmse": 3.2873
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        10.0
+       ],
+       "n": 105,
+       "mean_rmse": 2.8182
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 81,
+       "mean_rmse": 2.7786
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0764
+       ],
+       "n": 75,
+       "mean_rmse": 3.081
+      },
+      "Q2": {
+       "range": [
+        0.0764,
+        0.089
+       ],
+       "n": 75,
+       "mean_rmse": 2.831
+      },
+      "Q3": {
+       "range": [
+        0.089,
+        0.11
+       ],
+       "n": 75,
+       "mean_rmse": 2.7171
+      },
+      "Q4": {
+       "range": [
+        0.11,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 2.9905
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        61.0
+       ],
+       "n": 72,
+       "mean_rmse": 3.0294
+      },
+      "Q2": {
+       "range": [
+        61.0,
+        68.0
+       ],
+       "n": 74,
+       "mean_rmse": 2.7675
+      },
+      "Q3": {
+       "range": [
+        68.0,
+        88.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.9939
+      },
+      "Q4": {
+       "range": [
+        88.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 2.8293
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 59,
+       "mean_rmse": 3.137
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 163,
+       "mean_rmse": 2.7727
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 3.0056
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        33.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.9616
+      },
+      "Q2": {
+       "range": [
+        33.0,
+        36.0
+       ],
+       "n": 56,
+       "mean_rmse": 2.7632
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        40.0
+       ],
+       "n": 87,
+       "mean_rmse": 2.7724
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 85,
+       "mean_rmse": 3.0858
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 653.9,
+    "holdout": {
+     "holdout_rmse": 1.9352602246147093,
+     "retrain_s": 0.6756,
+     "predict_s": 0.0036,
+     "cv_rmse_of_winner": 2.5186301556633053
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_wine_quality_ensemble_report.md
+++ b/bench_results/meth2_v081/ds_wine_quality_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['wine_quality'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| wine_quality | naive-ensemble | **0.60819** ± 0.01215 | 0.66418 | 0.0% | 1.36 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| wine_quality@s42 | naive-ensemble | 0.6651 | 0.6707 | 1.123 | 1503 |
+| wine_quality@s43 | naive-ensemble | 0.6574 | 0.6623 | 0.820 | 1142 |
+| wine_quality@s44 | naive-ensemble | 0.6701 | 0.6780 | 0.630 | 840 |
+
+
+
+---
+
+## wine_quality@s42  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.60706** (winner retrained in 1.55s, cv score of winner: 0.6651)
+- cv best RMSE: 0.6651, median: 0.6707, p10: 0.6667
+- train: median 1.123s/fold, mean 0.999s, p90 1.503s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.467 |
+| `learning_rate` | 0.310 |
+| `min_data_in_leaf` | 0.128 |
+| `max_depth` | 0.029 |
+| `feature_fraction` | 0.024 |
+| `n_models` | 0.022 |
+| `lambda_l1` | 0.007 |
+| `num_leaves` | 0.006 |
+| `bagging_fraction` | 0.005 |
+| `bagging_freq` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 280 | 0.6750 | 0.0122 | 0.6651 |
+| True | 20 | 0.7165 | 0.0252 | 0.6842 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6869 | 0.6736 | 0.6719 | 0.6787 | **Q3** [0.0565, 0.0658] |
+| `num_leaves` | 0.6832 | 0.6768 | 0.6756 | 0.6757 | **Q3** [112.0, 121.0] |
+| `max_depth` | 0.6939 | 0.6808 | — | 0.6719 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | — | 0.6709 | 0.6758 | 0.6915 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 0.6856 | 0.6736 | 0.6739 | 0.6780 | **Q2** [0.0135, 0.0949] |
+| `lambda_l2` | 0.6804 | 0.6748 | 0.6803 | 0.6756 | **Q2** [0.0, 0.0002] |
+| `feature_fraction` | 0.6848 | 0.6726 | 0.6743 | 0.6794 | **Q2** [0.6852, 0.7443] |
+| `bagging_fraction` | 0.6777 | 0.6728 | 0.6729 | 0.6877 | **Q2** [0.6758, 0.7057] |
+
+#### E. Slice plot
+
+![wine_quality@s42/naive-ensemble](slice_wine_quality@s42_naive-ensemble.png)
+
+
+---
+
+## wine_quality@s43  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.62359** (winner retrained in 1.32s, cv score of winner: 0.6574)
+- cv best RMSE: 0.6574, median: 0.6623, p10: 0.6594
+- train: median 0.820s/fold, mean 0.759s, p90 1.108s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.333 |
+| `learning_rate` | 0.321 |
+| `min_data_in_leaf` | 0.200 |
+| `max_depth` | 0.088 |
+| `bagging_fraction` | 0.021 |
+| `bagging_freq` | 0.012 |
+| `n_models` | 0.008 |
+| `feature_fraction` | 0.007 |
+| `num_leaves` | 0.007 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.6660 | 0.0104 | 0.6574 |
+| True | 22 | 0.7032 | 0.0223 | 0.6770 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6781 | 0.6635 | 0.6628 | 0.6706 | **Q3** [0.1006, 0.1155] |
+| `num_leaves` | 0.6791 | 0.6659 | 0.6653 | 0.6648 | **Q4** [124.25, ∞) |
+| `max_depth` | 0.6862 | 0.6663 | — | 0.6649 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | — | 0.6631 | 0.6652 | 0.6831 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 0.6730 | 0.6683 | 0.6635 | 0.6701 | **Q3** [0.0003, 0.0016] |
+| `lambda_l2` | 0.6673 | 0.6649 | 0.6653 | 0.6775 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6689 | 0.6632 | 0.6655 | 0.6774 | **Q2** [0.6241, 0.6459] |
+| `bagging_fraction` | 0.6782 | 0.6641 | 0.6652 | 0.6674 | **Q2** [0.8801, 0.902] |
+
+#### E. Slice plot
+
+![wine_quality@s43/naive-ensemble](slice_wine_quality@s43_naive-ensemble.png)
+
+
+---
+
+## wine_quality@s44  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.59391** (winner retrained in 1.20s, cv score of winner: 0.6701)
+- cv best RMSE: 0.6701, median: 0.6780, p10: 0.6734
+- train: median 0.630s/fold, mean 0.557s, p90 0.797s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.454 |
+| `learning_rate` | 0.380 |
+| `min_data_in_leaf` | 0.088 |
+| `max_depth` | 0.019 |
+| `feature_fraction` | 0.017 |
+| `bagging_freq` | 0.015 |
+| `n_models` | 0.012 |
+| `num_leaves` | 0.006 |
+| `lambda_l1` | 0.005 |
+| `bagging_fraction` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.6813 | 0.0106 | 0.6701 |
+| True | 21 | 0.7198 | 0.0259 | 0.6945 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6902 | 0.6795 | 0.6794 | 0.6869 | **Q3** [0.0638, 0.0783] |
+| `num_leaves` | 0.6900 | 0.6833 | 0.6836 | 0.6794 | **Q4** [124.0, ∞) |
+| `max_depth` | 0.6981 | 0.6817 | — | 0.6818 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | — | 0.6777 | 0.6812 | 0.6986 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 0.6908 | 0.6790 | 0.6791 | 0.6872 | **Q2** [0.009, 0.0359] |
+| `lambda_l2` | 0.6887 | 0.6833 | 0.6800 | 0.6841 | **Q3** [0.0032, 0.0092] |
+| `feature_fraction` | 0.6804 | 0.6792 | 0.6854 | 0.6912 | **Q2** [0.5295, 0.565] |
+| `bagging_fraction` | 0.6933 | 0.6829 | 0.6794 | 0.6805 | **Q3** [0.8318, 0.8602] |
+
+#### E. Slice plot
+
+![wine_quality@s44/naive-ensemble](slice_wine_quality@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v081/ds_wine_quality_ensemble_summary.json
+++ b/bench_results/meth2_v081/ds_wine_quality_ensemble_summary.json
@@ -1,0 +1,1145 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "wine_quality"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "wine_quality": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6070632952920164,
+      "cv_best": 0.6650850798093074,
+      "crash_rate": 0.0,
+      "retrain_s": 1.5524
+     },
+     "43": {
+      "holdout_rmse": 0.6235949651424885,
+      "cv_best": 0.6573574143310335,
+      "crash_rate": 0.0,
+      "retrain_s": 1.3239
+     },
+     "44": {
+      "holdout_rmse": 0.5939066886200302,
+      "cv_best": 0.6700958043136409,
+      "crash_rate": 0.0,
+      "retrain_s": 1.1961
+     }
+    },
+    "holdout_mean": 0.608188,
+    "holdout_std": 0.012146,
+    "cv_best_mean": 0.664179
+   }
+  }
+ },
+ "runs": {
+  "wine_quality@s42": {
+   "dataset": "wine_quality",
+   "seed": 42,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.814159292035399,
+    "std": 0.8812175760471399
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6650850798093074,
+    "rmse_p10": 0.6666960309280181,
+    "rmse_median": 0.6706633299431639,
+    "train_s_median": 1.1229742128401994,
+    "train_s_mean": 0.9987735563839476,
+    "train_s_p90": 1.502671145498753,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.05006058097665773,
+     "num_leaves": 107,
+     "max_depth": 12,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 0.05783266775622405,
+     "lambda_l2": 0.00018077432023892078,
+     "feature_fraction": 0.8099984761627959,
+     "bagging_fraction": 0.6345576339275214,
+     "bagging_freq": 7,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4665,
+     "learning_rate": 0.3096,
+     "min_data_in_leaf": 0.1281,
+     "max_depth": 0.0293,
+     "feature_fraction": 0.0242,
+     "n_models": 0.0219,
+     "lambda_l1": 0.007,
+     "num_leaves": 0.0058,
+     "bagging_fraction": 0.0051,
+     "bagging_freq": 0.0024,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 0.675,
+        "std": 0.0122,
+        "min": 0.6651
+       },
+       "True": {
+        "n": 20,
+        "mean": 0.7165,
+        "std": 0.0252,
+        "min": 0.6842
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0415,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0475
+       ],
+       "n": 75,
+       "mean_rmse": 0.6869
+      },
+      "Q2": {
+       "range": [
+        0.0475,
+        0.0565
+       ],
+       "n": 75,
+       "mean_rmse": 0.6736
+      },
+      "Q3": {
+       "range": [
+        0.0565,
+        0.0658
+       ],
+       "n": 75,
+       "mean_rmse": 0.6719
+      },
+      "Q4": {
+       "range": [
+        0.0658,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6787
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        103.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6832
+      },
+      "Q2": {
+       "range": [
+        103.0,
+        112.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.6768
+      },
+      "Q3": {
+       "range": [
+        112.0,
+        121.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6756
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 86,
+       "mean_rmse": 0.6757
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.6939
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 38,
+       "mean_rmse": 0.6808
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 197,
+       "mean_rmse": 0.6719
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 142,
+       "mean_rmse": 0.6709
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.6758
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.6915
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0135
+       ],
+       "n": 75,
+       "mean_rmse": 0.6856
+      },
+      "Q2": {
+       "range": [
+        0.0135,
+        0.0949
+       ],
+       "n": 75,
+       "mean_rmse": 0.6736
+      },
+      "Q3": {
+       "range": [
+        0.0949,
+        0.2065
+       ],
+       "n": 75,
+       "mean_rmse": 0.6739
+      },
+      "Q4": {
+       "range": [
+        0.2065,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.678
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6804
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 75,
+       "mean_rmse": 0.6748
+      },
+      "Q3": {
+       "range": [
+        0.0002,
+        0.0085
+       ],
+       "n": 75,
+       "mean_rmse": 0.6803
+      },
+      "Q4": {
+       "range": [
+        0.0085,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6756
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6852
+       ],
+       "n": 75,
+       "mean_rmse": 0.6848
+      },
+      "Q2": {
+       "range": [
+        0.6852,
+        0.7443
+       ],
+       "n": 75,
+       "mean_rmse": 0.6726
+      },
+      "Q3": {
+       "range": [
+        0.7443,
+        0.8019
+       ],
+       "n": 75,
+       "mean_rmse": 0.6743
+      },
+      "Q4": {
+       "range": [
+        0.8019,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6794
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6758
+       ],
+       "n": 75,
+       "mean_rmse": 0.6777
+      },
+      "Q2": {
+       "range": [
+        0.6758,
+        0.7057
+       ],
+       "n": 75,
+       "mean_rmse": 0.6728
+      },
+      "Q3": {
+       "range": [
+        0.7057,
+        0.7648
+       ],
+       "n": 75,
+       "mean_rmse": 0.6729
+      },
+      "Q4": {
+       "range": [
+        0.7648,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6877
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1502.7,
+    "holdout": {
+     "holdout_rmse": 0.6070632952920164,
+     "retrain_s": 1.5524,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.6650850798093074
+    }
+   }
+  },
+  "wine_quality@s43": {
+   "dataset": "wine_quality",
+   "seed": 43,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.824163139669103,
+    "std": 0.8714271981133532
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6573574143310335,
+    "rmse_p10": 0.6594121474549902,
+    "rmse_median": 0.6623378218811278,
+    "train_s_median": 0.8199129980057478,
+    "train_s_mean": 0.7586597979130845,
+    "train_s_p90": 1.1083630809560419,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.09615740525816543,
+     "num_leaves": 113,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0005297723703777012,
+     "lambda_l2": 2.1652179398172016e-07,
+     "feature_fraction": 0.6379982913902352,
+     "bagging_fraction": 0.8900954387344908,
+     "bagging_freq": 7,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.3334,
+     "learning_rate": 0.3207,
+     "min_data_in_leaf": 0.2,
+     "max_depth": 0.0883,
+     "bagging_fraction": 0.0205,
+     "bagging_freq": 0.0123,
+     "n_models": 0.0079,
+     "feature_fraction": 0.0075,
+     "num_leaves": 0.0073,
+     "lambda_l2": 0.0017,
+     "lambda_l1": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 278,
+        "mean": 0.666,
+        "std": 0.0104,
+        "min": 0.6574
+       },
+       "True": {
+        "n": 22,
+        "mean": 0.7032,
+        "std": 0.0223,
+        "min": 0.677
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0372,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0871
+       ],
+       "n": 75,
+       "mean_rmse": 0.6781
+      },
+      "Q2": {
+       "range": [
+        0.0871,
+        0.1006
+       ],
+       "n": 75,
+       "mean_rmse": 0.6635
+      },
+      "Q3": {
+       "range": [
+        0.1006,
+        0.1155
+       ],
+       "n": 75,
+       "mean_rmse": 0.6628
+      },
+      "Q4": {
+       "range": [
+        0.1155,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6706
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        111.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.6791
+      },
+      "Q2": {
+       "range": [
+        111.0,
+        120.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.6659
+      },
+      "Q3": {
+       "range": [
+        120.0,
+        124.25
+       ],
+       "n": 79,
+       "mean_rmse": 0.6653
+      },
+      "Q4": {
+       "range": [
+        124.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6648
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 51,
+       "mean_rmse": 0.6862
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 39,
+       "mean_rmse": 0.6663
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 210,
+       "mean_rmse": 0.6649
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 141,
+       "mean_rmse": 0.6631
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.6652
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.6831
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.673
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.6683
+      },
+      "Q3": {
+       "range": [
+        0.0003,
+        0.0016
+       ],
+       "n": 75,
+       "mean_rmse": 0.6635
+      },
+      "Q4": {
+       "range": [
+        0.0016,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6701
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6673
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6649
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6653
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6775
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6241
+       ],
+       "n": 75,
+       "mean_rmse": 0.6689
+      },
+      "Q2": {
+       "range": [
+        0.6241,
+        0.6459
+       ],
+       "n": 75,
+       "mean_rmse": 0.6632
+      },
+      "Q3": {
+       "range": [
+        0.6459,
+        0.6796
+       ],
+       "n": 75,
+       "mean_rmse": 0.6655
+      },
+      "Q4": {
+       "range": [
+        0.6796,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6774
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8801
+       ],
+       "n": 75,
+       "mean_rmse": 0.6782
+      },
+      "Q2": {
+       "range": [
+        0.8801,
+        0.902
+       ],
+       "n": 75,
+       "mean_rmse": 0.6641
+      },
+      "Q3": {
+       "range": [
+        0.902,
+        0.9382
+       ],
+       "n": 75,
+       "mean_rmse": 0.6652
+      },
+      "Q4": {
+       "range": [
+        0.9382,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6674
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1142.1,
+    "holdout": {
+     "holdout_rmse": 0.6235949651424885,
+     "retrain_s": 1.3239,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.6573574143310335
+    }
+   }
+  },
+  "wine_quality@s44": {
+   "dataset": "wine_quality",
+   "seed": 44,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.82185455944594,
+    "std": 0.880623502625106
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6700958043136409,
+    "rmse_p10": 0.6734164286432799,
+    "rmse_median": 0.6779982388398629,
+    "train_s_median": 0.6295880591496825,
+    "train_s_mean": 0.5572875729451577,
+    "train_s_p90": 0.7972703709825874,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.0657236973098598,
+     "num_leaves": 123,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.1104858324234023e-07,
+     "lambda_l2": 0.004513587360379444,
+     "feature_fraction": 0.5718944483732363,
+     "bagging_fraction": 0.8188822902247452,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4543,
+     "learning_rate": 0.3795,
+     "min_data_in_leaf": 0.0879,
+     "max_depth": 0.0191,
+     "feature_fraction": 0.017,
+     "bagging_freq": 0.0155,
+     "n_models": 0.012,
+     "num_leaves": 0.006,
+     "lambda_l1": 0.0049,
+     "bagging_fraction": 0.0034,
+     "lambda_l2": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.7198,
+        "std": 0.0259,
+        "min": 0.6945
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.6813,
+        "std": 0.0106,
+        "min": 0.6701
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0385,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0527
+       ],
+       "n": 75,
+       "mean_rmse": 0.6902
+      },
+      "Q2": {
+       "range": [
+        0.0527,
+        0.0638
+       ],
+       "n": 75,
+       "mean_rmse": 0.6795
+      },
+      "Q3": {
+       "range": [
+        0.0638,
+        0.0783
+       ],
+       "n": 75,
+       "mean_rmse": 0.6794
+      },
+      "Q4": {
+       "range": [
+        0.0783,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6869
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        84.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.69
+      },
+      "Q2": {
+       "range": [
+        84.0,
+        103.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.6833
+      },
+      "Q3": {
+       "range": [
+        103.5,
+        124.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.6836
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.6794
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 41,
+       "mean_rmse": 0.6981
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 40,
+       "mean_rmse": 0.6817
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 219,
+       "mean_rmse": 0.6818
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 143,
+       "mean_rmse": 0.6777
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        13.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.6812
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.6986
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.009
+       ],
+       "n": 75,
+       "mean_rmse": 0.6908
+      },
+      "Q2": {
+       "range": [
+        0.009,
+        0.0359
+       ],
+       "n": 75,
+       "mean_rmse": 0.679
+      },
+      "Q3": {
+       "range": [
+        0.0359,
+        0.1131
+       ],
+       "n": 75,
+       "mean_rmse": 0.6791
+      },
+      "Q4": {
+       "range": [
+        0.1131,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6872
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 75,
+       "mean_rmse": 0.6887
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0032
+       ],
+       "n": 75,
+       "mean_rmse": 0.6833
+      },
+      "Q3": {
+       "range": [
+        0.0032,
+        0.0092
+       ],
+       "n": 75,
+       "mean_rmse": 0.68
+      },
+      "Q4": {
+       "range": [
+        0.0092,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6841
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5295
+       ],
+       "n": 75,
+       "mean_rmse": 0.6804
+      },
+      "Q2": {
+       "range": [
+        0.5295,
+        0.565
+       ],
+       "n": 75,
+       "mean_rmse": 0.6792
+      },
+      "Q3": {
+       "range": [
+        0.565,
+        0.6424
+       ],
+       "n": 75,
+       "mean_rmse": 0.6854
+      },
+      "Q4": {
+       "range": [
+        0.6424,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6912
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7324
+       ],
+       "n": 75,
+       "mean_rmse": 0.6933
+      },
+      "Q2": {
+       "range": [
+        0.7324,
+        0.8318
+       ],
+       "n": 75,
+       "mean_rmse": 0.6829
+      },
+      "Q3": {
+       "range": [
+        0.8318,
+        0.8602
+       ],
+       "n": 75,
+       "mean_rmse": 0.6794
+      },
+      "Q4": {
+       "range": [
+        0.8602,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6805
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 839.6,
+    "holdout": {
+     "holdout_rmse": 0.5939066886200302,
+     "retrain_s": 1.1961,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.6700958043136409
+    }
+   }
+  }
+ }
+}

--- a/bench_results/meth2_v081/ds_wine_quality_report.md
+++ b/bench_results/meth2_v081/ds_wine_quality_report.md
@@ -1,0 +1,492 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 300
+
+- **Datasets**: ['wine_quality'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `5232455cdc8d`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| wine_quality | naive-lightgbm | **0.61547** ± 0.01639 | 0.66867 | 0.0% | 0.57 |
+| wine_quality | moe | **0.61920** ± 0.01025 | 0.67219 | 0.0% | 5.99 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| wine_quality@s42 | naive-lightgbm | 0.6678 | 0.6775 | 0.402 | 583 |
+| wine_quality@s42 | moe | 0.6823 | 0.6921 | 0.874 | 2286 |
+| wine_quality@s43 | naive-lightgbm | 0.6630 | 0.6686 | 0.446 | 618 |
+| wine_quality@s43 | moe | 0.6597 | 0.6709 | 2.255 | 4044 |
+| wine_quality@s44 | naive-lightgbm | 0.6752 | 0.6836 | 0.260 | 352 |
+| wine_quality@s44 | moe | 0.6747 | 0.6855 | 1.519 | 3474 |
+
+
+
+---
+
+## wine_quality@s42  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.60747** (winner retrained in 0.55s, cv score of winner: 0.6678)
+- cv best RMSE: 0.6678, median: 0.6775, p10: 0.6709
+- train: median 0.402s/fold, mean 0.384s, p90 0.597s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.427 |
+| `extra_trees` | 0.294 |
+| `min_data_in_leaf` | 0.180 |
+| `max_depth` | 0.043 |
+| `bagging_fraction` | 0.023 |
+| `feature_fraction` | 0.018 |
+| `num_leaves` | 0.007 |
+| `bagging_freq` | 0.005 |
+| `lambda_l2` | 0.002 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 278 | 0.6799 | 0.0108 | 0.6678 |
+| True | 22 | 0.7226 | 0.0318 | 0.6907 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6896 | 0.6759 | 0.6794 | 0.6871 | **Q2** [0.0424, 0.0489] |
+| `num_leaves` | 0.6918 | 0.6845 | 0.6780 | 0.6778 | **Q4** [120.25, ∞) |
+| `max_depth` | 0.6997 | 0.6796 | — | 0.6782 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6774 | 0.6765 | 0.6788 | 0.6981 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 0.6817 | 0.6793 | 0.6787 | 0.6923 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.6775 | 0.6869 | 0.6872 | 0.6804 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.6831 | 0.6797 | 0.6814 | 0.6878 | **Q2** [0.623, 0.6574] |
+| `bagging_fraction` | 0.6905 | 0.6807 | 0.6772 | 0.6836 | **Q3** [0.8827, 0.9014] |
+
+#### E. Slice plot
+
+![wine_quality@s42/naive-lightgbm](slice_wine_quality@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.60869** (winner retrained in 12.85s, cv score of winner: 0.6823)
+- cv best RMSE: 0.6823, median: 0.6921, p10: 0.6853
+- train: median 0.874s/fold, mean 1.507s, p90 2.930s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.461 |
+| `lambda_l1` | 0.233 |
+| `mixture_diversity_lambda` | 0.053 |
+| `learning_rate` | 0.048 |
+| `mixture_gate_type` | 0.030 |
+| `bagging_fraction` | 0.027 |
+| `extra_trees` | 0.023 |
+| `feature_fraction` | 0.018 |
+| `bagging_freq` | 0.018 |
+| `mixture_e_step_mode` | 0.017 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 206 | 0.8358 | 0.5626 | 0.6828 |
+| gbdt | 59 | 0.8736 | 0.7408 | 0.6823 |
+| none | 35 | 0.9949 | 0.8207 | 0.6911 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 88 | 0.8610 | 0.5737 | 0.6823 |
+| token_choice | 212 | 0.8622 | 0.6622 | 0.6828 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 43 | 0.8371 | 0.4076 | 0.6826 |
+| gate_only | 223 | 0.8551 | 0.6470 | 0.6823 |
+| em | 34 | 0.9375 | 0.7898 | 0.6823 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 176 | 0.7662 | 0.3917 | 0.6823 |
+| tree_hierarchical | 14 | 0.8962 | 0.2927 | 0.6874 |
+| random | 80 | 0.9998 | 0.8487 | 0.6865 |
+| uniform | 30 | 1.0390 | 1.0327 | 0.6911 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 166 | 0.7813 | 0.4797 | 0.6823 |
+| markov | 33 | 0.8718 | 0.4389 | 0.6911 |
+| none | 101 | 0.9910 | 0.8595 | 0.6856 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 197 | 0.7764 | 0.4010 | 0.6823 |
+| True | 103 | 1.0251 | 0.9141 | 0.6892 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 270 | 0.8159 | 0.5104 | 0.6823 |
+| True | 30 | 1.2747 | 1.2368 | 0.6998 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9636 | 0.9981 | — | 0.7699 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.7007 | 0.7429 | 1.0417 | 0.9619 | **Q1** [None, 0.0128] |
+| `mixture_warmup_iters` | 0.7916 | 0.7564 | 0.9439 | 0.9462 | **Q2** [24.0, 28.0] |
+| `mixture_balance_factor` | — | — | 0.7848 | 1.0889 | **Q3** [2.0, 5.0] |
+| `learning_rate` | 1.0842 | 0.6937 | 0.7682 | 0.9011 | **Q2** [0.1184, 0.1425] |
+| `num_leaves` | 0.7363 | 0.8116 | 1.1113 | 0.7776 | **Q1** [None, 33.0] |
+| `max_depth` | 1.1286 | — | — | 0.7895 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 0.8454 | 0.7881 | 0.8132 | 0.9935 | **Q2** [48.0, 53.0] |
+
+#### E. Slice plot
+
+![wine_quality@s42/moe](slice_wine_quality@s42_moe.png)
+
+
+---
+
+## wine_quality@s43  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.63831** (winner retrained in 0.73s, cv score of winner: 0.6630)
+- cv best RMSE: 0.6630, median: 0.6686, p10: 0.6653
+- train: median 0.446s/fold, mean 0.406s, p90 0.620s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.431 |
+| `extra_trees` | 0.408 |
+| `min_data_in_leaf` | 0.061 |
+| `bagging_freq` | 0.032 |
+| `bagging_fraction` | 0.023 |
+| `max_depth` | 0.019 |
+| `num_leaves` | 0.011 |
+| `feature_fraction` | 0.010 |
+| `lambda_l1` | 0.003 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 279 | 0.6728 | 0.0112 | 0.6630 |
+| True | 21 | 0.7180 | 0.0213 | 0.6886 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6847 | 0.6711 | 0.6711 | 0.6770 | **Q2** [0.0516, 0.0598] |
+| `num_leaves` | 0.6877 | 0.6725 | 0.6726 | 0.6714 | **Q4** [123.0, ∞) |
+| `max_depth` | 0.6871 | — | 0.6741 | 0.6718 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6692 | 0.6715 | 0.6725 | 0.6894 | **Q1** [None, 6.0] |
+| `lambda_l1` | 0.6831 | 0.6735 | 0.6698 | 0.6776 | **Q3** [0.0733, 0.1665] |
+| `lambda_l2` | 0.6754 | 0.6693 | 0.6759 | 0.6834 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6737 | 0.6716 | 0.6720 | 0.6867 | **Q2** [0.5368, 0.5666] |
+| `bagging_fraction` | 0.6761 | 0.6727 | 0.6702 | 0.6851 | **Q3** [0.6535, 0.6781] |
+
+#### E. Slice plot
+
+![wine_quality@s43/naive-lightgbm](slice_wine_quality@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.63309** (winner retrained in 2.94s, cv score of winner: 0.6597)
+- cv best RMSE: 0.6597, median: 0.6709, p10: 0.6628
+- train: median 2.255s/fold, mean 2.670s, p90 4.948s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.304 |
+| `bagging_fraction` | 0.113 |
+| `feature_fraction` | 0.087 |
+| `max_depth` | 0.069 |
+| `learning_rate` | 0.068 |
+| `mixture_r_smoothing` | 0.059 |
+| `min_data_in_leaf` | 0.051 |
+| `num_leaves` | 0.043 |
+| `mixture_gate_type` | 0.041 |
+| `mixture_init` | 0.036 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 263 | 0.7349 | 0.3441 | 0.6597 |
+| none | 21 | 0.9407 | 0.6219 | 0.6678 |
+| leaf_reuse | 16 | 1.2272 | 1.1813 | 0.6895 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 273 | 0.7431 | 0.3476 | 0.6597 |
+| token_choice | 27 | 1.1034 | 1.0488 | 0.6700 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 116 | 0.7507 | 0.3122 | 0.6609 |
+| loss_only | 167 | 0.7539 | 0.4124 | 0.6597 |
+| gate_only | 17 | 1.1570 | 1.1767 | 0.6670 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 250 | 0.7378 | 0.3501 | 0.6597 |
+| uniform | 18 | 0.7442 | 0.1743 | 0.6663 |
+| tree_hierarchical | 15 | 0.8774 | 0.3601 | 0.6708 |
+| random | 17 | 1.2738 | 1.2829 | 0.6677 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 261 | 0.7342 | 0.3442 | 0.6597 |
+| markov | 19 | 1.0443 | 1.1163 | 0.6688 |
+| none | 20 | 1.0597 | 0.6263 | 0.6779 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 276 | 0.7332 | 0.2852 | 0.6597 |
+| True | 24 | 1.2621 | 1.2457 | 0.6691 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 20 | 0.7670 | 0.1875 | 0.6822 |
+| False | 280 | 0.7761 | 0.4824 | 0.6597 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.8473 | — | — | 0.7709 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 0.7244 | 0.8071 | 0.6892 | 0.8814 | **Q3** [0.0956, 0.1205] |
+| `mixture_warmup_iters` | 0.8107 | 0.7237 | 0.7840 | 0.7779 | **Q2** [23.0, 26.0] |
+| `mixture_balance_factor` | 1.1795 | 0.7311 | — | 0.7479 | **Q2** [6.0, 8.0] |
+| `learning_rate` | 0.8472 | 0.7250 | 0.7222 | 0.8077 | **Q3** [0.0667, 0.0904] |
+| `num_leaves` | 0.8544 | 0.7413 | 0.7067 | 0.8106 | **Q3** [74.0, 84.25] |
+| `max_depth` | 0.9125 | 0.7428 | 0.7866 | 0.7318 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 0.7297 | 0.7564 | 0.7965 | 0.8117 | **Q1** [None, 10.0] |
+
+#### E. Slice plot
+
+![wine_quality@s43/moe](slice_wine_quality@s43_moe.png)
+
+
+---
+
+## wine_quality@s44  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.60061** (winner retrained in 0.44s, cv score of winner: 0.6752)
+- cv best RMSE: 0.6752, median: 0.6836, p10: 0.6790
+- train: median 0.260s/fold, mean 0.230s, p90 0.339s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.498 |
+| `learning_rate` | 0.184 |
+| `min_data_in_leaf` | 0.092 |
+| `max_depth` | 0.059 |
+| `bagging_fraction` | 0.057 |
+| `num_leaves` | 0.049 |
+| `bagging_freq` | 0.028 |
+| `lambda_l2` | 0.015 |
+| `feature_fraction` | 0.014 |
+| `lambda_l1` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 277 | 0.6869 | 0.0103 | 0.6752 |
+| True | 23 | 0.7177 | 0.0155 | 0.6983 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6919 | 0.6861 | 0.6853 | 0.6937 | **Q3** [0.0494, 0.0663] |
+| `num_leaves` | 0.6991 | 0.6865 | 0.6863 | 0.6856 | **Q4** [121.0, ∞) |
+| `max_depth` | 0.6980 | — | 0.6845 | 0.6934 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | — | 0.6835 | 0.6883 | 0.7004 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 0.6947 | 0.6862 | 0.6849 | 0.6913 | **Q3** [0.027, 0.0871] |
+| `lambda_l2` | 0.6903 | 0.6838 | 0.6869 | 0.6962 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6873 | 0.6854 | 0.6856 | 0.6989 | **Q2** [0.5384, 0.5618] |
+| `bagging_fraction` | 0.7004 | 0.6865 | 0.6836 | 0.6866 | **Q3** [0.9024, 0.9231] |
+
+#### E. Slice plot
+
+![wine_quality@s44/naive-lightgbm](slice_wine_quality@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.61581** (winner retrained in 2.19s, cv score of winner: 0.6747)
+- cv best RMSE: 0.6747, median: 0.6855, p10: 0.6779
+- train: median 1.519s/fold, mean 2.299s, p90 5.477s
+- finite trials: 300 / 300
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.396 |
+| `lambda_l1` | 0.337 |
+| `bagging_fraction` | 0.038 |
+| `feature_fraction` | 0.036 |
+| `mixture_e_step_mode` | 0.036 |
+| `mixture_hard_m_step` | 0.034 |
+| `mixture_gate_type` | 0.023 |
+| `learning_rate` | 0.022 |
+| `mixture_warmup_iters` | 0.019 |
+| `mixture_r_smoothing` | 0.018 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 261 | 0.7639 | 0.4972 | 0.6747 |
+| leaf_reuse | 21 | 1.0345 | 0.6712 | 0.6911 |
+| none | 18 | 1.3239 | 1.1068 | 0.6917 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 250 | 0.8090 | 0.5930 | 0.6747 |
+| token_choice | 50 | 0.8537 | 0.5364 | 0.6756 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 31 | 0.7871 | 0.2774 | 0.6778 |
+| loss_only | 241 | 0.8016 | 0.5802 | 0.6747 |
+| gate_only | 28 | 0.9761 | 0.8036 | 0.6773 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 16 | 0.7108 | 0.0317 | 0.6841 |
+| tree_hierarchical | 19 | 0.7887 | 0.2049 | 0.6896 |
+| gmm | 219 | 0.7896 | 0.5295 | 0.6747 |
+| random | 46 | 0.9923 | 0.9138 | 0.6870 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 141 | 0.7693 | 0.5133 | 0.6747 |
+| ema | 101 | 0.7785 | 0.4059 | 0.6758 |
+| none | 58 | 0.9970 | 0.8931 | 0.6799 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 279 | 0.7757 | 0.5007 | 0.6747 |
+| False | 21 | 1.3575 | 1.1093 | 0.6823 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 30 | 0.7614 | 0.1672 | 0.7013 |
+| False | 270 | 0.8225 | 0.6130 | 0.6747 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.8038 | 0.8428 | — | 0.8077 | **Q1** [None, 3.0] |
+| `mixture_diversity_lambda` | 0.8835 | 0.8844 | 0.7337 | 0.7642 | **Q3** [0.3829, 0.417] |
+| `mixture_warmup_iters` | 0.9755 | 0.7210 | 0.7932 | 0.7878 | **Q2** [43.0, 47.5] |
+| `mixture_balance_factor` | 1.2272 | 0.7947 | — | 0.7672 | **Q4** [5.0, ∞) |
+| `learning_rate` | 0.8516 | 0.7445 | 0.8151 | 0.8546 | **Q2** [0.0563, 0.0714] |
+| `num_leaves` | 0.7957 | 0.8429 | 0.7414 | 0.8835 | **Q3** [73.0, 85.0] |
+| `max_depth` | 1.0047 | — | 0.7301 | 0.8450 | **Q3** [10.0, 11.0] |
+| `min_data_in_leaf` | 0.8283 | 0.7450 | 0.7715 | 0.9123 | **Q2** [7.0, 9.0] |
+
+#### E. Slice plot
+
+![wine_quality@s44/moe](slice_wine_quality@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/meth2_v081/ds_wine_quality_summary.json
+++ b/bench_results/meth2_v081/ds_wine_quality_summary.json
@@ -1,0 +1,2756 @@
+{
+ "config": {
+  "trials": 300,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "wine_quality"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "5232455cdc8d575b446d0c882d3467fbc5682ec1",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "wine_quality": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6074681092037725,
+      "cv_best": 0.6678315805287544,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5506
+     },
+     "43": {
+      "holdout_rmse": 0.6383110160230044,
+      "cv_best": 0.6630117003555592,
+      "crash_rate": 0.0,
+      "retrain_s": 0.7307
+     },
+     "44": {
+      "holdout_rmse": 0.6006148504583017,
+      "cv_best": 0.6751723908916849,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4385
+     }
+    },
+    "holdout_mean": 0.615465,
+    "holdout_std": 0.016395,
+    "cv_best_mean": 0.668672
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6086904014228621,
+      "cv_best": 0.6822502400468365,
+      "crash_rate": 0.0,
+      "retrain_s": 12.8492
+     },
+     "43": {
+      "holdout_rmse": 0.633091453662589,
+      "cv_best": 0.6596629866593664,
+      "crash_rate": 0.0,
+      "retrain_s": 2.9381
+     },
+     "44": {
+      "holdout_rmse": 0.6158083527117513,
+      "cv_best": 0.6746509644301645,
+      "crash_rate": 0.0,
+      "retrain_s": 2.1854
+     }
+    },
+    "holdout_mean": 0.619197,
+    "holdout_std": 0.010246,
+    "cv_best_mean": 0.672188
+   }
+  }
+ },
+ "runs": {
+  "wine_quality@s42": {
+   "dataset": "wine_quality",
+   "seed": 42,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.814159292035399,
+    "std": 0.8812175760471399
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6678315805287544,
+    "rmse_p10": 0.6709041883958695,
+    "rmse_median": 0.6774949609121834,
+    "train_s_median": 0.401563255302608,
+    "train_s_mean": 0.38351287299767134,
+    "train_s_p90": 0.5974481502920389,
+    "best_params": {
+     "learning_rate": 0.04561171136354861,
+     "num_leaves": 112,
+     "max_depth": 12,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 1.1006876169427215e-06,
+     "lambda_l2": 0.01627506790725957,
+     "feature_fraction": 0.6077025846821319,
+     "bagging_fraction": 0.8927049696094213,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.427,
+     "extra_trees": 0.2942,
+     "min_data_in_leaf": 0.1805,
+     "max_depth": 0.0435,
+     "bagging_fraction": 0.0231,
+     "feature_fraction": 0.0176,
+     "num_leaves": 0.007,
+     "bagging_freq": 0.0052,
+     "lambda_l2": 0.0018,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 22,
+        "mean": 0.7226,
+        "std": 0.0318,
+        "min": 0.6907
+       },
+       "False": {
+        "n": 278,
+        "mean": 0.6799,
+        "std": 0.0108,
+        "min": 0.6678
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0427,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0424
+       ],
+       "n": 75,
+       "mean_rmse": 0.6896
+      },
+      "Q2": {
+       "range": [
+        0.0424,
+        0.0489
+       ],
+       "n": 75,
+       "mean_rmse": 0.6759
+      },
+      "Q3": {
+       "range": [
+        0.0489,
+        0.06
+       ],
+       "n": 75,
+       "mean_rmse": 0.6794
+      },
+      "Q4": {
+       "range": [
+        0.06,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6871
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        79.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.6918
+      },
+      "Q2": {
+       "range": [
+        79.0,
+        111.5
+       ],
+       "n": 76,
+       "mean_rmse": 0.6845
+      },
+      "Q3": {
+       "range": [
+        111.5,
+        120.25
+       ],
+       "n": 75,
+       "mean_rmse": 0.678
+      },
+      "Q4": {
+       "range": [
+        120.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6778
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 63,
+       "mean_rmse": 0.6997
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.6796
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 183,
+       "mean_rmse": 0.6782
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.6774
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6765
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6788
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.6981
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6817
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6793
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6787
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6923
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6775
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6869
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0133
+       ],
+       "n": 75,
+       "mean_rmse": 0.6872
+      },
+      "Q4": {
+       "range": [
+        0.0133,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6804
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.623
+       ],
+       "n": 75,
+       "mean_rmse": 0.6831
+      },
+      "Q2": {
+       "range": [
+        0.623,
+        0.6574
+       ],
+       "n": 75,
+       "mean_rmse": 0.6797
+      },
+      "Q3": {
+       "range": [
+        0.6574,
+        0.7561
+       ],
+       "n": 75,
+       "mean_rmse": 0.6814
+      },
+      "Q4": {
+       "range": [
+        0.7561,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6878
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8435
+       ],
+       "n": 75,
+       "mean_rmse": 0.6905
+      },
+      "Q2": {
+       "range": [
+        0.8435,
+        0.8827
+       ],
+       "n": 75,
+       "mean_rmse": 0.6807
+      },
+      "Q3": {
+       "range": [
+        0.8827,
+        0.9014
+       ],
+       "n": 75,
+       "mean_rmse": 0.6772
+      },
+      "Q4": {
+       "range": [
+        0.9014,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6836
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 583.3,
+    "holdout": {
+     "holdout_rmse": 0.6074681092037725,
+     "retrain_s": 0.5506,
+     "predict_s": 0.003,
+     "cv_rmse_of_winner": 0.6678315805287544
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6822502400468365,
+    "rmse_p10": 0.6853077877579385,
+    "rmse_median": 0.6921281345730609,
+    "train_s_median": 0.8739855011925102,
+    "train_s_mean": 1.5069942800812421,
+    "train_s_p90": 2.9302618983761484,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.18551279938371848,
+     "num_leaves": 119,
+     "max_depth": 12,
+     "min_data_in_leaf": 55,
+     "lambda_l1": 0.0005251033458498782,
+     "lambda_l2": 0.03280616257691427,
+     "feature_fraction": 0.7069469283056291,
+     "bagging_fraction": 0.5000945798932566,
+     "bagging_freq": 2,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 34,
+     "mixture_balance_factor": 3,
+     "mixture_smoothing_lambda": 0.5537332628502684,
+     "mixture_diversity_lambda": 0.03217052307969458,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 40,
+     "mixture_gate_learning_rate": 0.017354278006405214,
+     "mixture_gate_lambda_l2": 0.0017789636396016108,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 1.326590925501422,
+     "mixture_expert_choice_boost": 8.248857066217287,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.08715027397619997,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "lambda_l2": 0.4605,
+     "lambda_l1": 0.2329,
+     "mixture_diversity_lambda": 0.0532,
+     "learning_rate": 0.0479,
+     "mixture_gate_type": 0.0299,
+     "bagging_fraction": 0.027,
+     "extra_trees": 0.023,
+     "feature_fraction": 0.0178,
+     "bagging_freq": 0.0175,
+     "mixture_e_step_mode": 0.0173,
+     "mixture_balance_factor": 0.017,
+     "num_leaves": 0.0169,
+     "mixture_init": 0.0137,
+     "min_data_in_leaf": 0.01,
+     "mixture_num_experts": 0.0059,
+     "max_depth": 0.0057,
+     "mixture_r_smoothing": 0.0023,
+     "mixture_warmup_iters": 0.0014,
+     "mixture_hard_m_step": 0.0001,
+     "mixture_routing_mode": 0.0,
+     "mixture_refit_leaves": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 206,
+        "mean": 0.8358,
+        "std": 0.5626,
+        "min": 0.6828
+       },
+       "none": {
+        "n": 35,
+        "mean": 0.9949,
+        "std": 0.8207,
+        "min": 0.6911
+       },
+       "gbdt": {
+        "n": 59,
+        "mean": 0.8736,
+        "std": 0.7408,
+        "min": 0.6823
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0378,
+       "p_value": 0.719998,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 212,
+        "mean": 0.8622,
+        "std": 0.6622,
+        "min": 0.6828
+       },
+       "expert_choice": {
+        "n": 88,
+        "mean": 0.861,
+        "std": 0.5737,
+        "min": 0.6823
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0012,
+       "p_value": 0.988279,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 43,
+        "mean": 0.8371,
+        "std": 0.4076,
+        "min": 0.6826
+       },
+       "gate_only": {
+        "n": 223,
+        "mean": 0.8551,
+        "std": 0.647,
+        "min": 0.6823
+       },
+       "em": {
+        "n": 34,
+        "mean": 0.9375,
+        "std": 0.7898,
+        "min": 0.6823
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.018,
+       "p_value": 0.814357,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "random": {
+        "n": 80,
+        "mean": 0.9998,
+        "std": 0.8487,
+        "min": 0.6865
+       },
+       "gmm": {
+        "n": 176,
+        "mean": 0.7662,
+        "std": 0.3917,
+        "min": 0.6823
+       },
+       "tree_hierarchical": {
+        "n": 14,
+        "mean": 0.8962,
+        "std": 0.2927,
+        "min": 0.6874
+       },
+       "uniform": {
+        "n": 30,
+        "mean": 1.039,
+        "std": 1.0327,
+        "min": 0.6911
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.13,
+       "p_value": 0.150925,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 166,
+        "mean": 0.7813,
+        "std": 0.4797,
+        "min": 0.6823
+       },
+       "markov": {
+        "n": 33,
+        "mean": 0.8718,
+        "std": 0.4389,
+        "min": 0.6911
+       },
+       "none": {
+        "n": 101,
+        "mean": 0.991,
+        "std": 0.8595,
+        "min": 0.6856
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0905,
+       "p_value": 0.298525,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 103,
+        "mean": 1.0251,
+        "std": 0.9141,
+        "min": 0.6892
+       },
+       "False": {
+        "n": 197,
+        "mean": 0.7764,
+        "std": 0.401,
+        "min": 0.6823
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2487,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 30,
+        "mean": 1.2747,
+        "std": 1.2368,
+        "min": 0.6998
+       },
+       "False": {
+        "n": 270,
+        "mean": 0.8159,
+        "std": 0.5104,
+        "min": 0.6823
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.4588,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 41,
+       "mean_rmse": 0.9636
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 86,
+       "mean_rmse": 0.9981
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 173,
+       "mean_rmse": 0.7699
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0128
+       ],
+       "n": 75,
+       "mean_rmse": 0.7007
+      },
+      "Q2": {
+       "range": [
+        0.0128,
+        0.0382
+       ],
+       "n": 75,
+       "mean_rmse": 0.7429
+      },
+      "Q3": {
+       "range": [
+        0.0382,
+        0.1535
+       ],
+       "n": 75,
+       "mean_rmse": 1.0417
+      },
+      "Q4": {
+       "range": [
+        0.1535,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9619
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        24.0
+       ],
+       "n": 68,
+       "mean_rmse": 0.7916
+      },
+      "Q2": {
+       "range": [
+        24.0,
+        28.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.7564
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        37.25
+       ],
+       "n": 80,
+       "mean_rmse": 0.9439
+      },
+      "Q4": {
+       "range": [
+        37.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9462
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        5.0
+       ],
+       "n": 224,
+       "mean_rmse": 0.7848
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 1.0889
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1184
+       ],
+       "n": 75,
+       "mean_rmse": 1.0842
+      },
+      "Q2": {
+       "range": [
+        0.1184,
+        0.1425
+       ],
+       "n": 75,
+       "mean_rmse": 0.6937
+      },
+      "Q3": {
+       "range": [
+        0.1425,
+        0.1815
+       ],
+       "n": 75,
+       "mean_rmse": 0.7682
+      },
+      "Q4": {
+       "range": [
+        0.1815,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.9011
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        33.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.7363
+      },
+      "Q2": {
+       "range": [
+        33.0,
+        48.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8116
+      },
+      "Q3": {
+       "range": [
+        48.0,
+        115.0
+       ],
+       "n": 77,
+       "mean_rmse": 1.1113
+      },
+      "Q4": {
+       "range": [
+        115.0,
+        null
+       ],
+       "n": 76,
+       "mean_rmse": 0.7776
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 64,
+       "mean_rmse": 1.1286
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 236,
+       "mean_rmse": 0.7895
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        48.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8454
+      },
+      "Q2": {
+       "range": [
+        48.0,
+        53.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.7881
+      },
+      "Q3": {
+       "range": [
+        53.0,
+        59.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8132
+      },
+      "Q4": {
+       "range": [
+        59.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.9935
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2286.5,
+    "holdout": {
+     "holdout_rmse": 0.6086904014228621,
+     "retrain_s": 12.8492,
+     "predict_s": 0.0227,
+     "cv_rmse_of_winner": 0.6822502400468365
+    }
+   }
+  },
+  "wine_quality@s43": {
+   "dataset": "wine_quality",
+   "seed": 43,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.824163139669103,
+    "std": 0.8714271981133532
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6630117003555592,
+    "rmse_p10": 0.6652916949856063,
+    "rmse_median": 0.6686034449229524,
+    "train_s_median": 0.4459565604105592,
+    "train_s_mean": 0.40622116262217367,
+    "train_s_p90": 0.6196634876728058,
+    "best_params": {
+     "learning_rate": 0.058292601472847656,
+     "num_leaves": 124,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.027838010330702843,
+     "lambda_l2": 1.6605084873834622e-05,
+     "feature_fraction": 0.5819151637052645,
+     "bagging_fraction": 0.6562093320646756,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.4315,
+     "extra_trees": 0.408,
+     "min_data_in_leaf": 0.0614,
+     "bagging_freq": 0.0315,
+     "bagging_fraction": 0.0233,
+     "max_depth": 0.0191,
+     "num_leaves": 0.0108,
+     "feature_fraction": 0.0098,
+     "lambda_l1": 0.0025,
+     "lambda_l2": 0.0021
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 21,
+        "mean": 0.718,
+        "std": 0.0213,
+        "min": 0.6886
+       },
+       "False": {
+        "n": 279,
+        "mean": 0.6728,
+        "std": 0.0112,
+        "min": 0.663
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0452,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0516
+       ],
+       "n": 75,
+       "mean_rmse": 0.6847
+      },
+      "Q2": {
+       "range": [
+        0.0516,
+        0.0598
+       ],
+       "n": 75,
+       "mean_rmse": 0.6711
+      },
+      "Q3": {
+       "range": [
+        0.0598,
+        0.0689
+       ],
+       "n": 75,
+       "mean_rmse": 0.6711
+      },
+      "Q4": {
+       "range": [
+        0.0689,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.677
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        98.75
+       ],
+       "n": 75,
+       "mean_rmse": 0.6877
+      },
+      "Q2": {
+       "range": [
+        98.75,
+        116.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6725
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        123.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.6726
+      },
+      "Q4": {
+       "range": [
+        123.0,
+        null
+       ],
+       "n": 86,
+       "mean_rmse": 0.6714
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.6871
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.6741
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 147,
+       "mean_rmse": 0.6718
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.6692
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        9.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.6715
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6725
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 80,
+       "mean_rmse": 0.6894
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0215
+       ],
+       "n": 75,
+       "mean_rmse": 0.6831
+      },
+      "Q2": {
+       "range": [
+        0.0215,
+        0.0733
+       ],
+       "n": 75,
+       "mean_rmse": 0.6735
+      },
+      "Q3": {
+       "range": [
+        0.0733,
+        0.1665
+       ],
+       "n": 75,
+       "mean_rmse": 0.6698
+      },
+      "Q4": {
+       "range": [
+        0.1665,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6776
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6754
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6693
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0018
+       ],
+       "n": 75,
+       "mean_rmse": 0.6759
+      },
+      "Q4": {
+       "range": [
+        0.0018,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6834
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5368
+       ],
+       "n": 75,
+       "mean_rmse": 0.6737
+      },
+      "Q2": {
+       "range": [
+        0.5368,
+        0.5666
+       ],
+       "n": 75,
+       "mean_rmse": 0.6716
+      },
+      "Q3": {
+       "range": [
+        0.5666,
+        0.5929
+       ],
+       "n": 75,
+       "mean_rmse": 0.672
+      },
+      "Q4": {
+       "range": [
+        0.5929,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6867
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6197
+       ],
+       "n": 75,
+       "mean_rmse": 0.6761
+      },
+      "Q2": {
+       "range": [
+        0.6197,
+        0.6535
+       ],
+       "n": 75,
+       "mean_rmse": 0.6727
+      },
+      "Q3": {
+       "range": [
+        0.6535,
+        0.6781
+       ],
+       "n": 75,
+       "mean_rmse": 0.6702
+      },
+      "Q4": {
+       "range": [
+        0.6781,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6851
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 617.7,
+    "holdout": {
+     "holdout_rmse": 0.6383110160230044,
+     "retrain_s": 0.7307,
+     "predict_s": 0.0025,
+     "cv_rmse_of_winner": 0.6630117003555592
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6596629866593664,
+    "rmse_p10": 0.662754363801908,
+    "rmse_median": 0.6708787235454188,
+    "train_s_median": 2.2546238696202634,
+    "train_s_mean": 2.6700533300675455,
+    "train_s_p90": 4.948485972844065,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.06005484311129144,
+     "num_leaves": 78,
+     "max_depth": 11,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 1.5328128490798412e-07,
+     "lambda_l2": 3.0621019417998815e-07,
+     "feature_fraction": 0.8210518443476802,
+     "bagging_fraction": 0.7963217928731064,
+     "bagging_freq": 7,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 24,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.6850984268900384,
+     "mixture_diversity_lambda": 0.09934900670934707,
+     "mixture_hard_m_step": false,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 62,
+     "mixture_gate_learning_rate": 0.1794332577968655,
+     "mixture_gate_lambda_l2": 0.3542194415627409,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_expert_capacity_factor": 0.8271522564294564,
+     "mixture_expert_choice_boost": 21.018082413141784,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.034303102629229296,
+     "mixture_elbo_drop_threshold": 0.004574544200614818,
+     "mixture_elbo_plateau_threshold": 0.00031765250279348217,
+     "mixture_elbo_window": 16,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 3,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "lambda_l1": 0.3038,
+     "bagging_fraction": 0.1129,
+     "feature_fraction": 0.087,
+     "max_depth": 0.0685,
+     "learning_rate": 0.0681,
+     "mixture_r_smoothing": 0.0588,
+     "min_data_in_leaf": 0.0507,
+     "num_leaves": 0.0434,
+     "mixture_gate_type": 0.041,
+     "mixture_init": 0.0357,
+     "mixture_warmup_iters": 0.0303,
+     "mixture_refit_leaves": 0.0261,
+     "mixture_hard_m_step": 0.0219,
+     "mixture_e_step_mode": 0.0159,
+     "mixture_diversity_lambda": 0.0127,
+     "mixture_routing_mode": 0.0098,
+     "mixture_balance_factor": 0.007,
+     "bagging_freq": 0.0051,
+     "lambda_l2": 0.0011,
+     "mixture_num_experts": 0.0001,
+     "extra_trees": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 263,
+        "mean": 0.7349,
+        "std": 0.3441,
+        "min": 0.6597
+       },
+       "none": {
+        "n": 21,
+        "mean": 0.9407,
+        "std": 0.6219,
+        "min": 0.6678
+       },
+       "leaf_reuse": {
+        "n": 16,
+        "mean": 1.2272,
+        "std": 1.1813,
+        "min": 0.6895
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.2058,
+       "p_value": 0.158186,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 273,
+        "mean": 0.7431,
+        "std": 0.3476,
+        "min": 0.6597
+       },
+       "token_choice": {
+        "n": 27,
+        "mean": 1.1034,
+        "std": 1.0488,
+        "min": 0.67
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.3603,
+       "p_value": 0.092945,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 167,
+        "mean": 0.7539,
+        "std": 0.4124,
+        "min": 0.6597
+       },
+       "em": {
+        "n": 116,
+        "mean": 0.7507,
+        "std": 0.3122,
+        "min": 0.6609
+       },
+       "gate_only": {
+        "n": 17,
+        "mean": 1.157,
+        "std": 1.1767,
+        "min": 0.667
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0032,
+       "p_value": 0.941885,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 250,
+        "mean": 0.7378,
+        "std": 0.3501,
+        "min": 0.6597
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 0.8774,
+        "std": 0.3601,
+        "min": 0.6708
+       },
+       "random": {
+        "n": 17,
+        "mean": 1.2738,
+        "std": 1.2829,
+        "min": 0.6677
+       },
+       "uniform": {
+        "n": 18,
+        "mean": 0.7442,
+        "std": 0.1743,
+        "min": 0.6663
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "uniform",
+       "delta_mean": 0.0064,
+       "p_value": 0.894732,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 261,
+        "mean": 0.7342,
+        "std": 0.3442,
+        "min": 0.6597
+       },
+       "none": {
+        "n": 20,
+        "mean": 1.0597,
+        "std": 0.6263,
+        "min": 0.6779
+       },
+       "markov": {
+        "n": 19,
+        "mean": 1.0443,
+        "std": 1.1163,
+        "min": 0.6688
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.3101,
+       "p_value": 0.255214,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 24,
+        "mean": 1.2621,
+        "std": 1.2457,
+        "min": 0.6691
+       },
+       "False": {
+        "n": 276,
+        "mean": 0.7332,
+        "std": 0.2852,
+        "min": 0.6597
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5289,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 280,
+        "mean": 0.7761,
+        "std": 0.4824,
+        "min": 0.6597
+       },
+       "True": {
+        "n": 20,
+        "mean": 0.767,
+        "std": 0.1875,
+        "min": 0.6822
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0091,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 18,
+       "mean_rmse": 0.8473
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 282,
+       "mean_rmse": 0.7709
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.045
+       ],
+       "n": 75,
+       "mean_rmse": 0.7244
+      },
+      "Q2": {
+       "range": [
+        0.045,
+        0.0956
+       ],
+       "n": 75,
+       "mean_rmse": 0.8071
+      },
+      "Q3": {
+       "range": [
+        0.0956,
+        0.1205
+       ],
+       "n": 75,
+       "mean_rmse": 0.6892
+      },
+      "Q4": {
+       "range": [
+        0.1205,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8814
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.8107
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        26.0
+       ],
+       "n": 67,
+       "mean_rmse": 0.7237
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        38.25
+       ],
+       "n": 85,
+       "mean_rmse": 0.784
+      },
+      "Q4": {
+       "range": [
+        38.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.7779
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 24,
+       "mean_rmse": 1.1795
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.7311
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 153,
+       "mean_rmse": 0.7479
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0584
+       ],
+       "n": 75,
+       "mean_rmse": 0.8472
+      },
+      "Q2": {
+       "range": [
+        0.0584,
+        0.0667
+       ],
+       "n": 75,
+       "mean_rmse": 0.725
+      },
+      "Q3": {
+       "range": [
+        0.0667,
+        0.0904
+       ],
+       "n": 75,
+       "mean_rmse": 0.7222
+      },
+      "Q4": {
+       "range": [
+        0.0904,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8077
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        64.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8544
+      },
+      "Q2": {
+       "range": [
+        64.0,
+        74.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.7413
+      },
+      "Q3": {
+       "range": [
+        74.0,
+        84.25
+       ],
+       "n": 79,
+       "mean_rmse": 0.7067
+      },
+      "Q4": {
+       "range": [
+        84.25,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8106
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 58,
+       "mean_rmse": 0.9125
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.7428
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 34,
+       "mean_rmse": 0.7866
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 138,
+       "mean_rmse": 0.7318
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 62,
+       "mean_rmse": 0.7297
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        16.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.7564
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        36.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.7965
+      },
+      "Q4": {
+       "range": [
+        36.0,
+        null
+       ],
+       "n": 77,
+       "mean_rmse": 0.8117
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 4043.7,
+    "holdout": {
+     "holdout_rmse": 0.633091453662589,
+     "retrain_s": 2.9381,
+     "predict_s": 0.0334,
+     "cv_rmse_of_winner": 0.6596629866593664
+    }
+   }
+  },
+  "wine_quality@s44": {
+   "dataset": "wine_quality",
+   "seed": 44,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.82185455944594,
+    "std": 0.880623502625106
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6751723908916849,
+    "rmse_p10": 0.6789699648505451,
+    "rmse_median": 0.6836410835484472,
+    "train_s_median": 0.26002126727253194,
+    "train_s_mean": 0.23026682805269957,
+    "train_s_p90": 0.3393544051423669,
+    "best_params": {
+     "learning_rate": 0.0587143485662275,
+     "num_leaves": 119,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.003573614893132869,
+     "lambda_l2": 0.0004758300725305213,
+     "feature_fraction": 0.550124632729228,
+     "bagging_fraction": 0.899924270649385,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4977,
+     "learning_rate": 0.1841,
+     "min_data_in_leaf": 0.0918,
+     "max_depth": 0.0595,
+     "bagging_fraction": 0.0568,
+     "num_leaves": 0.0488,
+     "bagging_freq": 0.0283,
+     "lambda_l2": 0.015,
+     "feature_fraction": 0.0144,
+     "lambda_l1": 0.0038
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 277,
+        "mean": 0.6869,
+        "std": 0.0103,
+        "min": 0.6752
+       },
+       "True": {
+        "n": 23,
+        "mean": 0.7177,
+        "std": 0.0155,
+        "min": 0.6983
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0308,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0427
+       ],
+       "n": 75,
+       "mean_rmse": 0.6919
+      },
+      "Q2": {
+       "range": [
+        0.0427,
+        0.0494
+       ],
+       "n": 75,
+       "mean_rmse": 0.6861
+      },
+      "Q3": {
+       "range": [
+        0.0494,
+        0.0663
+       ],
+       "n": 75,
+       "mean_rmse": 0.6853
+      },
+      "Q4": {
+       "range": [
+        0.0663,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6937
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        110.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6991
+      },
+      "Q2": {
+       "range": [
+        110.0,
+        116.0
+       ],
+       "n": 64,
+       "mean_rmse": 0.6865
+      },
+      "Q3": {
+       "range": [
+        116.0,
+        121.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.6863
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.6856
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 54,
+       "mean_rmse": 0.698
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 167,
+       "mean_rmse": 0.6845
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.6934
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 145,
+       "mean_rmse": 0.6835
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.6883
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.7004
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0057
+       ],
+       "n": 75,
+       "mean_rmse": 0.6947
+      },
+      "Q2": {
+       "range": [
+        0.0057,
+        0.027
+       ],
+       "n": 75,
+       "mean_rmse": 0.6862
+      },
+      "Q3": {
+       "range": [
+        0.027,
+        0.0871
+       ],
+       "n": 75,
+       "mean_rmse": 0.6849
+      },
+      "Q4": {
+       "range": [
+        0.0871,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6913
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6903
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6838
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 75,
+       "mean_rmse": 0.6869
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6962
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5384
+       ],
+       "n": 75,
+       "mean_rmse": 0.6873
+      },
+      "Q2": {
+       "range": [
+        0.5384,
+        0.5618
+       ],
+       "n": 75,
+       "mean_rmse": 0.6854
+      },
+      "Q3": {
+       "range": [
+        0.5618,
+        0.6006
+       ],
+       "n": 75,
+       "mean_rmse": 0.6856
+      },
+      "Q4": {
+       "range": [
+        0.6006,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6989
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8761
+       ],
+       "n": 75,
+       "mean_rmse": 0.7004
+      },
+      "Q2": {
+       "range": [
+        0.8761,
+        0.9024
+       ],
+       "n": 75,
+       "mean_rmse": 0.6865
+      },
+      "Q3": {
+       "range": [
+        0.9024,
+        0.9231
+       ],
+       "n": 75,
+       "mean_rmse": 0.6836
+      },
+      "Q4": {
+       "range": [
+        0.9231,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.6866
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 352.5,
+    "holdout": {
+     "holdout_rmse": 0.6006148504583017,
+     "retrain_s": 0.4385,
+     "predict_s": 0.0028,
+     "cv_rmse_of_winner": 0.6751723908916849
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 300,
+    "n_finite": 300,
+    "rmse_best": 0.6746509644301645,
+    "rmse_p10": 0.6778876453445495,
+    "rmse_median": 0.6854862270877169,
+    "train_s_median": 1.519180561043322,
+    "train_s_mean": 2.298663109994183,
+    "train_s_p90": 5.477050170190642,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.07216973464225963,
+     "num_leaves": 65,
+     "max_depth": 10,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 0.0022585262055828813,
+     "lambda_l2": 0.0005797539280368215,
+     "feature_fraction": 0.5378811277325486,
+     "bagging_fraction": 0.9572246554838996,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 45,
+     "mixture_balance_factor": 4,
+     "mixture_smoothing_lambda": 0.344322758051866,
+     "mixture_diversity_lambda": 0.3881763505772058,
+     "mixture_hard_m_step": true,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 61,
+     "mixture_gate_learning_rate": 0.015101631937232,
+     "mixture_gate_lambda_l2": 0.007770874774281743,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_expert_capacity_factor": 1.3748006101088894,
+     "mixture_expert_choice_boost": 6.542636247176536,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.293878057362568,
+     "mixture_refit_every_n": 21,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 3,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "lambda_l2": 0.3961,
+     "lambda_l1": 0.3367,
+     "bagging_fraction": 0.0379,
+     "feature_fraction": 0.0363,
+     "mixture_e_step_mode": 0.0356,
+     "mixture_hard_m_step": 0.0335,
+     "mixture_gate_type": 0.0231,
+     "learning_rate": 0.0218,
+     "mixture_warmup_iters": 0.0187,
+     "mixture_r_smoothing": 0.0177,
+     "mixture_diversity_lambda": 0.0105,
+     "num_leaves": 0.0075,
+     "mixture_refit_leaves": 0.0064,
+     "min_data_in_leaf": 0.0062,
+     "mixture_balance_factor": 0.0043,
+     "bagging_freq": 0.004,
+     "mixture_init": 0.003,
+     "mixture_routing_mode": 0.0007,
+     "max_depth": 0.0,
+     "extra_trees": 0.0,
+     "mixture_num_experts": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 261,
+        "mean": 0.7639,
+        "std": 0.4972,
+        "min": 0.6747
+       },
+       "none": {
+        "n": 18,
+        "mean": 1.3239,
+        "std": 1.1068,
+        "min": 0.6917
+       },
+       "leaf_reuse": {
+        "n": 21,
+        "mean": 1.0345,
+        "std": 0.6712,
+        "min": 0.6911
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.2706,
+       "p_value": 0.091433,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 50,
+        "mean": 0.8537,
+        "std": 0.5364,
+        "min": 0.6756
+       },
+       "expert_choice": {
+        "n": 250,
+        "mean": 0.809,
+        "std": 0.593,
+        "min": 0.6747
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0447,
+       "p_value": 0.602094,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 28,
+        "mean": 0.9761,
+        "std": 0.8036,
+        "min": 0.6773
+       },
+       "em": {
+        "n": 31,
+        "mean": 0.7871,
+        "std": 0.2774,
+        "min": 0.6778
+       },
+       "loss_only": {
+        "n": 241,
+        "mean": 0.8016,
+        "std": 0.5802,
+        "min": 0.6747
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0145,
+       "p_value": 0.818649,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 16,
+        "mean": 0.7108,
+        "std": 0.0317,
+        "min": 0.6841
+       },
+       "tree_hierarchical": {
+        "n": 19,
+        "mean": 0.7887,
+        "std": 0.2049,
+        "min": 0.6896
+       },
+       "random": {
+        "n": 46,
+        "mean": 0.9923,
+        "std": 0.9138,
+        "min": 0.687
+       },
+       "gmm": {
+        "n": 219,
+        "mean": 0.7896,
+        "std": 0.5295,
+        "min": 0.6747
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0779,
+       "p_value": 0.128705,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 58,
+        "mean": 0.997,
+        "std": 0.8931,
+        "min": 0.6799
+       },
+       "ema": {
+        "n": 101,
+        "mean": 0.7785,
+        "std": 0.4059,
+        "min": 0.6758
+       },
+       "markov": {
+        "n": 141,
+        "mean": 0.7693,
+        "std": 0.5133,
+        "min": 0.6747
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.0092,
+       "p_value": 0.876658,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "True": {
+        "n": 279,
+        "mean": 0.7757,
+        "std": 0.5007,
+        "min": 0.6747
+       },
+       "False": {
+        "n": 21,
+        "mean": 1.3575,
+        "std": 1.1093,
+        "min": 0.6823
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.5818,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 30,
+        "mean": 0.7614,
+        "std": 0.1672,
+        "min": 0.7013
+       },
+       "False": {
+        "n": 270,
+        "mean": 0.8225,
+        "std": 0.613,
+        "min": 0.6747
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0611,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 15,
+       "mean_rmse": 0.8038
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.8428
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 209,
+       "mean_rmse": 0.8077
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3234
+       ],
+       "n": 75,
+       "mean_rmse": 0.8835
+      },
+      "Q2": {
+       "range": [
+        0.3234,
+        0.3829
+       ],
+       "n": 75,
+       "mean_rmse": 0.8844
+      },
+      "Q3": {
+       "range": [
+        0.3829,
+        0.417
+       ],
+       "n": 75,
+       "mean_rmse": 0.7337
+      },
+      "Q4": {
+       "range": [
+        0.417,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.7642
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        43.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.9755
+      },
+      "Q2": {
+       "range": [
+        43.0,
+        47.5
+       ],
+       "n": 78,
+       "mean_rmse": 0.721
+      },
+      "Q3": {
+       "range": [
+        47.5,
+        49.0
+       ],
+       "n": 53,
+       "mean_rmse": 0.7932
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 97,
+       "mean_rmse": 0.7878
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 26,
+       "mean_rmse": 1.2272
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 102,
+       "mean_rmse": 0.7947
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 172,
+       "mean_rmse": 0.7672
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0563
+       ],
+       "n": 75,
+       "mean_rmse": 0.8516
+      },
+      "Q2": {
+       "range": [
+        0.0563,
+        0.0714
+       ],
+       "n": 75,
+       "mean_rmse": 0.7445
+      },
+      "Q3": {
+       "range": [
+        0.0714,
+        0.0959
+       ],
+       "n": 75,
+       "mean_rmse": 0.8151
+      },
+      "Q4": {
+       "range": [
+        0.0959,
+        null
+       ],
+       "n": 75,
+       "mean_rmse": 0.8546
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        63.0
+       ],
+       "n": 72,
+       "mean_rmse": 0.7957
+      },
+      "Q2": {
+       "range": [
+        63.0,
+        73.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8429
+      },
+      "Q3": {
+       "range": [
+        73.0,
+        85.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.7414
+      },
+      "Q4": {
+       "range": [
+        85.0,
+        null
+       ],
+       "n": 78,
+       "mean_rmse": 0.8835
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 60,
+       "mean_rmse": 1.0047
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 158,
+       "mean_rmse": 0.7301
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 82,
+       "mean_rmse": 0.845
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 74,
+       "mean_rmse": 0.8283
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 70,
+       "mean_rmse": 0.745
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        15.0
+       ],
+       "n": 77,
+       "mean_rmse": 0.7715
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 79,
+       "mean_rmse": 0.9123
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 3473.8,
+    "holdout": {
+     "holdout_rmse": 0.6158083527117513,
+     "retrain_s": 2.1854,
+     "predict_s": 0.0219,
+     "cv_rmse_of_winner": 0.6746509644301645
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_cpu_act_ensemble_report.md
+++ b/bench_results/wide_v081/ds_cpu_act_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['cpu_act'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `4e208d83bace`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| cpu_act | naive-ensemble | **2.44848** ± 0.33583 | 2.41525 | 0.0% | 0.41 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| cpu_act@s42 | naive-ensemble | 2.4889 | 2.5387 | 0.431 | 1168 |
+| cpu_act@s43 | naive-ensemble | 2.3056 | 2.3412 | 0.422 | 1084 |
+| cpu_act@s44 | naive-ensemble | 2.4512 | 2.4980 | 0.305 | 819 |
+
+
+
+---
+
+## cpu_act@s42  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.17111** (winner retrained in 0.35s, cv score of winner: 2.4889)
+- cv best RMSE: 2.4889, median: 2.5387, p10: 2.5076
+- train: median 0.431s/fold, mean 0.464s, p90 0.644s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.450 |
+| `min_data_in_leaf` | 0.367 |
+| `extra_trees` | 0.115 |
+| `feature_fraction` | 0.035 |
+| `num_leaves` | 0.014 |
+| `bagging_fraction` | 0.006 |
+| `bagging_freq` | 0.005 |
+| `n_models` | 0.005 |
+| `max_depth` | 0.002 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 2.6868 | 0.5755 | 2.4889 |
+| True | 31 | 3.9209 | 1.7827 | 2.9891 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.1156 | 2.6255 | 2.6588 | 2.6534 | **Q2** [0.1296, 0.1597] |
+| `num_leaves` | 2.6483 | 2.6765 | 2.6492 | 3.0698 | **Q1** [None, 17.0] |
+| `max_depth` | 3.0887 | 2.8398 | 2.6972 | 2.6731 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | — | 2.6012 | 2.6379 | 3.1572 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 2.8631 | 2.6670 | 2.6997 | 2.8233 | **Q2** [0.0004, 0.0011] |
+| `lambda_l2` | 3.0140 | 2.6876 | 2.6504 | 2.7012 | **Q3** [0.0158, 0.0433] |
+| `feature_fraction` | 2.7862 | 2.6790 | 2.6354 | 2.9526 | **Q3** [0.652, 0.6791] |
+| `bagging_fraction` | 2.6772 | 2.7591 | 2.7279 | 2.8890 | **Q1** [None, 0.5312] |
+
+#### E. Slice plot
+
+![cpu_act@s42/naive-ensemble](slice_cpu_act@s42_naive-ensemble.png)
+
+
+---
+
+## cpu_act@s43  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.92104** (winner retrained in 0.50s, cv score of winner: 2.3056)
+- cv best RMSE: 2.3056, median: 2.3412, p10: 2.3170
+- train: median 0.422s/fold, mean 0.430s, p90 0.576s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.610 |
+| `learning_rate` | 0.286 |
+| `extra_trees` | 0.035 |
+| `bagging_fraction` | 0.021 |
+| `num_leaves` | 0.018 |
+| `bagging_freq` | 0.016 |
+| `feature_fraction` | 0.009 |
+| `max_depth` | 0.002 |
+| `lambda_l2` | 0.002 |
+| `n_models` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 2.4838 | 0.5328 | 2.3056 |
+| True | 32 | 3.6754 | 1.6598 | 2.6196 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8752 | 2.4080 | 2.4155 | 2.5418 | **Q2** [0.1506, 0.1733] |
+| `num_leaves` | 2.5635 | 2.5013 | 2.4581 | 2.7206 | **Q3** [40.0, 48.0] |
+| `max_depth` | 2.6555 | — | — | 2.5473 | **Q4** [5.0, ∞) |
+| `min_data_in_leaf` | — | 2.3887 | 2.4588 | 2.9370 | **Q2** [5.0, 8.0] |
+| `lambda_l1` | 2.4677 | 2.5515 | 2.6585 | 2.5627 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.5512 | 2.5146 | 2.4890 | 2.6856 | **Q3** [0.0, 0.0021] |
+| `feature_fraction` | 2.9020 | 2.4195 | 2.4396 | 2.4793 | **Q2** [0.9381, 0.9634] |
+| `bagging_fraction` | 2.7924 | 2.5251 | 2.4210 | 2.5019 | **Q3** [0.886, 0.909] |
+
+#### E. Slice plot
+
+![cpu_act@s43/naive-ensemble](slice_cpu_act@s43_naive-ensemble.png)
+
+
+---
+
+## cpu_act@s44  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.25330** (winner retrained in 0.37s, cv score of winner: 2.4512)
+- cv best RMSE: 2.4512, median: 2.4980, p10: 2.4684
+- train: median 0.305s/fold, mean 0.324s, p90 0.459s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.385 |
+| `learning_rate` | 0.379 |
+| `bagging_freq` | 0.091 |
+| `extra_trees` | 0.073 |
+| `max_depth` | 0.026 |
+| `num_leaves` | 0.019 |
+| `feature_fraction` | 0.011 |
+| `bagging_fraction` | 0.009 |
+| `lambda_l2` | 0.004 |
+| `n_models` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 455 | 2.6740 | 0.6567 | 2.4512 |
+| True | 45 | 3.5669 | 1.1725 | 2.8613 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.3075 | 2.5685 | 2.5339 | 2.6076 | **Q3** [0.2038, 0.2343] |
+| `num_leaves` | 2.6290 | 2.6242 | 2.6454 | 3.1069 | **Q2** [15.75, 20.0] |
+| `max_depth` | 3.1408 | 2.6535 | 2.6529 | 2.6485 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.6126 | 2.5798 | 2.5548 | 3.2649 | **Q3** [8.0, 12.0] |
+| `lambda_l1` | 2.9587 | 2.7398 | 2.7198 | 2.5990 | **Q4** [0.9857, ∞) |
+| `lambda_l2` | 2.7626 | 2.8383 | 2.6597 | 2.7568 | **Q3** [0.0024, 0.0185] |
+| `feature_fraction` | 2.7468 | 2.6178 | 2.7558 | 2.8970 | **Q2** [0.6719, 0.7013] |
+| `bagging_fraction` | 2.7468 | 2.6598 | 2.6411 | 2.9698 | **Q3** [0.7346, 0.7607] |
+
+#### E. Slice plot
+
+![cpu_act@s44/naive-ensemble](slice_cpu_act@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_cpu_act_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_cpu_act_ensemble_summary.json
@@ -1,0 +1,1161 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "cpu_act"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "4e208d83baceaa5a1ebd0eccaa975a01d7361bd2",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "cpu_act": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.1711093742397867,
+      "cv_best": 2.4889363218100486,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3536
+     },
+     "43": {
+      "holdout_rmse": 2.921043877536094,
+      "cv_best": 2.3056145481710026,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5032
+     },
+     "44": {
+      "holdout_rmse": 2.253299455098022,
+      "cv_best": 2.4511851178957684,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3659
+     }
+    },
+    "holdout_mean": 2.448484,
+    "holdout_std": 0.335831,
+    "cv_best_mean": 2.415245
+   }
+  }
+ },
+ "runs": {
+  "cpu_act@s42": {
+   "dataset": "cpu_act",
+   "seed": 42,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 83.92462618248398,
+    "std": 18.493954695764945
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.4889363218100486,
+    "rmse_p10": 2.507647675659583,
+    "rmse_median": 2.538707278914684,
+    "train_s_median": 0.43149039093405006,
+    "train_s_mean": 0.46368214363083243,
+    "train_s_p90": 0.6442347069457174,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.2065603603719714,
+     "num_leaves": 14,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0018856062706660913,
+     "lambda_l2": 0.0024442915675220315,
+     "feature_fraction": 0.6551346699251709,
+     "bagging_fraction": 0.8081626931526306,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.4503,
+     "min_data_in_leaf": 0.3673,
+     "extra_trees": 0.1151,
+     "feature_fraction": 0.035,
+     "num_leaves": 0.0144,
+     "bagging_fraction": 0.0059,
+     "bagging_freq": 0.0054,
+     "n_models": 0.0048,
+     "max_depth": 0.0016,
+     "lambda_l2": 0.0001,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 469,
+        "mean": 2.6868,
+        "std": 0.5755,
+        "min": 2.4889
+       },
+       "True": {
+        "n": 31,
+        "mean": 3.9209,
+        "std": 1.7827,
+        "min": 2.9891
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.2341,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1296
+       ],
+       "n": 125,
+       "mean_rmse": 3.1156
+      },
+      "Q2": {
+       "range": [
+        0.1296,
+        0.1597
+       ],
+       "n": 125,
+       "mean_rmse": 2.6255
+      },
+      "Q3": {
+       "range": [
+        0.1597,
+        0.1953
+       ],
+       "n": 125,
+       "mean_rmse": 2.6588
+      },
+      "Q4": {
+       "range": [
+        0.1953,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6534
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        17.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.6483
+      },
+      "Q2": {
+       "range": [
+        17.0,
+        21.0
+       ],
+       "n": 106,
+       "mean_rmse": 2.6765
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        28.0
+       ],
+       "n": 145,
+       "mean_rmse": 2.6492
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 3.0698
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 68,
+       "mean_rmse": 3.0887
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.8398
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 228,
+       "mean_rmse": 2.6972
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 136,
+       "mean_rmse": 2.6731
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 159,
+       "mean_rmse": 2.6012
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 209,
+       "mean_rmse": 2.6379
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 3.1572
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0004
+       ],
+       "n": 125,
+       "mean_rmse": 2.8631
+      },
+      "Q2": {
+       "range": [
+        0.0004,
+        0.0011
+       ],
+       "n": 125,
+       "mean_rmse": 2.667
+      },
+      "Q3": {
+       "range": [
+        0.0011,
+        0.0036
+       ],
+       "n": 125,
+       "mean_rmse": 2.6997
+      },
+      "Q4": {
+       "range": [
+        0.0036,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8233
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0049
+       ],
+       "n": 125,
+       "mean_rmse": 3.014
+      },
+      "Q2": {
+       "range": [
+        0.0049,
+        0.0158
+       ],
+       "n": 125,
+       "mean_rmse": 2.6876
+      },
+      "Q3": {
+       "range": [
+        0.0158,
+        0.0433
+       ],
+       "n": 125,
+       "mean_rmse": 2.6504
+      },
+      "Q4": {
+       "range": [
+        0.0433,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7012
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.633
+       ],
+       "n": 125,
+       "mean_rmse": 2.7862
+      },
+      "Q2": {
+       "range": [
+        0.633,
+        0.652
+       ],
+       "n": 125,
+       "mean_rmse": 2.679
+      },
+      "Q3": {
+       "range": [
+        0.652,
+        0.6791
+       ],
+       "n": 125,
+       "mean_rmse": 2.6354
+      },
+      "Q4": {
+       "range": [
+        0.6791,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.9526
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5312
+       ],
+       "n": 125,
+       "mean_rmse": 2.6772
+      },
+      "Q2": {
+       "range": [
+        0.5312,
+        0.5736
+       ],
+       "n": 125,
+       "mean_rmse": 2.7591
+      },
+      "Q3": {
+       "range": [
+        0.5736,
+        0.7141
+       ],
+       "n": 125,
+       "mean_rmse": 2.7279
+      },
+      "Q4": {
+       "range": [
+        0.7141,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.889
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 1168.2,
+    "holdout": {
+     "holdout_rmse": 2.1711093742397867,
+     "retrain_s": 0.3536,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.4889363218100486
+    }
+   }
+  },
+  "cpu_act@s43": {
+   "dataset": "cpu_act",
+   "seed": 43,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.04531583765639,
+    "std": 18.208031997815638
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.3056145481710026,
+    "rmse_p10": 2.316989643312069,
+    "rmse_median": 2.3411906337893678,
+    "train_s_median": 0.42174832951277497,
+    "train_s_mean": 0.43013330125510696,
+    "train_s_p90": 0.5764348784834147,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.18858745967322912,
+     "num_leaves": 78,
+     "max_depth": 5,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.2894469908655045,
+     "lambda_l2": 2.3796215229666276e-06,
+     "feature_fraction": 0.9853255026682104,
+     "bagging_fraction": 0.9265464165133228,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6101,
+     "learning_rate": 0.2856,
+     "extra_trees": 0.0349,
+     "bagging_fraction": 0.0213,
+     "num_leaves": 0.018,
+     "bagging_freq": 0.0164,
+     "feature_fraction": 0.009,
+     "max_depth": 0.0022,
+     "lambda_l2": 0.0017,
+     "n_models": 0.0008,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 2.4838,
+        "std": 0.5328,
+        "min": 2.3056
+       },
+       "True": {
+        "n": 32,
+        "mean": 3.6754,
+        "std": 1.6598,
+        "min": 2.6196
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.1916,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1506
+       ],
+       "n": 125,
+       "mean_rmse": 2.8752
+      },
+      "Q2": {
+       "range": [
+        0.1506,
+        0.1733
+       ],
+       "n": 125,
+       "mean_rmse": 2.408
+      },
+      "Q3": {
+       "range": [
+        0.1733,
+        0.1982
+       ],
+       "n": 125,
+       "mean_rmse": 2.4155
+      },
+      "Q4": {
+       "range": [
+        0.1982,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.5418
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        33.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.5635
+      },
+      "Q2": {
+       "range": [
+        33.0,
+        40.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.5013
+      },
+      "Q3": {
+       "range": [
+        40.0,
+        48.0
+       ],
+       "n": 137,
+       "mean_rmse": 2.4581
+      },
+      "Q4": {
+       "range": [
+        48.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 2.7206
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 59,
+       "mean_rmse": 2.6555
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 441,
+       "mean_rmse": 2.5473
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 246,
+       "mean_rmse": 2.3887
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 112,
+       "mean_rmse": 2.4588
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 2.937
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.4677
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.5515
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0248
+       ],
+       "n": 125,
+       "mean_rmse": 2.6585
+      },
+      "Q4": {
+       "range": [
+        0.0248,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.5627
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.5512
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.5146
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0021
+       ],
+       "n": 125,
+       "mean_rmse": 2.489
+      },
+      "Q4": {
+       "range": [
+        0.0021,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6856
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9381
+       ],
+       "n": 125,
+       "mean_rmse": 2.902
+      },
+      "Q2": {
+       "range": [
+        0.9381,
+        0.9634
+       ],
+       "n": 125,
+       "mean_rmse": 2.4195
+      },
+      "Q3": {
+       "range": [
+        0.9634,
+        0.9811
+       ],
+       "n": 125,
+       "mean_rmse": 2.4396
+      },
+      "Q4": {
+       "range": [
+        0.9811,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.4793
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8626
+       ],
+       "n": 125,
+       "mean_rmse": 2.7924
+      },
+      "Q2": {
+       "range": [
+        0.8626,
+        0.886
+       ],
+       "n": 125,
+       "mean_rmse": 2.5251
+      },
+      "Q3": {
+       "range": [
+        0.886,
+        0.909
+       ],
+       "n": 125,
+       "mean_rmse": 2.421
+      },
+      "Q4": {
+       "range": [
+        0.909,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.5019
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1084.3,
+    "holdout": {
+     "holdout_rmse": 2.921043877536094,
+     "retrain_s": 0.5032,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.3056145481710026
+    }
+   }
+  },
+  "cpu_act@s44": {
+   "dataset": "cpu_act",
+   "seed": 44,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.05965822398535,
+    "std": 18.44113958458848
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.4511851178957684,
+    "rmse_p10": 2.4684438207985013,
+    "rmse_median": 2.497975909039365,
+    "train_s_median": 0.30450016297399995,
+    "train_s_mean": 0.32391299537569285,
+    "train_s_p90": 0.4586912952363492,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.20608616920310546,
+     "num_leaves": 20,
+     "max_depth": 10,
+     "min_data_in_leaf": 8,
+     "lambda_l1": 8.81185557248106e-07,
+     "lambda_l2": 0.002380023463772641,
+     "feature_fraction": 0.6548186892410883,
+     "bagging_fraction": 0.7617070751591255,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.3848,
+     "learning_rate": 0.379,
+     "bagging_freq": 0.0909,
+     "extra_trees": 0.0734,
+     "max_depth": 0.0258,
+     "num_leaves": 0.019,
+     "feature_fraction": 0.0111,
+     "bagging_fraction": 0.0089,
+     "lambda_l2": 0.0035,
+     "n_models": 0.0021,
+     "lambda_l1": 0.0013
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 45,
+        "mean": 3.5669,
+        "std": 1.1725,
+        "min": 2.8613
+       },
+       "False": {
+        "n": 455,
+        "mean": 2.674,
+        "std": 0.6567,
+        "min": 2.4512
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.8929,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1667
+       ],
+       "n": 125,
+       "mean_rmse": 3.3075
+      },
+      "Q2": {
+       "range": [
+        0.1667,
+        0.2038
+       ],
+       "n": 125,
+       "mean_rmse": 2.5685
+      },
+      "Q3": {
+       "range": [
+        0.2038,
+        0.2343
+       ],
+       "n": 125,
+       "mean_rmse": 2.5339
+      },
+      "Q4": {
+       "range": [
+        0.2343,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6076
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        15.75
+       ],
+       "n": 125,
+       "mean_rmse": 2.629
+      },
+      "Q2": {
+       "range": [
+        15.75,
+        20.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.6242
+      },
+      "Q3": {
+       "range": [
+        20.0,
+        27.0
+       ],
+       "n": 127,
+       "mean_rmse": 2.6454
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 3.1069
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 106,
+       "mean_rmse": 3.1408
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.6535
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 83,
+       "mean_rmse": 2.6529
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 238,
+       "mean_rmse": 2.6485
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 118,
+       "mean_rmse": 2.6126
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 111,
+       "mean_rmse": 2.5798
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 144,
+       "mean_rmse": 2.5548
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 3.2649
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 2.9587
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.2002
+       ],
+       "n": 125,
+       "mean_rmse": 2.7398
+      },
+      "Q3": {
+       "range": [
+        0.2002,
+        0.9857
+       ],
+       "n": 125,
+       "mean_rmse": 2.7198
+      },
+      "Q4": {
+       "range": [
+        0.9857,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.599
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7626
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0024
+       ],
+       "n": 125,
+       "mean_rmse": 2.8383
+      },
+      "Q3": {
+       "range": [
+        0.0024,
+        0.0185
+       ],
+       "n": 125,
+       "mean_rmse": 2.6597
+      },
+      "Q4": {
+       "range": [
+        0.0185,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7568
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6719
+       ],
+       "n": 125,
+       "mean_rmse": 2.7468
+      },
+      "Q2": {
+       "range": [
+        0.6719,
+        0.7013
+       ],
+       "n": 125,
+       "mean_rmse": 2.6178
+      },
+      "Q3": {
+       "range": [
+        0.7013,
+        0.7765
+       ],
+       "n": 125,
+       "mean_rmse": 2.7558
+      },
+      "Q4": {
+       "range": [
+        0.7765,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.897
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.678
+       ],
+       "n": 125,
+       "mean_rmse": 2.7468
+      },
+      "Q2": {
+       "range": [
+        0.678,
+        0.7346
+       ],
+       "n": 125,
+       "mean_rmse": 2.6598
+      },
+      "Q3": {
+       "range": [
+        0.7346,
+        0.7607
+       ],
+       "n": 125,
+       "mean_rmse": 2.6411
+      },
+      "Q4": {
+       "range": [
+        0.7607,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.9698
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 818.7,
+    "holdout": {
+     "holdout_rmse": 2.253299455098022,
+     "retrain_s": 0.3659,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.4511851178957684
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_cpu_act_report.md
+++ b/bench_results/wide_v081/ds_cpu_act_report.md
@@ -1,0 +1,498 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['cpu_act'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| cpu_act | naive-lightgbm | **2.49817** ± 0.29668 | 2.44834 | 0.0% | 0.17 |
+| cpu_act | moe | **2.43085** ± 0.33341 | 2.38000 | 0.0% | 2.69 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| cpu_act@s42 | naive-lightgbm | 2.5168 | 2.5811 | 0.161 | 440 |
+| cpu_act@s42 | moe | 2.4156 | 2.5414 | 1.848 | 5580 |
+| cpu_act@s43 | naive-lightgbm | 2.3502 | 2.3963 | 0.195 | 499 |
+| cpu_act@s43 | moe | 2.2936 | 2.3552 | 1.048 | 4036 |
+| cpu_act@s44 | naive-lightgbm | 2.4780 | 2.5377 | 0.121 | 323 |
+| cpu_act@s44 | moe | 2.4308 | 2.5295 | 0.601 | 1931 |
+
+
+
+---
+
+## cpu_act@s42  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.30096** (winner retrained in 0.14s, cv score of winner: 2.5168)
+- cv best RMSE: 2.5168, median: 2.5811, p10: 2.5383
+- train: median 0.161s/fold, mean 0.170s, p90 0.224s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.523 |
+| `min_data_in_leaf` | 0.326 |
+| `extra_trees` | 0.080 |
+| `num_leaves` | 0.028 |
+| `bagging_freq` | 0.015 |
+| `bagging_fraction` | 0.013 |
+| `feature_fraction` | 0.009 |
+| `max_depth` | 0.005 |
+| `lambda_l1` | 0.002 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 2.7109 | 0.5267 | 2.5168 |
+| True | 32 | 4.6123 | 2.5358 | 2.9974 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 3.2347 | 2.6648 | 2.6706 | 2.7602 | **Q2** [0.0888, 0.1003] |
+| `num_leaves` | 2.7448 | 2.6924 | 2.7699 | 3.0788 | **Q2** [18.0, 22.0] |
+| `max_depth` | 3.4628 | 2.7405 | — | 2.7123 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.7492 | 2.5831 | 2.6221 | 3.3756 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 3.0699 | 2.8129 | 2.6887 | 2.7588 | **Q3** [0.1361, 0.2856] |
+| `lambda_l2` | 2.7000 | 2.6290 | 2.7748 | 3.2265 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 3.1650 | 2.7474 | 2.6873 | 2.7306 | **Q3** [0.8599, 0.8784] |
+| `bagging_fraction` | 2.8267 | 2.6647 | 2.9527 | 2.8862 | **Q2** [0.5678, 0.5935] |
+
+#### E. Slice plot
+
+![cpu_act@s42/naive-lightgbm](slice_cpu_act@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.15948** (winner retrained in 3.91s, cv score of winner: 2.4156)
+- cv best RMSE: 2.4156, median: 2.5414, p10: 2.4444
+- train: median 1.848s/fold, mean 2.200s, p90 3.727s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.792 |
+| `mixture_e_step_mode` | 0.124 |
+| `mixture_init` | 0.031 |
+| `mixture_diversity_lambda` | 0.011 |
+| `mixture_warmup_iters` | 0.008 |
+| `max_depth` | 0.004 |
+| `bagging_freq` | 0.004 |
+| `lambda_l1` | 0.003 |
+| `bagging_fraction` | 0.003 |
+| `min_data_in_leaf` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 450 | 3.7921 | 5.3561 | 2.4156 |
+| gbdt | 25 | 5.3982 | 5.5241 | 2.5298 |
+| none | 25 | 7.3902 | 8.0931 | 3.1988 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 468 | 3.8182 | 5.0504 | 2.4156 |
+| expert_choice | 32 | 7.4761 | 10.1954 | 2.7236 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 448 | 3.5946 | 4.8581 | 2.4156 |
+| loss_only | 25 | 7.2402 | 6.5495 | 2.9788 |
+| em | 27 | 8.6954 | 10.6953 | 2.8078 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm_features | 382 | 3.4214 | 4.0397 | 2.4156 |
+| tree_hierarchical | 26 | 3.9161 | 3.1549 | 2.4782 |
+| kmeans_features | 33 | 5.1038 | 5.7075 | 2.4461 |
+| random | 18 | 5.9172 | 10.1263 | 2.4755 |
+| uniform | 20 | 7.2977 | 11.5074 | 2.4485 |
+| gmm | 21 | 9.3571 | 11.0178 | 2.4836 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 306 | 3.5423 | 4.2733 | 2.4156 |
+| markov | 170 | 4.3792 | 6.0961 | 2.4317 |
+| none | 24 | 8.2402 | 11.6189 | 2.4658 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 468 | 3.7517 | 4.8868 | 2.4156 |
+| False | 32 | 8.4497 | 10.9358 | 2.5890 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 3.6865 | 4.7635 | 2.4156 |
+| True | 32 | 9.4020 | 11.2728 | 2.9617 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 4.9951 | — | 3.4238 | **Q4** [6.0, ∞) |
+| `mixture_diversity_lambda` | 4.3101 | 4.6922 | 3.2621 | 3.9448 | **Q3** [0.322, 0.3666] |
+| `mixture_warmup_iters` | 4.8217 | 3.3383 | 3.4808 | 4.5727 | **Q2** [14.0, 16.0] |
+| `mixture_balance_factor` | 3.7468 | 5.0436 | — | 3.7269 | **Q4** [8.0, ∞) |
+| `learning_rate` | 7.3765 | 2.8910 | 2.8180 | 3.1238 | **Q3** [0.225, 0.2507] |
+| `num_leaves` | 3.5466 | 3.4315 | 4.5939 | 4.6092 | **Q2** [19.75, 34.0] |
+| `max_depth` | 4.0821 | 3.5576 | 3.5597 | 5.2373 | **Q2** [5.0, 6.0] |
+| `min_data_in_leaf` | 3.7904 | 3.2789 | 3.9784 | 5.0832 | **Q2** [8.0, 11.0] |
+
+#### E. Slice plot
+
+![cpu_act@s42/moe](slice_cpu_act@s42_moe.png)
+
+
+---
+
+## cpu_act@s43  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.91750** (winner retrained in 0.25s, cv score of winner: 2.3502)
+- cv best RMSE: 2.3502, median: 2.3963, p10: 2.3683
+- train: median 0.195s/fold, mean 0.194s, p90 0.260s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.520 |
+| `learning_rate` | 0.337 |
+| `extra_trees` | 0.055 |
+| `bagging_fraction` | 0.026 |
+| `num_leaves` | 0.025 |
+| `feature_fraction` | 0.016 |
+| `bagging_freq` | 0.014 |
+| `lambda_l1` | 0.003 |
+| `max_depth` | 0.002 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 2.5500 | 0.6068 | 2.3502 |
+| True | 31 | 3.6338 | 1.2558 | 2.8568 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8419 | 2.5106 | 2.5571 | 2.5593 | **Q2** [0.0693, 0.0844] |
+| `num_leaves` | 2.6072 | 2.5236 | 2.5118 | 2.8061 | **Q3** [28.0, 33.0] |
+| `max_depth` | 2.8834 | 2.4895 | 2.5351 | 2.5840 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 2.4213 | 2.4891 | 2.4110 | 3.0877 | **Q3** [9.0, 12.0] |
+| `lambda_l1` | 2.5797 | 2.7601 | 2.4987 | 2.6305 | **Q3** [0.1564, 1.2329] |
+| `lambda_l2` | 2.6582 | 2.5230 | 2.5067 | 2.7811 | **Q3** [0.0026, 0.0157] |
+| `feature_fraction` | 2.8475 | 2.5626 | 2.5383 | 2.5205 | **Q4** [0.9563, ∞) |
+| `bagging_fraction` | 2.7173 | 2.5851 | 2.5059 | 2.6607 | **Q3** [0.782, 0.8282] |
+
+#### E. Slice plot
+
+![cpu_act@s43/naive-lightgbm](slice_cpu_act@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.90047** (winner retrained in 3.43s, cv score of winner: 2.2936)
+- cv best RMSE: 2.2936, median: 2.3552, p10: 2.3178
+- train: median 1.048s/fold, mean 1.591s, p90 3.049s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.496 |
+| `learning_rate` | 0.147 |
+| `mixture_num_experts` | 0.114 |
+| `bagging_fraction` | 0.044 |
+| `mixture_warmup_iters` | 0.039 |
+| `max_depth` | 0.029 |
+| `mixture_r_smoothing` | 0.022 |
+| `mixture_diversity_lambda` | 0.022 |
+| `mixture_balance_factor` | 0.018 |
+| `num_leaves` | 0.017 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 232 | 3.6588 | 5.1703 | 2.2936 |
+| none | 234 | 3.8429 | 5.9816 | 2.3135 |
+| gbdt | 34 | 5.1122 | 5.5190 | 2.3214 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 268 | 3.8033 | 5.6311 | 2.3051 |
+| expert_choice | 232 | 3.8905 | 5.5605 | 2.2936 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 342 | 3.4836 | 4.3618 | 2.2936 |
+| em | 93 | 4.2277 | 6.6206 | 2.3200 |
+| gate_only | 65 | 5.1899 | 8.6942 | 2.3220 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 391 | 2.9344 | 3.3467 | 2.2936 |
+| tree_hierarchical | 24 | 3.4164 | 1.5798 | 2.4495 |
+| random | 29 | 3.9463 | 4.0877 | 2.4319 |
+| kmeans_features | 18 | 9.0574 | 11.4437 | 2.6145 |
+| gmm | 19 | 9.1759 | 11.5666 | 2.6927 |
+| gmm_features | 19 | 12.6694 | 12.5903 | 3.4985 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 370 | 3.2802 | 3.7560 | 2.2936 |
+| markov | 54 | 4.4274 | 6.5096 | 2.3408 |
+| none | 76 | 6.1730 | 10.0106 | 2.3270 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 3.6119 | 5.1453 | 2.2936 |
+| True | 32 | 7.2351 | 9.5023 | 2.7916 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 3.6731 | 5.3620 | 2.2936 |
+| True | 30 | 6.5180 | 8.0228 | 2.7333 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 5.0737 | — | — | 3.7162 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 5.0114 | 3.2628 | 3.3566 | 3.7444 | **Q2** [0.2301, 0.383] |
+| `mixture_warmup_iters` | 4.8878 | 3.0681 | 3.0147 | 4.1872 | **Q3** [42.0, 44.0] |
+| `mixture_balance_factor` | 5.0976 | 4.1828 | — | 3.4774 | **Q4** [8.0, ∞) |
+| `learning_rate` | 6.0344 | 3.0598 | 3.3755 | 2.9055 | **Q4** [0.2169, ∞) |
+| `num_leaves` | 2.8956 | 3.3935 | 3.8249 | 5.1594 | **Q1** [None, 23.0] |
+| `max_depth` | 5.5076 | 3.2262 | 3.6953 | 3.6907 | **Q2** [8.0, 9.0] |
+| `min_data_in_leaf` | 3.3174 | 3.1631 | 3.2465 | 5.6075 | **Q2** [7.0, 9.0] |
+
+#### E. Slice plot
+
+![cpu_act@s43/moe](slice_cpu_act@s43_moe.png)
+
+
+---
+
+## cpu_act@s44  (search X=[6554, 21], holdout n=1638)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.27606** (winner retrained in 0.14s, cv score of winner: 2.4780)
+- cv best RMSE: 2.4780, median: 2.5377, p10: 2.5058
+- train: median 0.121s/fold, mean 0.124s, p90 0.166s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.463 |
+| `learning_rate` | 0.303 |
+| `extra_trees` | 0.136 |
+| `feature_fraction` | 0.049 |
+| `num_leaves` | 0.016 |
+| `max_depth` | 0.014 |
+| `bagging_fraction` | 0.012 |
+| `bagging_freq` | 0.005 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 2.6744 | 0.5240 | 2.4780 |
+| True | 30 | 3.6872 | 1.0227 | 2.8796 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.9760 | 2.6160 | 2.6132 | 2.7356 | **Q3** [0.0969, 0.1088] |
+| `num_leaves` | 2.6476 | 2.6437 | 2.6443 | 2.9940 | **Q2** [18.0, 21.0] |
+| `max_depth` | 2.9005 | — | — | 2.6891 | **Q4** [7.0, ∞) |
+| `min_data_in_leaf` | 2.5548 | 2.5718 | 2.6144 | 3.1387 | **Q1** [None, 5.75] |
+| `lambda_l1` | 2.7812 | 2.8047 | 2.5968 | 2.7581 | **Q3** [0.0071, 0.017] |
+| `lambda_l2` | 2.6496 | 2.7250 | 2.6849 | 2.8814 | **Q1** [None, 0.0] |
+| `feature_fraction` | 3.0691 | 2.6737 | 2.6105 | 2.5875 | **Q4** [0.9908, ∞) |
+| `bagging_fraction` | 2.8852 | 2.7112 | 2.6835 | 2.6610 | **Q4** [0.969, ∞) |
+
+#### E. Slice plot
+
+![cpu_act@s44/naive-lightgbm](slice_cpu_act@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.23260** (winner retrained in 0.74s, cv score of winner: 2.4308)
+- cv best RMSE: 2.4308, median: 2.5295, p10: 2.4677
+- train: median 0.601s/fold, mean 0.757s, p90 1.258s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.710 |
+| `mixture_balance_factor` | 0.091 |
+| `min_data_in_leaf` | 0.046 |
+| `mixture_diversity_lambda` | 0.028 |
+| `mixture_num_experts` | 0.020 |
+| `mixture_r_smoothing` | 0.019 |
+| `num_leaves` | 0.013 |
+| `mixture_gate_type` | 0.013 |
+| `mixture_e_step_mode` | 0.012 |
+| `feature_fraction` | 0.010 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 445 | 3.4393 | 3.7775 | 2.4308 |
+| gbdt | 28 | 4.9670 | 5.2716 | 2.4965 |
+| none | 27 | 8.4730 | 10.7533 | 2.6000 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 470 | 3.5816 | 4.1648 | 2.4308 |
+| expert_choice | 30 | 7.1659 | 8.9836 | 2.5578 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 445 | 3.5482 | 4.5879 | 2.4308 |
+| em | 31 | 5.7873 | 4.5601 | 2.5557 |
+| loss_only | 24 | 5.8327 | 5.3013 | 2.6351 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 16 | 3.1129 | 0.9213 | 2.5221 |
+| kmeans_features | 280 | 3.5567 | 4.4359 | 2.4308 |
+| gmm_features | 18 | 3.9028 | 1.9495 | 2.5061 |
+| gmm | 152 | 3.9141 | 4.9797 | 2.4364 |
+| tree_hierarchical | 17 | 5.1778 | 3.9221 | 2.5419 |
+| random | 17 | 5.8489 | 8.3442 | 2.5216 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 359 | 3.5529 | 4.3469 | 2.4308 |
+| markov | 118 | 3.9606 | 4.4813 | 2.4364 |
+| none | 23 | 6.7609 | 8.2249 | 2.4725 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 467 | 3.5447 | 4.1956 | 2.4308 |
+| False | 33 | 7.3624 | 8.2861 | 2.6066 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 3.6272 | 4.5084 | 2.4308 |
+| True | 31 | 6.3601 | 6.1854 | 3.3873 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 3.7967 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 3.9010 | 2.9620 | 3.8429 | 4.4808 | **Q2** [0.2864, 0.3452] |
+| `mixture_warmup_iters` | 3.6454 | 3.5146 | 3.9352 | 4.0965 | **Q2** [30.0, 33.0] |
+| `mixture_balance_factor` | 5.4695 | — | 3.2360 | 3.8461 | **Q3** [7.0, 8.0] |
+| `learning_rate` | 5.9971 | 2.9222 | 2.9665 | 3.3009 | **Q2** [0.1208, 0.149] |
+| `num_leaves` | 3.9645 | 3.2807 | 3.5504 | 4.4020 | **Q2** [52.0, 61.5] |
+| `max_depth` | 5.7290 | — | 3.4524 | 3.7940 | **Q3** [7.0, 8.0] |
+| `min_data_in_leaf` | 3.0859 | 3.4483 | 3.4378 | 4.9892 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![cpu_act@s44/moe](slice_cpu_act@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_cpu_act_summary.json
+++ b/bench_results/wide_v081/ds_cpu_act_summary.json
@@ -1,0 +1,2812 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "cpu_act"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "cpu_act": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.300955382422753,
+      "cv_best": 2.5167682181190614,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1431
+     },
+     "43": {
+      "holdout_rmse": 2.9174951688877546,
+      "cv_best": 2.350232686460832,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2451
+     },
+     "44": {
+      "holdout_rmse": 2.276056326993748,
+      "cv_best": 2.478020653643999,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1352
+     }
+    },
+    "holdout_mean": 2.498169,
+    "holdout_std": 0.296683,
+    "cv_best_mean": 2.448341
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 2.1594846712441726,
+      "cv_best": 2.4155624042025936,
+      "crash_rate": 0.0,
+      "retrain_s": 3.913
+     },
+     "43": {
+      "holdout_rmse": 2.9004656530002197,
+      "cv_best": 2.293625343355084,
+      "crash_rate": 0.0,
+      "retrain_s": 3.4277
+     },
+     "44": {
+      "holdout_rmse": 2.232601241257653,
+      "cv_best": 2.4308088077426087,
+      "crash_rate": 0.0,
+      "retrain_s": 0.7406
+     }
+    },
+    "holdout_mean": 2.430851,
+    "holdout_std": 0.333407,
+    "cv_best_mean": 2.379999
+   }
+  }
+ },
+ "runs": {
+  "cpu_act@s42": {
+   "dataset": "cpu_act",
+   "seed": 42,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 83.92462618248398,
+    "std": 18.493954695764945
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.5167682181190614,
+    "rmse_p10": 2.5383174198194935,
+    "rmse_median": 2.5810585946727915,
+    "train_s_median": 0.16085864156484603,
+    "train_s_mean": 0.17045146552994847,
+    "train_s_p90": 0.2238412004709244,
+    "best_params": {
+     "learning_rate": 0.09264509243568801,
+     "num_leaves": 16,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.03330432130542346,
+     "lambda_l2": 4.271764835509462e-08,
+     "feature_fraction": 0.8683160857189651,
+     "bagging_fraction": 0.5918727988243391,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5227,
+     "min_data_in_leaf": 0.326,
+     "extra_trees": 0.0796,
+     "num_leaves": 0.0282,
+     "bagging_freq": 0.0155,
+     "bagging_fraction": 0.0129,
+     "feature_fraction": 0.0089,
+     "max_depth": 0.0047,
+     "lambda_l1": 0.0015,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 4.6123,
+        "std": 2.5358,
+        "min": 2.9974
+       },
+       "False": {
+        "n": 468,
+        "mean": 2.7109,
+        "std": 0.5267,
+        "min": 2.5168
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.9014,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0888
+       ],
+       "n": 125,
+       "mean_rmse": 3.2347
+      },
+      "Q2": {
+       "range": [
+        0.0888,
+        0.1003
+       ],
+       "n": 125,
+       "mean_rmse": 2.6648
+      },
+      "Q3": {
+       "range": [
+        0.1003,
+        0.12
+       ],
+       "n": 125,
+       "mean_rmse": 2.6706
+      },
+      "Q4": {
+       "range": [
+        0.12,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7602
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.7448
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        22.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.6924
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        26.0
+       ],
+       "n": 116,
+       "mean_rmse": 2.7699
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 3.0788
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 78,
+       "mean_rmse": 3.4628
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 57,
+       "mean_rmse": 2.7405
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 365,
+       "mean_rmse": 2.7123
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 102,
+       "mean_rmse": 2.7492
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 146,
+       "mean_rmse": 2.5831
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        12.0
+       ],
+       "n": 122,
+       "mean_rmse": 2.6221
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 3.3756
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0233
+       ],
+       "n": 125,
+       "mean_rmse": 3.0699
+      },
+      "Q2": {
+       "range": [
+        0.0233,
+        0.1361
+       ],
+       "n": 125,
+       "mean_rmse": 2.8129
+      },
+      "Q3": {
+       "range": [
+        0.1361,
+        0.2856
+       ],
+       "n": 125,
+       "mean_rmse": 2.6887
+      },
+      "Q4": {
+       "range": [
+        0.2856,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7588
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.629
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7748
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.2265
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8351
+       ],
+       "n": 125,
+       "mean_rmse": 3.165
+      },
+      "Q2": {
+       "range": [
+        0.8351,
+        0.8599
+       ],
+       "n": 125,
+       "mean_rmse": 2.7474
+      },
+      "Q3": {
+       "range": [
+        0.8599,
+        0.8784
+       ],
+       "n": 125,
+       "mean_rmse": 2.6873
+      },
+      "Q4": {
+       "range": [
+        0.8784,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7306
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5678
+       ],
+       "n": 125,
+       "mean_rmse": 2.8267
+      },
+      "Q2": {
+       "range": [
+        0.5678,
+        0.5935
+       ],
+       "n": 125,
+       "mean_rmse": 2.6647
+      },
+      "Q3": {
+       "range": [
+        0.5935,
+        0.7935
+       ],
+       "n": 125,
+       "mean_rmse": 2.9527
+      },
+      "Q4": {
+       "range": [
+        0.7935,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8862
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 440.2,
+    "holdout": {
+     "holdout_rmse": 2.300955382422753,
+     "retrain_s": 0.1431,
+     "predict_s": 0.0015,
+     "cv_rmse_of_winner": 2.5167682181190614
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.4155624042025936,
+    "rmse_p10": 2.4443685173665988,
+    "rmse_median": 2.5413658118048756,
+    "train_s_median": 1.847801499068737,
+    "train_s_mean": 2.199741731186211,
+    "train_s_p90": 3.7265619530156258,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 6,
+     "learning_rate": 0.2682293847853872,
+     "num_leaves": 81,
+     "max_depth": 6,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 0.16802916621815914,
+     "lambda_l2": 5.716319036521718e-06,
+     "feature_fraction": 0.8607481408065906,
+     "bagging_fraction": 0.8617613032659153,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "gmm_features",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 14,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.5946564863818318,
+     "mixture_diversity_lambda": 0.28991932359465883,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.17144711673281263,
+     "mixture_load_balance_alpha": 0.3511125297275289,
+     "mixture_gate_max_depth": 6,
+     "mixture_gate_num_leaves": 57,
+     "mixture_gate_learning_rate": 0.1004643892799902,
+     "mixture_gate_lambda_l2": 1.3989347523008322,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_entropy_lambda": 0.20244296566054987,
+     "mixture_gate_temperature_init": 2.253096782037743,
+     "gate_temp_final_ratio": 0.7249833817967595,
+     "mixture_gate_retrain_interval": 27,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.2634344824619059,
+     "mixture_refit_every_n": 15,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.7919,
+     "mixture_e_step_mode": 0.1243,
+     "mixture_init": 0.0313,
+     "mixture_diversity_lambda": 0.0105,
+     "mixture_warmup_iters": 0.0076,
+     "max_depth": 0.0038,
+     "bagging_freq": 0.0035,
+     "lambda_l1": 0.0034,
+     "bagging_fraction": 0.0032,
+     "min_data_in_leaf": 0.0029,
+     "mixture_r_smoothing": 0.0027,
+     "mixture_load_balance_alpha": 0.0024,
+     "feature_fraction": 0.0023,
+     "mixture_expert_dropout_rate": 0.0023,
+     "mixture_gate_type": 0.0022,
+     "mixture_balance_factor": 0.0013,
+     "mixture_routing_mode": 0.001,
+     "mixture_refit_leaves": 0.0009,
+     "num_leaves": 0.0007,
+     "extra_trees": 0.0006,
+     "mixture_hard_m_step": 0.0006,
+     "mixture_num_experts": 0.0002,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 450,
+        "mean": 3.7921,
+        "std": 5.3561,
+        "min": 2.4156
+       },
+       "none": {
+        "n": 25,
+        "mean": 7.3902,
+        "std": 8.0931,
+        "min": 3.1988
+       },
+       "gbdt": {
+        "n": 25,
+        "mean": 5.3982,
+        "std": 5.5241,
+        "min": 2.5298
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 1.6061,
+       "p_value": 0.176163,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 468,
+        "mean": 3.8182,
+        "std": 5.0504,
+        "min": 2.4156
+       },
+       "expert_choice": {
+        "n": 32,
+        "mean": 7.4761,
+        "std": 10.1954,
+        "min": 2.7236
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 3.6579,
+       "p_value": 0.056176,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 448,
+        "mean": 3.5946,
+        "std": 4.8581,
+        "min": 2.4156
+       },
+       "loss_only": {
+        "n": 25,
+        "mean": 7.2402,
+        "std": 6.5495,
+        "min": 2.9788
+       },
+       "em": {
+        "n": 27,
+        "mean": 8.6954,
+        "std": 10.6953,
+        "min": 2.8078
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 3.6456,
+       "p_value": 0.012515,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 20,
+        "mean": 7.2977,
+        "std": 11.5074,
+        "min": 2.4485
+       },
+       "gmm": {
+        "n": 21,
+        "mean": 9.3571,
+        "std": 11.0178,
+        "min": 2.4836
+       },
+       "random": {
+        "n": 18,
+        "mean": 5.9172,
+        "std": 10.1263,
+        "min": 2.4755
+       },
+       "gmm_features": {
+        "n": 382,
+        "mean": 3.4214,
+        "std": 4.0397,
+        "min": 2.4156
+       },
+       "kmeans_features": {
+        "n": 33,
+        "mean": 5.1038,
+        "std": 5.7075,
+        "min": 2.4461
+       },
+       "tree_hierarchical": {
+        "n": 26,
+        "mean": 3.9161,
+        "std": 3.1549,
+        "min": 2.4782
+       }
+      },
+      "best": {
+       "value": "gmm_features",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.4947,
+       "p_value": 0.461886,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 306,
+        "mean": 3.5423,
+        "std": 4.2733,
+        "min": 2.4156
+       },
+       "markov": {
+        "n": 170,
+        "mean": 4.3792,
+        "std": 6.0961,
+        "min": 2.4317
+       },
+       "none": {
+        "n": 24,
+        "mean": 8.2402,
+        "std": 11.6189,
+        "min": 2.4658
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.8369,
+       "p_value": 0.114788,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 32,
+        "mean": 8.4497,
+        "std": 10.9358,
+        "min": 2.589
+       },
+       "True": {
+        "n": 468,
+        "mean": 3.7517,
+        "std": 4.8868,
+        "min": 2.4156
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 4.698,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 9.402,
+        "std": 11.2728,
+        "min": 2.9617
+       },
+       "False": {
+        "n": 468,
+        "mean": 3.6865,
+        "std": 4.7635,
+        "min": 2.4156
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 5.7155,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        6.0
+       ],
+       "n": 200,
+       "mean_rmse": 4.9951
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 300,
+       "mean_rmse": 3.4238
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2548
+       ],
+       "n": 125,
+       "mean_rmse": 4.3101
+      },
+      "Q2": {
+       "range": [
+        0.2548,
+        0.322
+       ],
+       "n": 125,
+       "mean_rmse": 4.6922
+      },
+      "Q3": {
+       "range": [
+        0.322,
+        0.3666
+       ],
+       "n": 125,
+       "mean_rmse": 3.2621
+      },
+      "Q4": {
+       "range": [
+        0.3666,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.9448
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 116,
+       "mean_rmse": 4.8217
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        16.0
+       ],
+       "n": 113,
+       "mean_rmse": 3.3383
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        19.0
+       ],
+       "n": 137,
+       "mean_rmse": 3.4808
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 4.5727
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 105,
+       "mean_rmse": 3.7468
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 122,
+       "mean_rmse": 5.0436
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 273,
+       "mean_rmse": 3.7269
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1934
+       ],
+       "n": 125,
+       "mean_rmse": 7.3765
+      },
+      "Q2": {
+       "range": [
+        0.1934,
+        0.225
+       ],
+       "n": 125,
+       "mean_rmse": 2.891
+      },
+      "Q3": {
+       "range": [
+        0.225,
+        0.2507
+       ],
+       "n": 125,
+       "mean_rmse": 2.818
+      },
+      "Q4": {
+       "range": [
+        0.2507,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.1238
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.75
+       ],
+       "n": 125,
+       "mean_rmse": 3.5466
+      },
+      "Q2": {
+       "range": [
+        19.75,
+        34.0
+       ],
+       "n": 122,
+       "mean_rmse": 3.4315
+      },
+      "Q3": {
+       "range": [
+        34.0,
+        77.0
+       ],
+       "n": 126,
+       "mean_rmse": 4.5939
+      },
+      "Q4": {
+       "range": [
+        77.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 4.6092
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 61,
+       "mean_rmse": 4.0821
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 132,
+       "mean_rmse": 3.5576
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 179,
+       "mean_rmse": 3.5597
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 5.2373
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 104,
+       "mean_rmse": 3.7904
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 134,
+       "mean_rmse": 3.2789
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        15.0
+       ],
+       "n": 126,
+       "mean_rmse": 3.9784
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 136,
+       "mean_rmse": 5.0832
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 5580.3,
+    "holdout": {
+     "holdout_rmse": 2.1594846712441726,
+     "retrain_s": 3.913,
+     "predict_s": 0.0516,
+     "cv_rmse_of_winner": 2.4155624042025936
+    }
+   }
+  },
+  "cpu_act@s43": {
+   "dataset": "cpu_act",
+   "seed": 43,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.04531583765639,
+    "std": 18.208031997815638
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.350232686460832,
+    "rmse_p10": 2.368325120323939,
+    "rmse_median": 2.3962889795967506,
+    "train_s_median": 0.19480155780911446,
+    "train_s_mean": 0.19354576024636624,
+    "train_s_p90": 0.2600524651259184,
+    "best_params": {
+     "learning_rate": 0.10235631603460242,
+     "num_leaves": 27,
+     "max_depth": 10,
+     "min_data_in_leaf": 6,
+     "lambda_l1": 1.8857515154709814,
+     "lambda_l2": 0.001163730137456517,
+     "feature_fraction": 0.9289189625761539,
+     "bagging_fraction": 0.7721972789854401,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5205,
+     "learning_rate": 0.3368,
+     "extra_trees": 0.0552,
+     "bagging_fraction": 0.0261,
+     "num_leaves": 0.0251,
+     "feature_fraction": 0.0161,
+     "bagging_freq": 0.0141,
+     "lambda_l1": 0.0026,
+     "max_depth": 0.0023,
+     "lambda_l2": 0.0013
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 3.6338,
+        "std": 1.2558,
+        "min": 2.8568
+       },
+       "False": {
+        "n": 469,
+        "mean": 2.55,
+        "std": 0.6068,
+        "min": 2.3502
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.0838,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0693
+       ],
+       "n": 125,
+       "mean_rmse": 2.8419
+      },
+      "Q2": {
+       "range": [
+        0.0693,
+        0.0844
+       ],
+       "n": 125,
+       "mean_rmse": 2.5106
+      },
+      "Q3": {
+       "range": [
+        0.0844,
+        0.1022
+       ],
+       "n": 125,
+       "mean_rmse": 2.5571
+      },
+      "Q4": {
+       "range": [
+        0.1022,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.5593
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 107,
+       "mean_rmse": 2.6072
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        28.0
+       ],
+       "n": 136,
+       "mean_rmse": 2.5236
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        33.0
+       ],
+       "n": 118,
+       "mean_rmse": 2.5118
+      },
+      "Q4": {
+       "range": [
+        33.0,
+        null
+       ],
+       "n": 139,
+       "mean_rmse": 2.8061
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 93,
+       "mean_rmse": 2.8834
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 48,
+       "mean_rmse": 2.4895
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 137,
+       "mean_rmse": 2.5351
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 222,
+       "mean_rmse": 2.584
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 114,
+       "mean_rmse": 2.4213
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 127,
+       "mean_rmse": 2.4891
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        12.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.411
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 136,
+       "mean_rmse": 3.0877
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.5797
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.1564
+       ],
+       "n": 125,
+       "mean_rmse": 2.7601
+      },
+      "Q3": {
+       "range": [
+        0.1564,
+        1.2329
+       ],
+       "n": 125,
+       "mean_rmse": 2.4987
+      },
+      "Q4": {
+       "range": [
+        1.2329,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6305
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0006
+       ],
+       "n": 125,
+       "mean_rmse": 2.6582
+      },
+      "Q2": {
+       "range": [
+        0.0006,
+        0.0026
+       ],
+       "n": 125,
+       "mean_rmse": 2.523
+      },
+      "Q3": {
+       "range": [
+        0.0026,
+        0.0157
+       ],
+       "n": 125,
+       "mean_rmse": 2.5067
+      },
+      "Q4": {
+       "range": [
+        0.0157,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7811
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8792
+       ],
+       "n": 125,
+       "mean_rmse": 2.8475
+      },
+      "Q2": {
+       "range": [
+        0.8792,
+        0.9305
+       ],
+       "n": 125,
+       "mean_rmse": 2.5626
+      },
+      "Q3": {
+       "range": [
+        0.9305,
+        0.9563
+       ],
+       "n": 125,
+       "mean_rmse": 2.5383
+      },
+      "Q4": {
+       "range": [
+        0.9563,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.5205
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7565
+       ],
+       "n": 125,
+       "mean_rmse": 2.7173
+      },
+      "Q2": {
+       "range": [
+        0.7565,
+        0.782
+       ],
+       "n": 125,
+       "mean_rmse": 2.5851
+      },
+      "Q3": {
+       "range": [
+        0.782,
+        0.8282
+       ],
+       "n": 125,
+       "mean_rmse": 2.5059
+      },
+      "Q4": {
+       "range": [
+        0.8282,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6607
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 498.8,
+    "holdout": {
+     "holdout_rmse": 2.9174951688877546,
+     "retrain_s": 0.2451,
+     "predict_s": 0.0019,
+     "cv_rmse_of_winner": 2.350232686460832
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.293625343355084,
+    "rmse_p10": 2.317822406619266,
+    "rmse_median": 2.355157836756982,
+    "train_s_median": 1.0482707841321826,
+    "train_s_mean": 1.5911552359834313,
+    "train_s_p90": 3.049166227951646,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.19247332102549333,
+     "num_leaves": 40,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.4818745347563474e-08,
+     "lambda_l2": 4.969354690714322,
+     "feature_fraction": 0.890963881567973,
+     "bagging_fraction": 0.7021838005042574,
+     "bagging_freq": 3,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 48,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.5019728319114266,
+     "mixture_diversity_lambda": 0.4751482016577913,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.04549375683349195,
+     "mixture_load_balance_alpha": 0.1112704579147649,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 52,
+     "mixture_gate_learning_rate": 0.2094187619155588,
+     "mixture_gate_lambda_l2": 5.689937350895524,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.11189905495697039,
+     "mixture_gate_temperature_init": 1.8705625173649014,
+     "gate_temp_final_ratio": 0.4463579928082349,
+     "mixture_gate_retrain_interval": 24,
+     "mixture_expert_capacity_factor": 1.1005422816600992,
+     "mixture_expert_choice_boost": 22.749433438527227,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.4257567812384221,
+     "mixture_refit_every_n": 7,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_init": 0.4958,
+     "learning_rate": 0.1468,
+     "mixture_num_experts": 0.114,
+     "bagging_fraction": 0.0436,
+     "mixture_warmup_iters": 0.0393,
+     "max_depth": 0.0294,
+     "mixture_r_smoothing": 0.0221,
+     "mixture_diversity_lambda": 0.0218,
+     "mixture_balance_factor": 0.0177,
+     "num_leaves": 0.0173,
+     "min_data_in_leaf": 0.0118,
+     "mixture_load_balance_alpha": 0.011,
+     "feature_fraction": 0.0089,
+     "mixture_e_step_mode": 0.0054,
+     "lambda_l2": 0.0053,
+     "bagging_freq": 0.0051,
+     "mixture_gate_type": 0.0015,
+     "extra_trees": 0.0013,
+     "mixture_expert_dropout_rate": 0.001,
+     "mixture_hard_m_step": 0.0008,
+     "lambda_l1": 0.0001,
+     "mixture_routing_mode": 0.0001,
+     "mixture_refit_leaves": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 34,
+        "mean": 5.1122,
+        "std": 5.519,
+        "min": 2.3214
+       },
+       "leaf_reuse": {
+        "n": 232,
+        "mean": 3.6588,
+        "std": 5.1703,
+        "min": 2.2936
+       },
+       "none": {
+        "n": 234,
+        "mean": 3.8429,
+        "std": 5.9816,
+        "min": 2.3135
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 0.1841,
+       "p_value": 0.723031,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 232,
+        "mean": 3.8905,
+        "std": 5.5605,
+        "min": 2.2936
+       },
+       "token_choice": {
+        "n": 268,
+        "mean": 3.8033,
+        "std": 5.6311,
+        "min": 2.3051
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0872,
+       "p_value": 0.862347,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 342,
+        "mean": 3.4836,
+        "std": 4.3618,
+        "min": 2.2936
+       },
+       "gate_only": {
+        "n": 65,
+        "mean": 5.1899,
+        "std": 8.6942,
+        "min": 2.322
+       },
+       "em": {
+        "n": 93,
+        "mean": 4.2277,
+        "std": 6.6206,
+        "min": 2.32
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.7441,
+       "p_value": 0.309888,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 19,
+        "mean": 9.1759,
+        "std": 11.5666,
+        "min": 2.6927
+       },
+       "tree_hierarchical": {
+        "n": 24,
+        "mean": 3.4164,
+        "std": 1.5798,
+        "min": 2.4495
+       },
+       "uniform": {
+        "n": 391,
+        "mean": 2.9344,
+        "std": 3.3467,
+        "min": 2.2936
+       },
+       "kmeans_features": {
+        "n": 18,
+        "mean": 9.0574,
+        "std": 11.4437,
+        "min": 2.6145
+       },
+       "gmm_features": {
+        "n": 19,
+        "mean": 12.6694,
+        "std": 12.5903,
+        "min": 3.4985
+       },
+       "random": {
+        "n": 29,
+        "mean": 3.9463,
+        "std": 4.0877,
+        "min": 2.4319
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.482,
+       "p_value": 0.201352,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 370,
+        "mean": 3.2802,
+        "std": 3.756,
+        "min": 2.2936
+       },
+       "none": {
+        "n": 76,
+        "mean": 6.173,
+        "std": 10.0106,
+        "min": 2.327
+       },
+       "markov": {
+        "n": 54,
+        "mean": 4.4274,
+        "std": 6.5096,
+        "min": 2.3408
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 1.1472,
+       "p_value": 0.215082,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 3.6119,
+        "std": 5.1453,
+        "min": 2.2936
+       },
+       "True": {
+        "n": 32,
+        "mean": 7.2351,
+        "std": 9.5023,
+        "min": 2.7916
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 3.6232,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 3.6731,
+        "std": 5.362,
+        "min": 2.2936
+       },
+       "True": {
+        "n": 30,
+        "mean": 6.518,
+        "std": 8.0228,
+        "min": 2.7333
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.8449,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 47,
+       "mean_rmse": 5.0737
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 453,
+       "mean_rmse": 3.7162
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2301
+       ],
+       "n": 125,
+       "mean_rmse": 5.0114
+      },
+      "Q2": {
+       "range": [
+        0.2301,
+        0.383
+       ],
+       "n": 125,
+       "mean_rmse": 3.2628
+      },
+      "Q3": {
+       "range": [
+        0.383,
+        0.4212
+       ],
+       "n": 125,
+       "mean_rmse": 3.3566
+      },
+      "Q4": {
+       "range": [
+        0.4212,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.7444
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        37.0
+       ],
+       "n": 116,
+       "mean_rmse": 4.8878
+      },
+      "Q2": {
+       "range": [
+        37.0,
+        42.0
+       ],
+       "n": 115,
+       "mean_rmse": 3.0681
+      },
+      "Q3": {
+       "range": [
+        42.0,
+        44.0
+       ],
+       "n": 106,
+       "mean_rmse": 3.0147
+      },
+      "Q4": {
+       "range": [
+        44.0,
+        null
+       ],
+       "n": 163,
+       "mean_rmse": 4.1872
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 90,
+       "mean_rmse": 5.0976
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 53,
+       "mean_rmse": 4.1828
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 357,
+       "mean_rmse": 3.4774
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1515
+       ],
+       "n": 125,
+       "mean_rmse": 6.0344
+      },
+      "Q2": {
+       "range": [
+        0.1515,
+        0.1854
+       ],
+       "n": 125,
+       "mean_rmse": 3.0598
+      },
+      "Q3": {
+       "range": [
+        0.1854,
+        0.2169
+       ],
+       "n": 125,
+       "mean_rmse": 3.3755
+      },
+      "Q4": {
+       "range": [
+        0.2169,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.9055
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.8956
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        27.0
+       ],
+       "n": 106,
+       "mean_rmse": 3.3935
+      },
+      "Q3": {
+       "range": [
+        27.0,
+        38.0
+       ],
+       "n": 144,
+       "mean_rmse": 3.8249
+      },
+      "Q4": {
+       "range": [
+        38.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 5.1594
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 69,
+       "mean_rmse": 5.5076
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 106,
+       "mean_rmse": 3.2262
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 92,
+       "mean_rmse": 3.6953
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 233,
+       "mean_rmse": 3.6907
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 104,
+       "mean_rmse": 3.3174
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 131,
+       "mean_rmse": 3.1631
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 137,
+       "mean_rmse": 3.2465
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 5.6075
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 4035.5,
+    "holdout": {
+     "holdout_rmse": 2.9004656530002197,
+     "retrain_s": 3.4277,
+     "predict_s": 0.0328,
+     "cv_rmse_of_winner": 2.293625343355084
+    }
+   }
+  },
+  "cpu_act@s44": {
+   "dataset": "cpu_act",
+   "seed": 44,
+   "X_search_shape": [
+    6554,
+    21
+   ],
+   "n_holdout": 1638,
+   "y_stats": {
+    "mean": 84.05965822398535,
+    "std": 18.44113958458848
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.478020653643999,
+    "rmse_p10": 2.5057536238429177,
+    "rmse_median": 2.53773466937374,
+    "train_s_median": 0.12072589732706546,
+    "train_s_mean": 0.124411271943897,
+    "train_s_p90": 0.16552506491541863,
+    "best_params": {
+     "learning_rate": 0.09794167184693416,
+     "num_leaves": 20,
+     "max_depth": 7,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.009843483454644992,
+     "lambda_l2": 0.0014078509805729065,
+     "feature_fraction": 0.9992950848593232,
+     "bagging_fraction": 0.9641084492758434,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.4633,
+     "learning_rate": 0.3035,
+     "extra_trees": 0.1363,
+     "feature_fraction": 0.0487,
+     "num_leaves": 0.0164,
+     "max_depth": 0.0136,
+     "bagging_fraction": 0.0119,
+     "bagging_freq": 0.0048,
+     "lambda_l1": 0.001,
+     "lambda_l2": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 2.6744,
+        "std": 0.524,
+        "min": 2.478
+       },
+       "True": {
+        "n": 30,
+        "mean": 3.6872,
+        "std": 1.0227,
+        "min": 2.8796
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.0128,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0872
+       ],
+       "n": 125,
+       "mean_rmse": 2.976
+      },
+      "Q2": {
+       "range": [
+        0.0872,
+        0.0969
+       ],
+       "n": 125,
+       "mean_rmse": 2.616
+      },
+      "Q3": {
+       "range": [
+        0.0969,
+        0.1088
+       ],
+       "n": 125,
+       "mean_rmse": 2.6132
+      },
+      "Q4": {
+       "range": [
+        0.1088,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7356
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.6476
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        21.0
+       ],
+       "n": 102,
+       "mean_rmse": 2.6437
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        28.0
+       ],
+       "n": 148,
+       "mean_rmse": 2.6443
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 2.994
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 109,
+       "mean_rmse": 2.9005
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 391,
+       "mean_rmse": 2.6891
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        5.75
+       ],
+       "n": 125,
+       "mean_rmse": 2.5548
+      },
+      "Q2": {
+       "range": [
+        5.75,
+        8.0
+       ],
+       "n": 118,
+       "mean_rmse": 2.5718
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 118,
+       "mean_rmse": 2.6144
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 139,
+       "mean_rmse": 3.1387
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 125,
+       "mean_rmse": 2.7812
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0071
+       ],
+       "n": 125,
+       "mean_rmse": 2.8047
+      },
+      "Q3": {
+       "range": [
+        0.0071,
+        0.017
+       ],
+       "n": 125,
+       "mean_rmse": 2.5968
+      },
+      "Q4": {
+       "range": [
+        0.017,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7581
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.6496
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0006
+       ],
+       "n": 125,
+       "mean_rmse": 2.725
+      },
+      "Q3": {
+       "range": [
+        0.0006,
+        0.0018
+       ],
+       "n": 125,
+       "mean_rmse": 2.6849
+      },
+      "Q4": {
+       "range": [
+        0.0018,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8814
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9624
+       ],
+       "n": 125,
+       "mean_rmse": 3.0691
+      },
+      "Q2": {
+       "range": [
+        0.9624,
+        0.9817
+       ],
+       "n": 125,
+       "mean_rmse": 2.6737
+      },
+      "Q3": {
+       "range": [
+        0.9817,
+        0.9908
+       ],
+       "n": 125,
+       "mean_rmse": 2.6105
+      },
+      "Q4": {
+       "range": [
+        0.9908,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.5875
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.922
+       ],
+       "n": 125,
+       "mean_rmse": 2.8852
+      },
+      "Q2": {
+       "range": [
+        0.922,
+        0.9491
+       ],
+       "n": 125,
+       "mean_rmse": 2.7112
+      },
+      "Q3": {
+       "range": [
+        0.9491,
+        0.969
+       ],
+       "n": 125,
+       "mean_rmse": 2.6835
+      },
+      "Q4": {
+       "range": [
+        0.969,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.661
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 322.8,
+    "holdout": {
+     "holdout_rmse": 2.276056326993748,
+     "retrain_s": 0.1352,
+     "predict_s": 0.0016,
+     "cv_rmse_of_winner": 2.478020653643999
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.4308088077426087,
+    "rmse_p10": 2.4676794080578213,
+    "rmse_median": 2.529478209589561,
+    "train_s_median": 0.6011269878596068,
+    "train_s_mean": 0.7567615038111806,
+    "train_s_p90": 1.258107333444059,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.13736726479690983,
+     "num_leaves": 68,
+     "max_depth": 7,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 2.9971303912375786,
+     "lambda_l2": 0.43871624623217037,
+     "feature_fraction": 0.705529301406953,
+     "bagging_fraction": 0.5767622400080251,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "kmeans_features",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 32,
+     "mixture_balance_factor": 7,
+     "mixture_smoothing_lambda": 0.8138873647773308,
+     "mixture_diversity_lambda": 0.06569567061356774,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.017296683492973725,
+     "mixture_load_balance_alpha": 0.45432553848616725,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 44,
+     "mixture_gate_learning_rate": 0.025931074547186954,
+     "mixture_gate_lambda_l2": 0.03251286646511701,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.08723025365938297,
+     "mixture_gate_temperature_init": 1.795203932838745,
+     "gate_temp_final_ratio": 0.5690134593263421,
+     "mixture_gate_retrain_interval": 10,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.15489003956130126,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.7097,
+     "mixture_balance_factor": 0.0907,
+     "min_data_in_leaf": 0.0464,
+     "mixture_diversity_lambda": 0.0281,
+     "mixture_num_experts": 0.0202,
+     "mixture_r_smoothing": 0.0192,
+     "num_leaves": 0.0133,
+     "mixture_gate_type": 0.0129,
+     "mixture_e_step_mode": 0.0119,
+     "feature_fraction": 0.0098,
+     "lambda_l2": 0.0064,
+     "mixture_refit_leaves": 0.006,
+     "mixture_routing_mode": 0.0059,
+     "bagging_freq": 0.0032,
+     "mixture_expert_dropout_rate": 0.0028,
+     "mixture_load_balance_alpha": 0.0025,
+     "mixture_warmup_iters": 0.0023,
+     "max_depth": 0.002,
+     "bagging_fraction": 0.0019,
+     "lambda_l1": 0.0014,
+     "mixture_hard_m_step": 0.0014,
+     "extra_trees": 0.0012,
+     "mixture_init": 0.0009
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 28,
+        "mean": 4.967,
+        "std": 5.2716,
+        "min": 2.4965
+       },
+       "none": {
+        "n": 27,
+        "mean": 8.473,
+        "std": 10.7533,
+        "min": 2.6
+       },
+       "leaf_reuse": {
+        "n": 445,
+        "mean": 3.4393,
+        "std": 3.7775,
+        "min": 2.4308
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 1.5277,
+       "p_value": 0.149009,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 470,
+        "mean": 3.5816,
+        "std": 4.1648,
+        "min": 2.4308
+       },
+       "expert_choice": {
+        "n": 30,
+        "mean": 7.1659,
+        "std": 8.9836,
+        "min": 2.5578
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 3.5843,
+       "p_value": 0.041161,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 31,
+        "mean": 5.7873,
+        "std": 4.5601,
+        "min": 2.5557
+       },
+       "gate_only": {
+        "n": 445,
+        "mean": 3.5482,
+        "std": 4.5879,
+        "min": 2.4308
+       },
+       "loss_only": {
+        "n": 24,
+        "mean": 5.8327,
+        "std": 5.3013,
+        "min": 2.6351
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 2.2391,
+       "p_value": 0.0136,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 280,
+        "mean": 3.5567,
+        "std": 4.4359,
+        "min": 2.4308
+       },
+       "tree_hierarchical": {
+        "n": 17,
+        "mean": 5.1778,
+        "std": 3.9221,
+        "min": 2.5419
+       },
+       "random": {
+        "n": 17,
+        "mean": 5.8489,
+        "std": 8.3442,
+        "min": 2.5216
+       },
+       "gmm": {
+        "n": 152,
+        "mean": 3.9141,
+        "std": 4.9797,
+        "min": 2.4364
+       },
+       "gmm_features": {
+        "n": 18,
+        "mean": 3.9028,
+        "std": 1.9495,
+        "min": 2.5061
+       },
+       "uniform": {
+        "n": 16,
+        "mean": 3.1129,
+        "std": 0.9213,
+        "min": 2.5221
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "kmeans_features",
+       "delta_mean": 0.4438,
+       "p_value": 0.217332,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 23,
+        "mean": 6.7609,
+        "std": 8.2249,
+        "min": 2.4725
+       },
+       "ema": {
+        "n": 359,
+        "mean": 3.5529,
+        "std": 4.3469,
+        "min": 2.4308
+       },
+       "markov": {
+        "n": 118,
+        "mean": 3.9606,
+        "std": 4.4813,
+        "min": 2.4364
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.4077,
+       "p_value": 0.390541,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 33,
+        "mean": 7.3624,
+        "std": 8.2861,
+        "min": 2.6066
+       },
+       "True": {
+        "n": 467,
+        "mean": 3.5447,
+        "std": 4.1956,
+        "min": 2.4308
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 3.8177,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 6.3601,
+        "std": 6.1854,
+        "min": 3.3873
+       },
+       "False": {
+        "n": 469,
+        "mean": 3.6272,
+        "std": 4.5084,
+        "min": 2.4308
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 2.7329,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 500,
+       "mean_rmse": 3.7967
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2864
+       ],
+       "n": 125,
+       "mean_rmse": 3.901
+      },
+      "Q2": {
+       "range": [
+        0.2864,
+        0.3452
+       ],
+       "n": 125,
+       "mean_rmse": 2.962
+      },
+      "Q3": {
+       "range": [
+        0.3452,
+        0.37
+       ],
+       "n": 125,
+       "mean_rmse": 3.8429
+      },
+      "Q4": {
+       "range": [
+        0.37,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 4.4808
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        30.0
+       ],
+       "n": 110,
+       "mean_rmse": 3.6454
+      },
+      "Q2": {
+       "range": [
+        30.0,
+        33.0
+       ],
+       "n": 138,
+       "mean_rmse": 3.5146
+      },
+      "Q3": {
+       "range": [
+        33.0,
+        35.0
+       ],
+       "n": 124,
+       "mean_rmse": 3.9352
+      },
+      "Q4": {
+       "range": [
+        35.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 4.0965
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 90,
+       "mean_rmse": 5.4695
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 280,
+       "mean_rmse": 3.236
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 3.8461
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1208
+       ],
+       "n": 125,
+       "mean_rmse": 5.9971
+      },
+      "Q2": {
+       "range": [
+        0.1208,
+        0.149
+       ],
+       "n": 125,
+       "mean_rmse": 2.9222
+      },
+      "Q3": {
+       "range": [
+        0.149,
+        0.1772
+       ],
+       "n": 125,
+       "mean_rmse": 2.9665
+      },
+      "Q4": {
+       "range": [
+        0.1772,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.3009
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        52.0
+       ],
+       "n": 123,
+       "mean_rmse": 3.9645
+      },
+      "Q2": {
+       "range": [
+        52.0,
+        61.5
+       ],
+       "n": 127,
+       "mean_rmse": 3.2807
+      },
+      "Q3": {
+       "range": [
+        61.5,
+        75.25
+       ],
+       "n": 125,
+       "mean_rmse": 3.5504
+      },
+      "Q4": {
+       "range": [
+        75.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 4.402
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 39,
+       "mean_rmse": 5.729
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 217,
+       "mean_rmse": 3.4524
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 244,
+       "mean_rmse": 3.794
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 102,
+       "mean_rmse": 3.0859
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 118,
+       "mean_rmse": 3.4483
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 142,
+       "mean_rmse": 3.4378
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 138,
+       "mean_rmse": 4.9892
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 1931.4,
+    "holdout": {
+     "holdout_rmse": 2.232601241257653,
+     "retrain_s": 0.7406,
+     "predict_s": 0.0072,
+     "cv_rmse_of_winner": 2.4308088077426087
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_elevators_ensemble_report.md
+++ b/bench_results/wide_v081/ds_elevators_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['elevators'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `4e208d83bace`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| elevators | naive-ensemble | **0.00230** ± 0.00006 | 0.00252 | 0.0% | 0.36 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| elevators@s42 | naive-ensemble | 0.0025 | 0.0026 | 0.224 | 690 |
+| elevators@s43 | naive-ensemble | 0.0025 | 0.0026 | 0.273 | 846 |
+| elevators@s44 | naive-ensemble | 0.0025 | 0.0025 | 0.310 | 848 |
+
+
+
+---
+
+## elevators@s42  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.00238** (winner retrained in 0.48s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0026, p10: 0.0026
+- train: median 0.224s/fold, mean 0.272s, p90 0.394s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.708 |
+| `learning_rate` | 0.111 |
+| `extra_trees` | 0.053 |
+| `min_data_in_leaf` | 0.036 |
+| `n_models` | 0.029 |
+| `feature_fraction` | 0.019 |
+| `max_depth` | 0.011 |
+| `bagging_freq` | 0.011 |
+| `num_leaves` | 0.010 |
+| `bagging_fraction` | 0.010 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.0027 | 0.0005 | 0.0025 |
+| True | 32 | 0.0032 | 0.0007 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0031 | 0.0027 | 0.0026 | 0.0027 | **Q3** [0.2517, 0.2785] |
+| `num_leaves` | 0.0027 | 0.0028 | 0.0027 | 0.0029 | **Q1** [None, 22.75] |
+| `max_depth` | 0.0028 | — | 0.0028 | 0.0028 | **Q1** [None, 4.0] |
+| `min_data_in_leaf` | 0.0027 | 0.0027 | 0.0027 | 0.0030 | **Q1** [None, 10.0] |
+| `lambda_l1` | 0.0028 | 0.0027 | 0.0027 | 0.0029 | **Q2** [0.0, 0.0001] |
+| `lambda_l2` | 0.0027 | 0.0028 | 0.0027 | 0.0029 | **Q1** [None, 0.0] |
+| `feature_fraction` | 0.0028 | 0.0028 | 0.0027 | 0.0028 | **Q3** [0.9601, 0.9779] |
+| `bagging_fraction` | 0.0028 | 0.0028 | 0.0028 | 0.0027 | **Q4** [0.9212, ∞) |
+
+#### E. Slice plot
+
+![elevators@s42/naive-ensemble](slice_elevators@s42_naive-ensemble.png)
+
+
+---
+
+## elevators@s43  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.00226** (winner retrained in 0.30s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0026, p10: 0.0026
+- train: median 0.273s/fold, mean 0.335s, p90 0.563s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.819 |
+| `bagging_freq` | 0.061 |
+| `learning_rate` | 0.030 |
+| `num_leaves` | 0.020 |
+| `bagging_fraction` | 0.019 |
+| `max_depth` | 0.019 |
+| `feature_fraction` | 0.019 |
+| `extra_trees` | 0.008 |
+| `min_data_in_leaf` | 0.002 |
+| `n_models` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.0027 | 0.0005 | 0.0025 |
+| True | 32 | 0.0033 | 0.0008 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0031 | 0.0027 | 0.0026 | 0.0027 | **Q3** [0.2375, 0.266] |
+| `num_leaves` | 0.0028 | 0.0027 | 0.0027 | 0.0030 | **Q2** [12.0, 15.0] |
+| `max_depth` | 0.0031 | 0.0028 | — | 0.0027 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 0.0027 | 0.0027 | 0.0027 | 0.0030 | **Q1** [None, 7.0] |
+| `lambda_l1` | 0.0027 | 0.0027 | 0.0026 | 0.0030 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.0028 | 0.0027 | 0.0028 | 0.0028 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.0030 | 0.0027 | 0.0027 | 0.0027 | **Q2** [0.929, 0.9593] |
+| `bagging_fraction` | 0.0028 | 0.0027 | 0.0027 | 0.0029 | **Q2** [0.7398, 0.7637] |
+
+#### E. Slice plot
+
+![elevators@s43/naive-ensemble](slice_elevators@s43_naive-ensemble.png)
+
+
+---
+
+## elevators@s44  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.00225** (winner retrained in 0.30s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0025, p10: 0.0025
+- train: median 0.310s/fold, mean 0.335s, p90 0.432s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.602 |
+| `learning_rate` | 0.221 |
+| `bagging_fraction` | 0.069 |
+| `num_leaves` | 0.030 |
+| `feature_fraction` | 0.024 |
+| `min_data_in_leaf` | 0.018 |
+| `max_depth` | 0.014 |
+| `lambda_l2` | 0.011 |
+| `extra_trees` | 0.009 |
+| `bagging_freq` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 0.0027 | 0.0005 | 0.0025 |
+| True | 30 | 0.0033 | 0.0008 | 0.0026 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0031 | 0.0026 | 0.0026 | 0.0026 | **Q2** [0.232, 0.2637] |
+| `num_leaves` | 0.0026 | 0.0027 | 0.0027 | 0.0030 | **Q1** [None, 12.0] |
+| `max_depth` | 0.0029 | 0.0027 | 0.0026 | 0.0027 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | 0.0026 | 0.0027 | 0.0027 | 0.0029 | **Q1** [None, 7.0] |
+| `lambda_l1` | 0.0026 | 0.0026 | 0.0027 | 0.0030 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0029 | 0.0027 | 0.0026 | 0.0027 | **Q3** [1.2242, 3.9295] |
+| `feature_fraction` | 0.0029 | 0.0026 | 0.0027 | 0.0027 | **Q2** [0.8848, 0.9175] |
+| `bagging_fraction` | 0.0027 | 0.0027 | 0.0027 | 0.0028 | **Q1** [None, 0.7029] |
+
+#### E. Slice plot
+
+![elevators@s44/naive-ensemble](slice_elevators@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_elevators_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_elevators_ensemble_summary.json
@@ -1,0 +1,1177 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "elevators"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "4e208d83baceaa5a1ebd0eccaa975a01d7361bd2",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "elevators": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.0023798413985376935,
+      "cv_best": 0.0025451438427209097,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4758
+     },
+     "43": {
+      "holdout_rmse": 0.002260311569955601,
+      "cv_best": 0.0025336735519510658,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2965
+     },
+     "44": {
+      "holdout_rmse": 0.0022463994461221744,
+      "cv_best": 0.0024825053282565702,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2981
+     }
+    },
+    "holdout_mean": 0.002296,
+    "holdout_std": 6e-05,
+    "cv_best_mean": 0.00252
+   }
+  }
+ },
+ "runs": {
+  "elevators@s42": {
+   "dataset": "elevators",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021624375,
+    "std": 0.006717125937435966
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0025451438427209097,
+    "rmse_p10": 0.002568626375420177,
+    "rmse_median": 0.0026093193214218532,
+    "train_s_median": 0.2237346075475216,
+    "train_s_mean": 0.27227774235829716,
+    "train_s_p90": 0.3939536515623332,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.1880902175568004,
+     "num_leaves": 18,
+     "max_depth": 6,
+     "min_data_in_leaf": 8,
+     "lambda_l1": 0.0010647031191962375,
+     "lambda_l2": 9.04159683998147e-05,
+     "feature_fraction": 0.9701838063454893,
+     "bagging_fraction": 0.6248114409483522,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.7077,
+     "learning_rate": 0.1106,
+     "extra_trees": 0.0527,
+     "min_data_in_leaf": 0.0356,
+     "n_models": 0.0285,
+     "feature_fraction": 0.0189,
+     "max_depth": 0.0111,
+     "bagging_freq": 0.011,
+     "num_leaves": 0.0102,
+     "bagging_fraction": 0.01,
+     "lambda_l2": 0.0036
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 0.0027,
+        "std": 0.0005,
+        "min": 0.0025
+       },
+       "True": {
+        "n": 32,
+        "mean": 0.0032,
+        "std": 0.0007,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0005,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2052
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.2052,
+        0.2517
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2517,
+        0.2785
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.2785,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        22.75
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        22.75,
+        38.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        38.0,
+        64.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        64.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 33,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        6.0
+       ],
+       "n": 339,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        13.0
+       ],
+       "n": 106,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        19.0
+       ],
+       "n": 145,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0009
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.0009,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9252
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.9252,
+        0.9601
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9601,
+        0.9779
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9779,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7493
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.7493,
+        0.8752
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.8752,
+        0.9212
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9212,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 689.6,
+    "holdout": {
+     "holdout_rmse": 0.0023798413985376935,
+     "retrain_s": 0.4758,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.0025451438427209097
+    }
+   }
+  },
+  "elevators@s43": {
+   "dataset": "elevators",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021558875,
+    "std": 0.0066420654720030425
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0025336735519510658,
+    "rmse_p10": 0.002561834684269561,
+    "rmse_median": 0.0025981123197130504,
+    "train_s_median": 0.2727898210287094,
+    "train_s_mean": 0.33473217815980316,
+    "train_s_p90": 0.5632690099254257,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.25075093749252536,
+     "num_leaves": 13,
+     "max_depth": 11,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 2.21899237507929e-06,
+     "lambda_l2": 2.682862651761984e-05,
+     "feature_fraction": 0.9711491934620731,
+     "bagging_fraction": 0.7797150335401617,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.8193,
+     "bagging_freq": 0.061,
+     "learning_rate": 0.0297,
+     "num_leaves": 0.0196,
+     "bagging_fraction": 0.0193,
+     "max_depth": 0.019,
+     "feature_fraction": 0.0188,
+     "extra_trees": 0.0081,
+     "min_data_in_leaf": 0.0024,
+     "n_models": 0.0023,
+     "lambda_l2": 0.0004
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 0.0027,
+        "std": 0.0005,
+        "min": 0.0025
+       },
+       "True": {
+        "n": 32,
+        "mean": 0.0033,
+        "std": 0.0008,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.198
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.198,
+        0.2375
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.2375,
+        0.266
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.266,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 110,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 126,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        21.0
+       ],
+       "n": 138,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        21.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 59,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 372,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 94,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 129,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 149,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        14.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.929
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.929,
+        0.9593
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.9593,
+        0.9802
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9802,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7398
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.7398,
+        0.7637
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.7637,
+        0.7861
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.7861,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 846.0,
+    "holdout": {
+     "holdout_rmse": 0.002260311569955601,
+     "retrain_s": 0.2965,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.0025336735519510658
+    }
+   }
+  },
+  "elevators@s44": {
+   "dataset": "elevators",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021623500000000004,
+    "std": 0.006704326793198554
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0024825053282565702,
+    "rmse_p10": 0.002502895309177832,
+    "rmse_median": 0.0025443031299984716,
+    "train_s_median": 0.31046407520771024,
+    "train_s_mean": 0.335312850869447,
+    "train_s_p90": 0.43229753017425543,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.29805729456197294,
+     "num_leaves": 10,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 3.5605030293585113e-07,
+     "lambda_l2": 1.7570751528202748,
+     "feature_fraction": 0.9020181624691609,
+     "bagging_fraction": 0.7675800390942373,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6023,
+     "learning_rate": 0.2209,
+     "bagging_fraction": 0.0688,
+     "num_leaves": 0.0301,
+     "feature_fraction": 0.0237,
+     "min_data_in_leaf": 0.0183,
+     "max_depth": 0.0138,
+     "lambda_l2": 0.0115,
+     "extra_trees": 0.0091,
+     "bagging_freq": 0.0013,
+     "n_models": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 30,
+        "mean": 0.0033,
+        "std": 0.0008,
+        "min": 0.0026
+       },
+       "False": {
+        "n": 470,
+        "mean": 0.0027,
+        "std": 0.0005,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.232
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.232,
+        0.2637
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        0.2637,
+        0.2812
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        0.2812,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.0026
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 112,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        25.0
+       ],
+       "n": 146,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 105,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 129,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 86,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 180,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 106,
+       "mean_rmse": 0.0026
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 127,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 131,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 136,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0069
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0069,
+        1.2242
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        1.2242,
+        3.9295
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q4": {
+       "range": [
+        3.9295,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8848
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.8848,
+        0.9175
+       ],
+       "n": 125,
+       "mean_rmse": 0.0026
+      },
+      "Q3": {
+       "range": [
+        0.9175,
+        0.9449
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9449,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7029
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        0.7029,
+        0.7591
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.7591,
+        0.8142
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.8142,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 847.5,
+    "holdout": {
+     "holdout_rmse": 0.0022463994461221744,
+     "retrain_s": 0.2981,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.0024825053282565702
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_elevators_report.md
+++ b/bench_results/wide_v081/ds_elevators_report.md
@@ -1,0 +1,518 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['elevators'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| elevators | naive-lightgbm | **0.00236** ± 0.00008 | 0.00263 | 0.0% | 0.24 |
+| elevators | moe | **0.00230** ± 0.00002 | 0.00256 | 0.0% | 2.09 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| elevators@s42 | naive-lightgbm | 0.0026 | 0.0027 | 0.118 | 324 |
+| elevators@s42 | moe | 0.0025 | 0.0028 | 1.216 | 3351 |
+| elevators@s43 | naive-lightgbm | 0.0026 | 0.0027 | 0.168 | 455 |
+| elevators@s43 | moe | 0.0026 | 0.0026 | 1.543 | 5622 |
+| elevators@s44 | naive-lightgbm | 0.0026 | 0.0027 | 0.168 | 418 |
+| elevators@s44 | moe | 0.0026 | 0.0028 | 1.422 | 4837 |
+
+
+
+---
+
+## elevators@s42  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00245** (winner retrained in 0.15s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0027
+- train: median 0.118s/fold, mean 0.124s, p90 0.163s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.683 |
+| `learning_rate` | 0.111 |
+| `min_data_in_leaf` | 0.107 |
+| `num_leaves` | 0.058 |
+| `feature_fraction` | 0.015 |
+| `bagging_fraction` | 0.014 |
+| `bagging_freq` | 0.007 |
+| `max_depth` | 0.004 |
+| `extra_trees` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.0028 | 0.0005 | 0.0026 |
+| True | 32 | 0.0034 | 0.0008 | 0.0028 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0031 | 0.0028 | 0.0027 | 0.0028 | **Q3** [0.2162, 0.2435] |
+| `num_leaves` | 0.0029 | 0.0028 | 0.0028 | 0.0030 | **Q2** [13.0, 17.0] |
+| `max_depth` | 0.0030 | — | — | 0.0028 | **Q4** [6.0, ∞) |
+| `min_data_in_leaf` | 0.0027 | 0.0029 | 0.0028 | 0.0030 | **Q1** [None, 11.0] |
+| `lambda_l1` | 0.0029 | 0.0028 | 0.0028 | 0.0030 | **Q2** [0.0001, 0.0004] |
+| `lambda_l2` | 0.0030 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.0001, 0.0004] |
+| `feature_fraction` | 0.0030 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.91, 0.9324] |
+| `bagging_fraction` | 0.0030 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.9364, 0.9573] |
+
+#### E. Slice plot
+
+![elevators@s42/naive-lightgbm](slice_elevators@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00233** (winner retrained in 1.16s, cv score of winner: 0.0025)
+- cv best RMSE: 0.0025, median: 0.0028, p10: 0.0026
+- train: median 1.216s/fold, mean 1.314s, p90 2.112s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_diversity_lambda` | 0.314 |
+| `max_depth` | 0.090 |
+| `bagging_fraction` | 0.086 |
+| `feature_fraction` | 0.080 |
+| `mixture_expert_dropout_rate` | 0.064 |
+| `mixture_balance_factor` | 0.062 |
+| `lambda_l1` | 0.055 |
+| `mixture_init` | 0.049 |
+| `num_leaves` | 0.039 |
+| `learning_rate` | 0.034 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 435 | 0.0047 | 0.0043 | 0.0025 |
+| gbdt | 41 | 0.0061 | 0.0135 | 0.0026 |
+| none | 24 | 0.0065 | 0.0058 | 0.0027 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 432 | 0.0045 | 0.0042 | 0.0025 |
+| token_choice | 68 | 0.0069 | 0.0112 | 0.0027 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 45 | 0.0047 | 0.0036 | 0.0026 |
+| gate_only | 52 | 0.0049 | 0.0043 | 0.0026 |
+| em | 403 | 0.0049 | 0.0061 | 0.0025 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 30 | 0.0036 | 0.0015 | 0.0026 |
+| random | 92 | 0.0036 | 0.0033 | 0.0025 |
+| tree_hierarchical | 17 | 0.0036 | 0.0021 | 0.0026 |
+| kmeans_features | 106 | 0.0037 | 0.0031 | 0.0025 |
+| gmm | 234 | 0.0055 | 0.0049 | 0.0025 |
+| gmm_features | 21 | 0.0115 | 0.0187 | 0.0026 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 82 | 0.0041 | 0.0035 | 0.0026 |
+| markov | 389 | 0.0047 | 0.0043 | 0.0025 |
+| none | 29 | 0.0094 | 0.0162 | 0.0026 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 453 | 0.0047 | 0.0044 | 0.0025 |
+| True | 47 | 0.0065 | 0.0128 | 0.0030 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.0046 | 0.0043 | 0.0025 |
+| True | 32 | 0.0080 | 0.0154 | 0.0027 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0056 | — | — | 0.0048 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0031 | 0.0035 | 0.0051 | 0.0077 | **Q1** [None, 0.0091] |
+| `mixture_warmup_iters` | 0.0043 | 0.0039 | 0.0050 | 0.0058 | **Q2** [15.0, 16.0] |
+| `mixture_balance_factor` | 0.0050 | — | 0.0044 | 0.0051 | **Q3** [8.0, 9.0] |
+| `learning_rate` | 0.0055 | 0.0049 | 0.0045 | 0.0045 | **Q3** [0.2595, 0.2812] |
+| `num_leaves` | 0.0042 | 0.0048 | 0.0055 | 0.0049 | **Q1** [None, 12.0] |
+| `max_depth` | 0.0056 | 0.0052 | — | 0.0046 | **Q4** [5.0, ∞) |
+| `min_data_in_leaf` | 0.0046 | 0.0046 | 0.0060 | 0.0044 | **Q4** [27.0, ∞) |
+
+#### E. Slice plot
+
+![elevators@s42/moe](slice_elevators@s42_moe.png)
+
+
+---
+
+## elevators@s43  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00237** (winner retrained in 0.27s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0027
+- train: median 0.168s/fold, mean 0.176s, p90 0.252s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.636 |
+| `learning_rate` | 0.137 |
+| `feature_fraction` | 0.053 |
+| `min_data_in_leaf` | 0.053 |
+| `num_leaves` | 0.050 |
+| `max_depth` | 0.036 |
+| `bagging_freq` | 0.021 |
+| `extra_trees` | 0.008 |
+| `lambda_l2` | 0.005 |
+| `bagging_fraction` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 0.0028 | 0.0004 | 0.0026 |
+| True | 31 | 0.0035 | 0.0006 | 0.0028 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0031 | 0.0028 | 0.0028 | 0.0028 | **Q2** [0.1346, 0.1677] |
+| `num_leaves` | 0.0028 | 0.0028 | 0.0028 | 0.0030 | **Q1** [None, 19.0] |
+| `max_depth` | 0.0030 | 0.0028 | 0.0028 | 0.0028 | **Q2** [7.0, 8.0] |
+| `min_data_in_leaf` | 0.0027 | 0.0028 | 0.0028 | 0.0030 | **Q1** [None, 13.0] |
+| `lambda_l1` | 0.0028 | 0.0028 | 0.0028 | 0.0030 | **Q1** [None, 0.0] |
+| `lambda_l2` | 0.0029 | 0.0028 | 0.0028 | 0.0029 | **Q2** [0.0035, 0.0406] |
+| `feature_fraction` | 0.0030 | 0.0027 | 0.0028 | 0.0027 | **Q2** [0.901, 0.9313] |
+| `bagging_fraction` | 0.0029 | 0.0028 | 0.0029 | 0.0028 | **Q2** [0.8597, 0.9186] |
+
+#### E. Slice plot
+
+![elevators@s43/naive-lightgbm](slice_elevators@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00228** (winner retrained in 3.29s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0026, p10: 0.0026
+- train: median 1.543s/fold, mean 2.213s, p90 3.320s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.396 |
+| `mixture_load_balance_alpha` | 0.084 |
+| `min_data_in_leaf` | 0.081 |
+| `mixture_routing_mode` | 0.077 |
+| `mixture_gate_type` | 0.060 |
+| `mixture_expert_dropout_rate` | 0.047 |
+| `bagging_fraction` | 0.044 |
+| `feature_fraction` | 0.042 |
+| `max_depth` | 0.028 |
+| `num_leaves` | 0.025 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 0.0036 (n=416) | token_choice | Δ +0.0021 | p=1.91e-04 |
+| `mixture_e_step_mode` | **loss_only** | 0.0035 (n=384) | em | Δ +0.0015 | p=6.42e-03 |
+| `mixture_r_smoothing` | **markov** | 0.0035 (n=361) | ema | Δ +0.0012 | p=5.34e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 367 | 0.0036 | 0.0032 | 0.0026 |
+| gbdt | 105 | 0.0042 | 0.0035 | 0.0026 |
+| none | 28 | 0.0065 | 0.0055 | 0.0027 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 416 | 0.0036 | 0.0030 | 0.0026 |
+| token_choice | 84 | 0.0057 | 0.0048 | 0.0026 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 384 | 0.0035 | 0.0029 | 0.0026 |
+| em | 83 | 0.0050 | 0.0046 | 0.0026 |
+| gate_only | 33 | 0.0056 | 0.0051 | 0.0026 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 327 | 0.0032 | 0.0025 | 0.0026 |
+| tree_hierarchical | 50 | 0.0038 | 0.0035 | 0.0026 |
+| random | 29 | 0.0040 | 0.0027 | 0.0026 |
+| gmm | 47 | 0.0056 | 0.0050 | 0.0027 |
+| kmeans_features | 30 | 0.0060 | 0.0048 | 0.0028 |
+| gmm_features | 17 | 0.0101 | 0.0045 | 0.0030 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 361 | 0.0035 | 0.0029 | 0.0026 |
+| ema | 113 | 0.0047 | 0.0040 | 0.0026 |
+| none | 26 | 0.0065 | 0.0062 | 0.0026 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.0038 | 0.0035 | 0.0026 |
+| True | 32 | 0.0052 | 0.0040 | 0.0029 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 0.0037 | 0.0033 | 0.0026 |
+| True | 31 | 0.0065 | 0.0053 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0066 | — | — | 0.0037 | **Q4** [5.0, ∞) |
+| `mixture_diversity_lambda` | 0.0035 | 0.0034 | 0.0033 | 0.0055 | **Q3** [0.0602, 0.0815] |
+| `mixture_warmup_iters` | 0.0040 | 0.0035 | 0.0036 | 0.0044 | **Q2** [21.0, 28.0] |
+| `mixture_balance_factor` | — | 0.0035 | 0.0040 | 0.0046 | **Q2** [2.0, 3.0] |
+| `learning_rate` | 0.0049 | 0.0036 | 0.0037 | 0.0034 | **Q4** [0.2809, ∞) |
+| `num_leaves` | 0.0039 | 0.0032 | 0.0040 | 0.0045 | **Q2** [26.0, 36.0] |
+| `max_depth` | 0.0035 | — | 0.0034 | 0.0049 | **Q3** [5.0, 6.0] |
+| `min_data_in_leaf` | 0.0036 | 0.0035 | 0.0033 | 0.0053 | **Q3** [16.0, 22.25] |
+
+#### E. Slice plot
+
+![elevators@s43/moe](slice_elevators@s43_moe.png)
+
+
+---
+
+## elevators@s44  (search X=[8000, 18], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.00225** (winner retrained in 0.30s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0027, p10: 0.0026
+- train: median 0.168s/fold, mean 0.162s, p90 0.217s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.696 |
+| `num_leaves` | 0.084 |
+| `learning_rate` | 0.066 |
+| `feature_fraction` | 0.054 |
+| `max_depth` | 0.037 |
+| `extra_trees` | 0.024 |
+| `min_data_in_leaf` | 0.019 |
+| `bagging_freq` | 0.009 |
+| `bagging_fraction` | 0.007 |
+| `lambda_l2` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 0.0028 | 0.0004 | 0.0026 |
+| True | 31 | 0.0034 | 0.0007 | 0.0029 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.0030 | 0.0027 | 0.0027 | 0.0028 | **Q2** [0.1225, 0.1411] |
+| `num_leaves` | 0.0028 | 0.0029 | 0.0030 | 0.0027 | **Q4** [121.0, ∞) |
+| `max_depth` | 0.0031 | 0.0028 | — | 0.0028 | **Q2** [6.0, 8.0] |
+| `min_data_in_leaf` | 0.0029 | 0.0028 | 0.0027 | 0.0029 | **Q3** [19.0, 23.0] |
+| `lambda_l1` | 0.0029 | 0.0027 | 0.0027 | 0.0030 | **Q2** [0.0, 0.0001] |
+| `lambda_l2` | 0.0028 | 0.0027 | 0.0028 | 0.0030 | **Q2** [0.0, 0.0001] |
+| `feature_fraction` | 0.0031 | 0.0028 | 0.0027 | 0.0027 | **Q3** [0.9642, 0.9813] |
+| `bagging_fraction` | 0.0030 | 0.0028 | 0.0028 | 0.0027 | **Q4** [0.9802, ∞) |
+
+#### E. Slice plot
+
+![elevators@s44/naive-lightgbm](slice_elevators@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.00228** (winner retrained in 1.82s, cv score of winner: 0.0026)
+- cv best RMSE: 0.0026, median: 0.0028, p10: 0.0027
+- train: median 1.422s/fold, mean 1.904s, p90 3.024s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l1` | 0.211 |
+| `num_leaves` | 0.171 |
+| `mixture_hard_m_step` | 0.126 |
+| `mixture_gate_type` | 0.096 |
+| `bagging_fraction` | 0.059 |
+| `mixture_diversity_lambda` | 0.046 |
+| `mixture_warmup_iters` | 0.044 |
+| `min_data_in_leaf` | 0.038 |
+| `mixture_balance_factor` | 0.034 |
+| `mixture_expert_dropout_rate` | 0.034 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 0.0036 (n=449) | leaf_reuse | Δ +0.0030 | p=1.39e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 449 | 0.0036 | 0.0026 | 0.0026 |
+| leaf_reuse | 25 | 0.0066 | 0.0041 | 0.0032 |
+| none | 26 | 0.0069 | 0.0039 | 0.0034 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 468 | 0.0038 | 0.0029 | 0.0026 |
+| expert_choice | 32 | 0.0050 | 0.0033 | 0.0031 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 446 | 0.0038 | 0.0028 | 0.0026 |
+| em | 29 | 0.0050 | 0.0035 | 0.0027 |
+| gate_only | 25 | 0.0054 | 0.0045 | 0.0029 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 366 | 0.0036 | 0.0026 | 0.0026 |
+| uniform | 25 | 0.0036 | 0.0016 | 0.0027 |
+| tree_hierarchical | 18 | 0.0048 | 0.0025 | 0.0028 |
+| kmeans_features | 31 | 0.0049 | 0.0037 | 0.0027 |
+| gmm_features | 41 | 0.0051 | 0.0044 | 0.0027 |
+| random | 19 | 0.0054 | 0.0045 | 0.0027 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 248 | 0.0038 | 0.0025 | 0.0026 |
+| markov | 230 | 0.0039 | 0.0031 | 0.0027 |
+| ema | 22 | 0.0057 | 0.0048 | 0.0029 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 468 | 0.0035 | 0.0023 | 0.0026 |
+| False | 32 | 0.0095 | 0.0051 | 0.0033 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.0038 | 0.0029 | 0.0026 |
+| True | 32 | 0.0056 | 0.0037 | 0.0030 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.0047 | — | — | 0.0038 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 0.0038 | 0.0041 | 0.0040 | 0.0038 | **Q1** [None, 0.2282] |
+| `mixture_warmup_iters` | 0.0035 | 0.0036 | 0.0038 | 0.0047 | **Q1** [None, 12.0] |
+| `mixture_balance_factor` | 0.0045 | 0.0033 | 0.0045 | 0.0039 | **Q2** [6.0, 8.0] |
+| `learning_rate` | 0.0045 | 0.0033 | 0.0037 | 0.0042 | **Q2** [0.1352, 0.1598] |
+| `num_leaves` | 0.0038 | 0.0037 | 0.0039 | 0.0042 | **Q2** [48.0, 61.5] |
+| `max_depth` | 0.0045 | — | 0.0038 | 0.0036 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.0041 | 0.0036 | 0.0036 | 0.0043 | **Q2** [27.0, 35.0] |
+
+#### E. Slice plot
+
+![elevators@s44/moe](slice_elevators@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| elevators@s43 | `mixture_routing_mode` | **expert_choice** | +0.0021 | 1.91e-04 |
+| elevators@s43 | `mixture_e_step_mode` | **loss_only** | +0.0015 | 6.42e-03 |
+| elevators@s43 | `mixture_r_smoothing` | **markov** | +0.0012 | 5.34e-03 |
+| elevators@s44 | `mixture_gate_type` | **gbdt** | +0.0030 | 1.39e-03 |

--- a/bench_results/wide_v081/ds_elevators_summary.json
+++ b/bench_results/wide_v081/ds_elevators_summary.json
@@ -1,0 +1,2814 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "elevators"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "elevators": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.0024475993016704815,
+      "cv_best": 0.0026330350603668623,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1456
+     },
+     "43": {
+      "holdout_rmse": 0.0023725818749864825,
+      "cv_best": 0.0026345957506207288,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2656
+     },
+     "44": {
+      "holdout_rmse": 0.0022522156769412497,
+      "cv_best": 0.0026095344168599716,
+      "crash_rate": 0.0,
+      "retrain_s": 0.302
+     }
+    },
+    "holdout_mean": 0.002357,
+    "holdout_std": 8e-05,
+    "cv_best_mean": 0.002626
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.002332174749497785,
+      "cv_best": 0.0025074428035895893,
+      "crash_rate": 0.0,
+      "retrain_s": 1.1636
+     },
+     "43": {
+      "holdout_rmse": 0.002282636949713543,
+      "cv_best": 0.002558666676868325,
+      "crash_rate": 0.0,
+      "retrain_s": 3.2949
+     },
+     "44": {
+      "holdout_rmse": 0.0022816275966050085,
+      "cv_best": 0.0026173620714983765,
+      "crash_rate": 0.0,
+      "retrain_s": 1.8181
+     }
+    },
+    "holdout_mean": 0.002299,
+    "holdout_std": 2.4e-05,
+    "cv_best_mean": 0.002561
+   }
+  }
+ },
+ "runs": {
+  "elevators@s42": {
+   "dataset": "elevators",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021624375,
+    "std": 0.006717125937435966
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0026330350603668623,
+    "rmse_p10": 0.0026660054740031904,
+    "rmse_median": 0.0027043089024425693,
+    "train_s_median": 0.11839508041739463,
+    "train_s_mean": 0.12373249301686882,
+    "train_s_p90": 0.16340486451983452,
+    "best_params": {
+     "learning_rate": 0.23778434791157024,
+     "num_leaves": 15,
+     "max_depth": 6,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 0.00034200225716518373,
+     "lambda_l2": 0.00011876407186465006,
+     "feature_fraction": 0.9097243991797953,
+     "bagging_fraction": 0.9406735868207391,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6833,
+     "learning_rate": 0.1105,
+     "min_data_in_leaf": 0.1067,
+     "num_leaves": 0.0582,
+     "feature_fraction": 0.0148,
+     "bagging_fraction": 0.0144,
+     "bagging_freq": 0.007,
+     "max_depth": 0.0038,
+     "extra_trees": 0.0012,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 0.0034,
+        "std": 0.0008,
+        "min": 0.0028
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.0028,
+        "std": 0.0005,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1884
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.1884,
+        0.2162
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.2162,
+        0.2435
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.2435,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 100,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        17.0
+       ],
+       "n": 142,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        23.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 380,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        14.0
+       ],
+       "n": 112,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        19.0
+       ],
+       "n": 137,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0015
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0015,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0016
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0016,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.91
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.91,
+        0.9324
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9324,
+        0.9539
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9539,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9364
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.9364,
+        0.9573
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9573,
+        0.9734
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9734,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 323.9,
+    "holdout": {
+     "holdout_rmse": 0.0024475993016704815,
+     "retrain_s": 0.1456,
+     "predict_s": 0.0016,
+     "cv_rmse_of_winner": 0.0026330350603668623
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0025074428035895893,
+    "rmse_p10": 0.0025584360765747733,
+    "rmse_median": 0.002786544134281862,
+    "train_s_median": 1.2158188268542292,
+    "train_s_mean": 1.313625917647034,
+    "train_s_p90": 2.1119015744328498,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.2991478433717599,
+     "num_leaves": 11,
+     "max_depth": 5,
+     "min_data_in_leaf": 24,
+     "lambda_l1": 4.124181776082348e-07,
+     "lambda_l2": 0.0006973445534869658,
+     "feature_fraction": 0.9829956560474248,
+     "bagging_fraction": 0.8184066316841041,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 15,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.20735694985699266,
+     "mixture_diversity_lambda": 0.0003272669592325533,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 1.0980131148884782e-05,
+     "mixture_load_balance_alpha": 0.37812530543987727,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 9,
+     "mixture_gate_learning_rate": 0.01367730697563204,
+     "mixture_gate_lambda_l2": 0.002479129791288414,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_entropy_lambda": 0.022922365864790243,
+     "mixture_gate_temperature_init": 2.630209376963363,
+     "gate_temp_final_ratio": 0.9229645529880549,
+     "mixture_gate_retrain_interval": 25,
+     "mixture_expert_capacity_factor": 0.8563550816853055,
+     "mixture_expert_choice_boost": 6.00210729133649,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.3902909909189194,
+     "mixture_refit_every_n": 10,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 2,
+     "mixture_regrow_mode": "delete"
+    },
+    "importance": {
+     "mixture_diversity_lambda": 0.3135,
+     "max_depth": 0.09,
+     "bagging_fraction": 0.0857,
+     "feature_fraction": 0.0798,
+     "mixture_expert_dropout_rate": 0.0637,
+     "mixture_balance_factor": 0.0623,
+     "lambda_l1": 0.0553,
+     "mixture_init": 0.0488,
+     "num_leaves": 0.0388,
+     "learning_rate": 0.034,
+     "mixture_load_balance_alpha": 0.0258,
+     "min_data_in_leaf": 0.0225,
+     "mixture_r_smoothing": 0.0202,
+     "mixture_warmup_iters": 0.0186,
+     "mixture_hard_m_step": 0.0146,
+     "extra_trees": 0.0101,
+     "lambda_l2": 0.009,
+     "mixture_e_step_mode": 0.002,
+     "mixture_gate_type": 0.0017,
+     "mixture_routing_mode": 0.0016,
+     "mixture_num_experts": 0.0009,
+     "mixture_refit_leaves": 0.0007,
+     "bagging_freq": 0.0005
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 435,
+        "mean": 0.0047,
+        "std": 0.0043,
+        "min": 0.0025
+       },
+       "none": {
+        "n": 24,
+        "mean": 0.0065,
+        "std": 0.0058,
+        "min": 0.0027
+       },
+       "gbdt": {
+        "n": 41,
+        "mean": 0.0061,
+        "std": 0.0135,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0014,
+       "p_value": 0.516891,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 68,
+        "mean": 0.0069,
+        "std": 0.0112,
+        "min": 0.0027
+       },
+       "expert_choice": {
+        "n": 432,
+        "mean": 0.0045,
+        "std": 0.0042,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0024,
+       "p_value": 0.094965,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 52,
+        "mean": 0.0049,
+        "std": 0.0043,
+        "min": 0.0026
+       },
+       "loss_only": {
+        "n": 45,
+        "mean": 0.0047,
+        "std": 0.0036,
+        "min": 0.0026
+       },
+       "em": {
+        "n": 403,
+        "mean": 0.0049,
+        "std": 0.0061,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0002,
+       "p_value": 0.760312,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 30,
+        "mean": 0.0036,
+        "std": 0.0015,
+        "min": 0.0026
+       },
+       "gmm": {
+        "n": 234,
+        "mean": 0.0055,
+        "std": 0.0049,
+        "min": 0.0025
+       },
+       "random": {
+        "n": 92,
+        "mean": 0.0036,
+        "std": 0.0033,
+        "min": 0.0025
+       },
+       "gmm_features": {
+        "n": 21,
+        "mean": 0.0115,
+        "std": 0.0187,
+        "min": 0.0026
+       },
+       "kmeans_features": {
+        "n": 106,
+        "mean": 0.0037,
+        "std": 0.0031,
+        "min": 0.0025
+       },
+       "tree_hierarchical": {
+        "n": 17,
+        "mean": 0.0036,
+        "std": 0.0021,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0,
+       "p_value": 0.995717,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 82,
+        "mean": 0.0041,
+        "std": 0.0035,
+        "min": 0.0026
+       },
+       "markov": {
+        "n": 389,
+        "mean": 0.0047,
+        "std": 0.0043,
+        "min": 0.0025
+       },
+       "none": {
+        "n": 29,
+        "mean": 0.0094,
+        "std": 0.0162,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0006,
+       "p_value": 0.159833,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 453,
+        "mean": 0.0047,
+        "std": 0.0044,
+        "min": 0.0025
+       },
+       "True": {
+        "n": 47,
+        "mean": 0.0065,
+        "std": 0.0128,
+        "min": 0.003
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0018,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 0.008,
+        "std": 0.0154,
+        "min": 0.0027
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.0046,
+        "std": 0.0043,
+        "min": 0.0025
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0034,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 20,
+       "mean_rmse": 0.0056
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 480,
+       "mean_rmse": 0.0048
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0091
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.0091,
+        0.019
+       ],
+       "n": 125,
+       "mean_rmse": 0.0035
+      },
+      "Q3": {
+       "range": [
+        0.019,
+        0.042
+       ],
+       "n": 125,
+       "mean_rmse": 0.0051
+      },
+      "Q4": {
+       "range": [
+        0.042,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0077
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.0043
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        16.0
+       ],
+       "n": 73,
+       "mean_rmse": 0.0039
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        19.0
+       ],
+       "n": 177,
+       "mean_rmse": 0.005
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 0.0058
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.005
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 147,
+       "mean_rmse": 0.0044
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 234,
+       "mean_rmse": 0.0051
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2189
+       ],
+       "n": 125,
+       "mean_rmse": 0.0055
+      },
+      "Q2": {
+       "range": [
+        0.2189,
+        0.2595
+       ],
+       "n": 125,
+       "mean_rmse": 0.0049
+      },
+      "Q3": {
+       "range": [
+        0.2595,
+        0.2812
+       ],
+       "n": 125,
+       "mean_rmse": 0.0045
+      },
+      "Q4": {
+       "range": [
+        0.2812,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0045
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.0042
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        16.0
+       ],
+       "n": 128,
+       "mean_rmse": 0.0048
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        27.25
+       ],
+       "n": 126,
+       "mean_rmse": 0.0055
+      },
+      "Q4": {
+       "range": [
+        27.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0049
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 25,
+       "mean_rmse": 0.0056
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 167,
+       "mean_rmse": 0.0052
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 308,
+       "mean_rmse": 0.0046
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.0046
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        22.5
+       ],
+       "n": 129,
+       "mean_rmse": 0.0046
+      },
+      "Q3": {
+       "range": [
+        22.5,
+        27.0
+       ],
+       "n": 112,
+       "mean_rmse": 0.006
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 138,
+       "mean_rmse": 0.0044
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 3350.6,
+    "holdout": {
+     "holdout_rmse": 0.002332174749497785,
+     "retrain_s": 1.1636,
+     "predict_s": 0.015,
+     "cv_rmse_of_winner": 0.0025074428035895893
+    }
+   }
+  },
+  "elevators@s43": {
+   "dataset": "elevators",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021558875,
+    "std": 0.0066420654720030425
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0026345957506207288,
+    "rmse_p10": 0.0026688985345302394,
+    "rmse_median": 0.0027034203162979494,
+    "train_s_median": 0.16798558589071033,
+    "train_s_mean": 0.1758707529626787,
+    "train_s_p90": 0.25189324080944064,
+    "best_params": {
+     "learning_rate": 0.1533620458041891,
+     "num_leaves": 30,
+     "max_depth": 9,
+     "min_data_in_leaf": 15,
+     "lambda_l1": 1.325427723629823e-05,
+     "lambda_l2": 0.017892659736986172,
+     "feature_fraction": 0.9314529033362612,
+     "bagging_fraction": 0.8654519404125345,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.6362,
+     "learning_rate": 0.1365,
+     "feature_fraction": 0.053,
+     "min_data_in_leaf": 0.0526,
+     "num_leaves": 0.0503,
+     "max_depth": 0.0357,
+     "bagging_freq": 0.0212,
+     "extra_trees": 0.0082,
+     "lambda_l2": 0.0054,
+     "bagging_fraction": 0.0008
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 0.0035,
+        "std": 0.0006,
+        "min": 0.0028
+       },
+       "False": {
+        "n": 469,
+        "mean": 0.0028,
+        "std": 0.0004,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0007,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1346
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.1346,
+        0.1677
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.1677,
+        0.2012
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.2012,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        29.0
+       ],
+       "n": 132,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        29.0,
+        41.25
+       ],
+       "n": 128,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        41.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 110,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 38,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 129,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 223,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 110,
+       "mean_rmse": 0.0027
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        19.0
+       ],
+       "n": 126,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        23.0
+       ],
+       "n": 113,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 151,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0008
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0008,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0035
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0035,
+        0.0406
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.0406,
+        0.3108
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.3108,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.901
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.901,
+        0.9313
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.9313,
+        0.9638
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9638,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8597
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.8597,
+        0.9186
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9186,
+        0.9559
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q4": {
+       "range": [
+        0.9559,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 455.3,
+    "holdout": {
+     "holdout_rmse": 0.0023725818749864825,
+     "retrain_s": 0.2656,
+     "predict_s": 0.0024,
+     "cv_rmse_of_winner": 0.0026345957506207288
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.002558666676868325,
+    "rmse_p10": 0.002584141190656232,
+    "rmse_median": 0.0026469899663331582,
+    "train_s_median": 1.5432951033115387,
+    "train_s_mean": 2.213499851770699,
+    "train_s_p90": 3.3202924778312446,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 5,
+     "learning_rate": 0.28010187939961523,
+     "num_leaves": 19,
+     "max_depth": 5,
+     "min_data_in_leaf": 14,
+     "lambda_l1": 1.3233185855583248e-07,
+     "lambda_l2": 0.576959544757758,
+     "feature_fraction": 0.7925039727230807,
+     "bagging_fraction": 0.7252168990226279,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 30,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.5055683941683132,
+     "mixture_diversity_lambda": 0.053458871756013465,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.041889518062387554,
+     "mixture_load_balance_alpha": 0.09739142660160041,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 60,
+     "mixture_gate_learning_rate": 0.1795153082156272,
+     "mixture_gate_lambda_l2": 0.016055764639398364,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.030355370452330752,
+     "mixture_gate_temperature_init": 2.598384499229178,
+     "gate_temp_final_ratio": 0.7483843608413057,
+     "mixture_gate_retrain_interval": 25,
+     "mixture_expert_capacity_factor": 0.9028044197187048,
+     "mixture_expert_choice_boost": 20.817960230301647,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.3981970345876766,
+     "mixture_elbo_drop_threshold": 0.00792737948612352,
+     "mixture_elbo_plateau_threshold": 0.004073508534640109,
+     "mixture_elbo_window": 19,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.3958,
+     "mixture_load_balance_alpha": 0.0836,
+     "min_data_in_leaf": 0.081,
+     "mixture_routing_mode": 0.0773,
+     "mixture_gate_type": 0.0603,
+     "mixture_expert_dropout_rate": 0.0466,
+     "bagging_fraction": 0.0437,
+     "feature_fraction": 0.0423,
+     "max_depth": 0.0282,
+     "num_leaves": 0.0253,
+     "extra_trees": 0.0248,
+     "mixture_refit_leaves": 0.0228,
+     "mixture_warmup_iters": 0.0188,
+     "mixture_init": 0.0122,
+     "mixture_r_smoothing": 0.0077,
+     "mixture_hard_m_step": 0.0061,
+     "mixture_diversity_lambda": 0.0061,
+     "bagging_freq": 0.0059,
+     "learning_rate": 0.0051,
+     "mixture_e_step_mode": 0.0035,
+     "mixture_balance_factor": 0.0018,
+     "mixture_num_experts": 0.001,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 105,
+        "mean": 0.0042,
+        "std": 0.0035,
+        "min": 0.0026
+       },
+       "leaf_reuse": {
+        "n": 367,
+        "mean": 0.0036,
+        "std": 0.0032,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 28,
+        "mean": 0.0065,
+        "std": 0.0055,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0006,
+       "p_value": 0.127036,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 416,
+        "mean": 0.0036,
+        "std": 0.003,
+        "min": 0.0026
+       },
+       "token_choice": {
+        "n": 84,
+        "mean": 0.0057,
+        "std": 0.0048,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0021,
+       "p_value": 0.000191,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 384,
+        "mean": 0.0035,
+        "std": 0.0029,
+        "min": 0.0026
+       },
+       "gate_only": {
+        "n": 33,
+        "mean": 0.0056,
+        "std": 0.0051,
+        "min": 0.0026
+       },
+       "em": {
+        "n": 83,
+        "mean": 0.005,
+        "std": 0.0046,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0015,
+       "p_value": 0.006421,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 47,
+        "mean": 0.0056,
+        "std": 0.005,
+        "min": 0.0027
+       },
+       "tree_hierarchical": {
+        "n": 50,
+        "mean": 0.0038,
+        "std": 0.0035,
+        "min": 0.0026
+       },
+       "uniform": {
+        "n": 327,
+        "mean": 0.0032,
+        "std": 0.0025,
+        "min": 0.0026
+       },
+       "kmeans_features": {
+        "n": 30,
+        "mean": 0.006,
+        "std": 0.0048,
+        "min": 0.0028
+       },
+       "gmm_features": {
+        "n": 17,
+        "mean": 0.0101,
+        "std": 0.0045,
+        "min": 0.003
+       },
+       "random": {
+        "n": 29,
+        "mean": 0.004,
+        "std": 0.0027,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.0006,
+       "p_value": 0.233907,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 113,
+        "mean": 0.0047,
+        "std": 0.004,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 26,
+        "mean": 0.0065,
+        "std": 0.0062,
+        "min": 0.0026
+       },
+       "markov": {
+        "n": 361,
+        "mean": 0.0035,
+        "std": 0.0029,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.0012,
+       "p_value": 0.005345,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 0.0038,
+        "std": 0.0035,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 32,
+        "mean": 0.0052,
+        "std": 0.004,
+        "min": 0.0029
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0014,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 469,
+        "mean": 0.0037,
+        "std": 0.0033,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 31,
+        "mean": 0.0065,
+        "std": 0.0053,
+        "min": 0.0029
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0028,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 30,
+       "mean_rmse": 0.0066
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 470,
+       "mean_rmse": 0.0037
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0414
+       ],
+       "n": 125,
+       "mean_rmse": 0.0035
+      },
+      "Q2": {
+       "range": [
+        0.0414,
+        0.0602
+       ],
+       "n": 125,
+       "mean_rmse": 0.0034
+      },
+      "Q3": {
+       "range": [
+        0.0602,
+        0.0815
+       ],
+       "n": 125,
+       "mean_rmse": 0.0033
+      },
+      "Q4": {
+       "range": [
+        0.0815,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0055
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        21.0
+       ],
+       "n": 116,
+       "mean_rmse": 0.004
+      },
+      "Q2": {
+       "range": [
+        21.0,
+        28.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.0035
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        31.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.0036
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 145,
+       "mean_rmse": 0.0044
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 231,
+       "mean_rmse": 0.0035
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        6.0
+       ],
+       "n": 141,
+       "mean_rmse": 0.004
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 0.0046
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2051
+       ],
+       "n": 125,
+       "mean_rmse": 0.0049
+      },
+      "Q2": {
+       "range": [
+        0.2051,
+        0.2574
+       ],
+       "n": 125,
+       "mean_rmse": 0.0036
+      },
+      "Q3": {
+       "range": [
+        0.2574,
+        0.2809
+       ],
+       "n": 125,
+       "mean_rmse": 0.0037
+      },
+      "Q4": {
+       "range": [
+        0.2809,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0034
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.0039
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        36.0
+       ],
+       "n": 127,
+       "mean_rmse": 0.0032
+      },
+      "Q3": {
+       "range": [
+        36.0,
+        77.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.004
+      },
+      "Q4": {
+       "range": [
+        77.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 0.0045
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 39,
+       "mean_rmse": 0.0035
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 304,
+       "mean_rmse": 0.0034
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 157,
+       "mean_rmse": 0.0049
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 104,
+       "mean_rmse": 0.0036
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        16.0
+       ],
+       "n": 142,
+       "mean_rmse": 0.0035
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        22.25
+       ],
+       "n": 129,
+       "mean_rmse": 0.0033
+      },
+      "Q4": {
+       "range": [
+        22.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0053
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 5621.6,
+    "holdout": {
+     "holdout_rmse": 0.002282636949713543,
+     "retrain_s": 3.2949,
+     "predict_s": 0.0525,
+     "cv_rmse_of_winner": 0.002558666676868325
+    }
+   }
+  },
+  "elevators@s44": {
+   "dataset": "elevators",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    18
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 0.021623500000000004,
+    "std": 0.006704326793198554
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0026095344168599716,
+    "rmse_p10": 0.0026444457830730296,
+    "rmse_median": 0.0026798531465084784,
+    "train_s_median": 0.1679738122969866,
+    "train_s_mean": 0.16150144207030537,
+    "train_s_p90": 0.21706607408821585,
+    "best_params": {
+     "learning_rate": 0.1453975953322897,
+     "num_leaves": 55,
+     "max_depth": 10,
+     "min_data_in_leaf": 19,
+     "lambda_l1": 1.4270501386969404e-06,
+     "lambda_l2": 1.0266015473265148e-08,
+     "feature_fraction": 0.9893436333268968,
+     "bagging_fraction": 0.9586701961151974,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "lambda_l1": 0.696,
+     "num_leaves": 0.0841,
+     "learning_rate": 0.0661,
+     "feature_fraction": 0.0536,
+     "max_depth": 0.0375,
+     "extra_trees": 0.0238,
+     "min_data_in_leaf": 0.0186,
+     "bagging_freq": 0.0088,
+     "bagging_fraction": 0.0074,
+     "lambda_l2": 0.0043
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 469,
+        "mean": 0.0028,
+        "std": 0.0004,
+        "min": 0.0026
+       },
+       "True": {
+        "n": 31,
+        "mean": 0.0034,
+        "std": 0.0007,
+        "min": 0.0029
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1225
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.1225,
+        0.1411
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.1411,
+        0.1604
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.1604,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        57.0
+       ],
+       "n": 122,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        57.0,
+        84.5
+       ],
+       "n": 128,
+       "mean_rmse": 0.0029
+      },
+      "Q3": {
+       "range": [
+        84.5,
+        121.0
+       ],
+       "n": 117,
+       "mean_rmse": 0.003
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 52,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 130,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 318,
+       "mean_rmse": 0.0028
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 112,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        19.0
+       ],
+       "n": 109,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        23.0
+       ],
+       "n": 135,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 144,
+       "mean_rmse": 0.0029
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0029
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.0003,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0039
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.0039,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9162
+       ],
+       "n": 125,
+       "mean_rmse": 0.0031
+      },
+      "Q2": {
+       "range": [
+        0.9162,
+        0.9642
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.9642,
+        0.9813
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "Q4": {
+       "range": [
+        0.9813,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9329
+       ],
+       "n": 125,
+       "mean_rmse": 0.003
+      },
+      "Q2": {
+       "range": [
+        0.9329,
+        0.964
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q3": {
+       "range": [
+        0.964,
+        0.9802
+       ],
+       "n": 125,
+       "mean_rmse": 0.0028
+      },
+      "Q4": {
+       "range": [
+        0.9802,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0027
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 418.1,
+    "holdout": {
+     "holdout_rmse": 0.0022522156769412497,
+     "retrain_s": 0.302,
+     "predict_s": 0.0029,
+     "cv_rmse_of_winner": 0.0026095344168599716
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.0026173620714983765,
+    "rmse_p10": 0.002663546028722627,
+    "rmse_median": 0.0028076868436357197,
+    "train_s_median": 1.4219900058582424,
+    "train_s_mean": 1.9041946660310027,
+    "train_s_p90": 3.0238784370943903,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.16171288621874116,
+     "num_leaves": 28,
+     "max_depth": 12,
+     "min_data_in_leaf": 39,
+     "lambda_l1": 1.934357568071438e-06,
+     "lambda_l2": 0.009629262910326255,
+     "feature_fraction": 0.9887705532595464,
+     "bagging_fraction": 0.9776062734410433,
+     "bagging_freq": 0,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 9,
+     "mixture_balance_factor": 7,
+     "mixture_diversity_lambda": 0.3886659726677989,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.17261939879511046,
+     "mixture_load_balance_alpha": 0.1939378350386121,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 23,
+     "mixture_gate_learning_rate": 0.10889323032555845,
+     "mixture_gate_lambda_l2": 2.600628653104896,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_entropy_lambda": 0.0339411078248817,
+     "mixture_gate_temperature_init": 0.8913827470716814,
+     "gate_temp_final_ratio": 0.5582733603613148,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "lambda_l1": 0.2113,
+     "num_leaves": 0.1705,
+     "mixture_hard_m_step": 0.1258,
+     "mixture_gate_type": 0.0955,
+     "bagging_fraction": 0.0587,
+     "mixture_diversity_lambda": 0.0461,
+     "mixture_warmup_iters": 0.0437,
+     "min_data_in_leaf": 0.0381,
+     "mixture_balance_factor": 0.0342,
+     "mixture_expert_dropout_rate": 0.034,
+     "mixture_routing_mode": 0.023,
+     "learning_rate": 0.0224,
+     "lambda_l2": 0.0201,
+     "mixture_refit_leaves": 0.0172,
+     "mixture_load_balance_alpha": 0.0172,
+     "max_depth": 0.015,
+     "feature_fraction": 0.0129,
+     "mixture_e_step_mode": 0.0065,
+     "mixture_init": 0.0037,
+     "mixture_num_experts": 0.0023,
+     "bagging_freq": 0.0008,
+     "mixture_r_smoothing": 0.0008,
+     "extra_trees": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 449,
+        "mean": 0.0036,
+        "std": 0.0026,
+        "min": 0.0026
+       },
+       "none": {
+        "n": 26,
+        "mean": 0.0069,
+        "std": 0.0039,
+        "min": 0.0034
+       },
+       "leaf_reuse": {
+        "n": 25,
+        "mean": 0.0066,
+        "std": 0.0041,
+        "min": 0.0032
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.003,
+       "p_value": 0.001392,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 468,
+        "mean": 0.0038,
+        "std": 0.0029,
+        "min": 0.0026
+       },
+       "expert_choice": {
+        "n": 32,
+        "mean": 0.005,
+        "std": 0.0033,
+        "min": 0.0031
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0012,
+       "p_value": 0.055696,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 29,
+        "mean": 0.005,
+        "std": 0.0035,
+        "min": 0.0027
+       },
+       "gate_only": {
+        "n": 25,
+        "mean": 0.0054,
+        "std": 0.0045,
+        "min": 0.0029
+       },
+       "loss_only": {
+        "n": 446,
+        "mean": 0.0038,
+        "std": 0.0028,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0012,
+       "p_value": 0.072129,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 31,
+        "mean": 0.0049,
+        "std": 0.0037,
+        "min": 0.0027
+       },
+       "tree_hierarchical": {
+        "n": 18,
+        "mean": 0.0048,
+        "std": 0.0025,
+        "min": 0.0028
+       },
+       "random": {
+        "n": 19,
+        "mean": 0.0054,
+        "std": 0.0045,
+        "min": 0.0027
+       },
+       "gmm": {
+        "n": 366,
+        "mean": 0.0036,
+        "std": 0.0026,
+        "min": 0.0026
+       },
+       "gmm_features": {
+        "n": 41,
+        "mean": 0.0051,
+        "std": 0.0044,
+        "min": 0.0027
+       },
+       "uniform": {
+        "n": 25,
+        "mean": 0.0036,
+        "std": 0.0016,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "uniform",
+       "delta_mean": 0.0,
+       "p_value": 0.997011,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 248,
+        "mean": 0.0038,
+        "std": 0.0025,
+        "min": 0.0026
+       },
+       "ema": {
+        "n": 22,
+        "mean": 0.0057,
+        "std": 0.0048,
+        "min": 0.0029
+       },
+       "markov": {
+        "n": 230,
+        "mean": 0.0039,
+        "std": 0.0031,
+        "min": 0.0027
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.0001,
+       "p_value": 0.594773,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 32,
+        "mean": 0.0095,
+        "std": 0.0051,
+        "min": 0.0033
+       },
+       "True": {
+        "n": 468,
+        "mean": 0.0035,
+        "std": 0.0023,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 0.0056,
+        "std": 0.0037,
+        "min": 0.003
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.0038,
+        "std": 0.0029,
+        "min": 0.0026
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0018,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 47,
+       "mean_rmse": 0.0047
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 453,
+       "mean_rmse": 0.0038
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2282
+       ],
+       "n": 125,
+       "mean_rmse": 0.0038
+      },
+      "Q2": {
+       "range": [
+        0.2282,
+        0.303
+       ],
+       "n": 125,
+       "mean_rmse": 0.0041
+      },
+      "Q3": {
+       "range": [
+        0.303,
+        0.3973
+       ],
+       "n": 125,
+       "mean_rmse": 0.004
+      },
+      "Q4": {
+       "range": [
+        0.3973,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0038
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 93,
+       "mean_rmse": 0.0035
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        14.5
+       ],
+       "n": 157,
+       "mean_rmse": 0.0036
+      },
+      "Q3": {
+       "range": [
+        14.5,
+        18.0
+       ],
+       "n": 113,
+       "mean_rmse": 0.0038
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 0.0047
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 96,
+       "mean_rmse": 0.0045
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 143,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 66,
+       "mean_rmse": 0.0045
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 195,
+       "mean_rmse": 0.0039
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1352
+       ],
+       "n": 125,
+       "mean_rmse": 0.0045
+      },
+      "Q2": {
+       "range": [
+        0.1352,
+        0.1598
+       ],
+       "n": 125,
+       "mean_rmse": 0.0033
+      },
+      "Q3": {
+       "range": [
+        0.1598,
+        0.1849
+       ],
+       "n": 125,
+       "mean_rmse": 0.0037
+      },
+      "Q4": {
+       "range": [
+        0.1849,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.0042
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        48.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.0038
+      },
+      "Q2": {
+       "range": [
+        48.0,
+        61.5
+       ],
+       "n": 126,
+       "mean_rmse": 0.0037
+      },
+      "Q3": {
+       "range": [
+        61.5,
+        76.0
+       ],
+       "n": 116,
+       "mean_rmse": 0.0039
+      },
+      "Q4": {
+       "range": [
+        76.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 0.0042
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.0045
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 198,
+       "mean_rmse": 0.0038
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 182,
+       "mean_rmse": 0.0036
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        27.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.0041
+      },
+      "Q2": {
+       "range": [
+        27.0,
+        35.0
+       ],
+       "n": 126,
+       "mean_rmse": 0.0036
+      },
+      "Q3": {
+       "range": [
+        35.0,
+        40.0
+       ],
+       "n": 116,
+       "mean_rmse": 0.0036
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 143,
+       "mean_rmse": 0.0043
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 4837.0,
+    "holdout": {
+     "holdout_rmse": 0.0022816275966050085,
+     "retrain_s": 1.8181,
+     "predict_s": 0.0335,
+     "cv_rmse_of_winner": 0.0026173620714983765
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_fred_gdp_ensemble_report.md
+++ b/bench_results/wide_v081/ds_fred_gdp_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['fred_gdp'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| fred_gdp | naive-ensemble | **1.53029** ± 0.00814 | 0.80924 | 0.0% | 0.04 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| fred_gdp@s42 | naive-ensemble | 0.8126 | 0.8301 | 0.020 | 63 |
+| fred_gdp@s43 | naive-ensemble | 0.8044 | 0.8218 | 0.017 | 52 |
+| fred_gdp@s44 | naive-ensemble | 0.8107 | 0.8243 | 0.019 | 57 |
+
+
+
+---
+
+## fred_gdp@s42  (search X=[249, 12], holdout n=62)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.52662** (winner retrained in 0.05s, cv score of winner: 0.8126)
+- cv best RMSE: 0.8126, median: 0.8301, p10: 0.8206
+- train: median 0.020s/fold, mean 0.022s, p90 0.030s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.974 |
+| `extra_trees` | 0.005 |
+| `num_leaves` | 0.004 |
+| `bagging_fraction` | 0.004 |
+| `learning_rate` | 0.004 |
+| `max_depth` | 0.003 |
+| `bagging_freq` | 0.003 |
+| `feature_fraction` | 0.002 |
+| `n_models` | 0.001 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 467 | 0.8304 | 0.0100 | 0.8126 |
+| True | 33 | 0.8416 | 0.0107 | 0.8235 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8305 | 0.8287 | 0.8310 | 0.8345 | **Q2** [0.0218, 0.0259] |
+| `num_leaves` | 0.8332 | 0.8296 | 0.8292 | 0.8328 | **Q3** [75.0, 82.0] |
+| `max_depth` | 0.8354 | 0.8309 | — | 0.8302 | **Q4** [10.0, ∞) |
+| `min_data_in_leaf` | 0.8354 | 0.8274 | 0.8275 | 0.8350 | **Q2** [23.0, 26.5] |
+| `lambda_l1` | 0.8346 | 0.8304 | 0.8288 | 0.8309 | **Q3** [0.0006, 0.0042] |
+| `lambda_l2` | 0.8351 | 0.8301 | 0.8292 | 0.8303 | **Q3** [0.09, 0.4816] |
+| `feature_fraction` | 0.8330 | 0.8305 | 0.8291 | 0.8322 | **Q3** [0.8576, 0.8882] |
+| `bagging_fraction` | 0.8349 | 0.8333 | 0.8289 | 0.8275 | **Q4** [0.9907, ∞) |
+
+#### E. Slice plot
+
+![fred_gdp@s42/naive-ensemble](slice_fred_gdp@s42_naive-ensemble.png)
+
+
+---
+
+## fred_gdp@s43  (search X=[249, 12], holdout n=62)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.54157** (winner retrained in 0.03s, cv score of winner: 0.8044)
+- cv best RMSE: 0.8044, median: 0.8218, p10: 0.8117
+- train: median 0.017s/fold, mean 0.018s, p90 0.024s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.975 |
+| `bagging_fraction` | 0.009 |
+| `learning_rate` | 0.007 |
+| `feature_fraction` | 0.002 |
+| `extra_trees` | 0.002 |
+| `num_leaves` | 0.002 |
+| `max_depth` | 0.002 |
+| `bagging_freq` | 0.001 |
+| `n_models` | 0.000 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 454 | 0.8236 | 0.0124 | 0.8044 |
+| True | 46 | 0.8348 | 0.0133 | 0.8095 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8345 | 0.8236 | 0.8208 | 0.8196 | **Q4** [0.2793, ∞) |
+| `num_leaves` | 0.8313 | 0.8234 | 0.8211 | 0.8230 | **Q3** [79.0, 88.0] |
+| `max_depth` | — | — | 0.8217 | 0.8311 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 0.8315 | 0.8200 | 0.8186 | 0.8300 | **Q3** [24.0, 28.0] |
+| `lambda_l1` | 0.8323 | 0.8237 | 0.8199 | 0.8227 | **Q3** [0.1003, 0.2288] |
+| `lambda_l2` | 0.8262 | 0.8224 | 0.8205 | 0.8295 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 0.8303 | 0.8207 | 0.8210 | 0.8267 | **Q2** [0.8615, 0.8826] |
+| `bagging_fraction` | 0.8318 | 0.8215 | 0.8221 | 0.8231 | **Q2** [0.9007, 0.9421] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/naive-ensemble](slice_fred_gdp@s43_naive-ensemble.png)
+
+
+---
+
+## fred_gdp@s44  (search X=[249, 12], holdout n=62)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.52267** (winner retrained in 0.04s, cv score of winner: 0.8107)
+- cv best RMSE: 0.8107, median: 0.8243, p10: 0.8145
+- train: median 0.019s/fold, mean 0.019s, p90 0.024s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.943 |
+| `learning_rate` | 0.016 |
+| `extra_trees` | 0.014 |
+| `bagging_fraction` | 0.007 |
+| `num_leaves` | 0.006 |
+| `feature_fraction` | 0.004 |
+| `max_depth` | 0.003 |
+| `bagging_freq` | 0.003 |
+| `lambda_l2` | 0.003 |
+| `n_models` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 451 | 0.8245 | 0.0095 | 0.8107 |
+| True | 49 | 0.8367 | 0.0122 | 0.8166 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8272 | 0.8225 | 0.8255 | 0.8276 | **Q2** [0.0522, 0.0624] |
+| `num_leaves` | 0.8256 | 0.8248 | 0.8270 | 0.8255 | **Q2** [34.0, 62.0] |
+| `max_depth` | 0.8333 | 0.8258 | 0.8232 | 0.8254 | **Q3** [10.0, 11.0] |
+| `min_data_in_leaf` | 0.8303 | 0.8209 | 0.8201 | 0.8309 | **Q3** [26.0, 29.0] |
+| `lambda_l1` | 0.8285 | 0.8219 | 0.8251 | 0.8274 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 0.8297 | 0.8240 | 0.8226 | 0.8267 | **Q3** [0.2789, 0.7212] |
+| `feature_fraction` | 0.8308 | 0.8229 | 0.8228 | 0.8264 | **Q3** [0.7157, 0.7414] |
+| `bagging_fraction` | 0.8252 | 0.8236 | 0.8260 | 0.8281 | **Q2** [0.714, 0.7585] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/naive-ensemble](slice_fred_gdp@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_fred_gdp_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_fred_gdp_ensemble_summary.json
@@ -1,0 +1,1169 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "fred_gdp"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "fred_gdp": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.5266215395924305,
+      "cv_best": 0.8126040723854102,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0547
+     },
+     "43": {
+      "holdout_rmse": 1.541573367898821,
+      "cv_best": 0.804377846648159,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0252
+     },
+     "44": {
+      "holdout_rmse": 1.5226687380857817,
+      "cv_best": 0.8107286066108289,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0421
+     }
+    },
+    "holdout_mean": 1.530288,
+    "holdout_std": 0.008142,
+    "cv_best_mean": 0.809237
+   }
+  }
+ },
+ "runs": {
+  "fred_gdp@s42": {
+   "dataset": "fred_gdp",
+   "seed": 42,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.8126040723854102,
+    "rmse_p10": 0.820639361351407,
+    "rmse_median": 0.8301064287071134,
+    "train_s_median": 0.020218051783740518,
+    "train_s_mean": 0.021804431676119562,
+    "train_s_p90": 0.030417890585958958,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.024710744914856298,
+     "num_leaves": 77,
+     "max_depth": 10,
+     "min_data_in_leaf": 26,
+     "lambda_l1": 0.002018353059079531,
+     "lambda_l2": 0.07758396694939401,
+     "feature_fraction": 0.843942282118951,
+     "bagging_fraction": 0.9998070695202163,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9737,
+     "extra_trees": 0.0048,
+     "num_leaves": 0.0045,
+     "bagging_fraction": 0.0045,
+     "learning_rate": 0.0038,
+     "max_depth": 0.003,
+     "bagging_freq": 0.0027,
+     "feature_fraction": 0.002,
+     "n_models": 0.0005,
+     "lambda_l2": 0.0005,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 467,
+        "mean": 0.8304,
+        "std": 0.01,
+        "min": 0.8126
+       },
+       "True": {
+        "n": 33,
+        "mean": 0.8416,
+        "std": 0.0107,
+        "min": 0.8235
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0112,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0218
+       ],
+       "n": 125,
+       "mean_rmse": 0.8305
+      },
+      "Q2": {
+       "range": [
+        0.0218,
+        0.0259
+       ],
+       "n": 125,
+       "mean_rmse": 0.8287
+      },
+      "Q3": {
+       "range": [
+        0.0259,
+        0.069
+       ],
+       "n": 125,
+       "mean_rmse": 0.831
+      },
+      "Q4": {
+       "range": [
+        0.069,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8345
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        70.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.8332
+      },
+      "Q2": {
+       "range": [
+        70.0,
+        75.0
+       ],
+       "n": 109,
+       "mean_rmse": 0.8296
+      },
+      "Q3": {
+       "range": [
+        75.0,
+        82.0
+       ],
+       "n": 143,
+       "mean_rmse": 0.8292
+      },
+      "Q4": {
+       "range": [
+        82.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 0.8328
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 83,
+       "mean_rmse": 0.8354
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 85,
+       "mean_rmse": 0.8309
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 332,
+       "mean_rmse": 0.8302
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 107,
+       "mean_rmse": 0.8354
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        26.5
+       ],
+       "n": 143,
+       "mean_rmse": 0.8274
+      },
+      "Q3": {
+       "range": [
+        26.5,
+        30.0
+       ],
+       "n": 116,
+       "mean_rmse": 0.8275
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 0.835
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.8346
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0006
+       ],
+       "n": 125,
+       "mean_rmse": 0.8304
+      },
+      "Q3": {
+       "range": [
+        0.0006,
+        0.0042
+       ],
+       "n": 125,
+       "mean_rmse": 0.8288
+      },
+      "Q4": {
+       "range": [
+        0.0042,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0037
+       ],
+       "n": 125,
+       "mean_rmse": 0.8351
+      },
+      "Q2": {
+       "range": [
+        0.0037,
+        0.09
+       ],
+       "n": 125,
+       "mean_rmse": 0.8301
+      },
+      "Q3": {
+       "range": [
+        0.09,
+        0.4816
+       ],
+       "n": 125,
+       "mean_rmse": 0.8292
+      },
+      "Q4": {
+       "range": [
+        0.4816,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8303
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8115
+       ],
+       "n": 125,
+       "mean_rmse": 0.833
+      },
+      "Q2": {
+       "range": [
+        0.8115,
+        0.8576
+       ],
+       "n": 125,
+       "mean_rmse": 0.8305
+      },
+      "Q3": {
+       "range": [
+        0.8576,
+        0.8882
+       ],
+       "n": 125,
+       "mean_rmse": 0.8291
+      },
+      "Q4": {
+       "range": [
+        0.8882,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8322
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7422
+       ],
+       "n": 125,
+       "mean_rmse": 0.8349
+      },
+      "Q2": {
+       "range": [
+        0.7422,
+        0.9766
+       ],
+       "n": 125,
+       "mean_rmse": 0.8333
+      },
+      "Q3": {
+       "range": [
+        0.9766,
+        0.9907
+       ],
+       "n": 125,
+       "mean_rmse": 0.8289
+      },
+      "Q4": {
+       "range": [
+        0.9907,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8275
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 62.7,
+    "holdout": {
+     "holdout_rmse": 1.5266215395924305,
+     "retrain_s": 0.0547,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.8126040723854102
+    }
+   }
+  },
+  "fred_gdp@s43": {
+   "dataset": "fred_gdp",
+   "seed": 43,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.804377846648159,
+    "rmse_p10": 0.8116958550487958,
+    "rmse_median": 0.821771697986724,
+    "train_s_median": 0.01668488159775734,
+    "train_s_mean": 0.017645035914331676,
+    "train_s_p90": 0.023663719296455384,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.2992397064020535,
+     "num_leaves": 80,
+     "max_depth": 3,
+     "min_data_in_leaf": 24,
+     "lambda_l1": 0.21805402994363113,
+     "lambda_l2": 7.360670235142667e-06,
+     "feature_fraction": 0.8665986492542982,
+     "bagging_fraction": 0.9445252943012582,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9753,
+     "bagging_fraction": 0.0087,
+     "learning_rate": 0.0075,
+     "feature_fraction": 0.0023,
+     "extra_trees": 0.002,
+     "num_leaves": 0.0016,
+     "max_depth": 0.0015,
+     "bagging_freq": 0.0006,
+     "n_models": 0.0003,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 454,
+        "mean": 0.8236,
+        "std": 0.0124,
+        "min": 0.8044
+       },
+       "True": {
+        "n": 46,
+        "mean": 0.8348,
+        "std": 0.0133,
+        "min": 0.8095
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0112,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2032
+       ],
+       "n": 125,
+       "mean_rmse": 0.8345
+      },
+      "Q2": {
+       "range": [
+        0.2032,
+        0.2561
+       ],
+       "n": 125,
+       "mean_rmse": 0.8236
+      },
+      "Q3": {
+       "range": [
+        0.2561,
+        0.2793
+       ],
+       "n": 125,
+       "mean_rmse": 0.8208
+      },
+      "Q4": {
+       "range": [
+        0.2793,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8196
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        69.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.8313
+      },
+      "Q2": {
+       "range": [
+        69.0,
+        79.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.8234
+      },
+      "Q3": {
+       "range": [
+        79.0,
+        88.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8211
+      },
+      "Q4": {
+       "range": [
+        88.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 0.823
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 345,
+       "mean_rmse": 0.8217
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 155,
+       "mean_rmse": 0.8311
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        21.0
+       ],
+       "n": 101,
+       "mean_rmse": 0.8315
+      },
+      "Q2": {
+       "range": [
+        21.0,
+        24.0
+       ],
+       "n": 111,
+       "mean_rmse": 0.82
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        28.0
+       ],
+       "n": 151,
+       "mean_rmse": 0.8186
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 0.83
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0029
+       ],
+       "n": 125,
+       "mean_rmse": 0.8323
+      },
+      "Q2": {
+       "range": [
+        0.0029,
+        0.1003
+       ],
+       "n": 125,
+       "mean_rmse": 0.8237
+      },
+      "Q3": {
+       "range": [
+        0.1003,
+        0.2288
+       ],
+       "n": 125,
+       "mean_rmse": 0.8199
+      },
+      "Q4": {
+       "range": [
+        0.2288,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8227
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8262
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8224
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8205
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8295
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8615
+       ],
+       "n": 125,
+       "mean_rmse": 0.8303
+      },
+      "Q2": {
+       "range": [
+        0.8615,
+        0.8826
+       ],
+       "n": 125,
+       "mean_rmse": 0.8207
+      },
+      "Q3": {
+       "range": [
+        0.8826,
+        0.9054
+       ],
+       "n": 125,
+       "mean_rmse": 0.821
+      },
+      "Q4": {
+       "range": [
+        0.9054,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8267
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9007
+       ],
+       "n": 125,
+       "mean_rmse": 0.8318
+      },
+      "Q2": {
+       "range": [
+        0.9007,
+        0.9421
+       ],
+       "n": 125,
+       "mean_rmse": 0.8215
+      },
+      "Q3": {
+       "range": [
+        0.9421,
+        0.9643
+       ],
+       "n": 125,
+       "mean_rmse": 0.8221
+      },
+      "Q4": {
+       "range": [
+        0.9643,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8231
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 52.4,
+    "holdout": {
+     "holdout_rmse": 1.541573367898821,
+     "retrain_s": 0.0252,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.804377846648159
+    }
+   }
+  },
+  "fred_gdp@s44": {
+   "dataset": "fred_gdp",
+   "seed": 44,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.8107286066108289,
+    "rmse_p10": 0.8144960406806647,
+    "rmse_median": 0.8243343887370592,
+    "train_s_median": 0.01891703177243471,
+    "train_s_mean": 0.01943382037729025,
+    "train_s_p90": 0.024214194864034658,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.07078454134797987,
+     "num_leaves": 62,
+     "max_depth": 10,
+     "min_data_in_leaf": 26,
+     "lambda_l1": 3.0110556963446593e-05,
+     "lambda_l2": 0.4623884698368178,
+     "feature_fraction": 0.6905888212338589,
+     "bagging_fraction": 0.7450100045441581,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9434,
+     "learning_rate": 0.016,
+     "extra_trees": 0.0139,
+     "bagging_fraction": 0.0069,
+     "num_leaves": 0.0063,
+     "feature_fraction": 0.0037,
+     "max_depth": 0.0032,
+     "bagging_freq": 0.003,
+     "lambda_l2": 0.0026,
+     "n_models": 0.0009,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 49,
+        "mean": 0.8367,
+        "std": 0.0122,
+        "min": 0.8166
+       },
+       "False": {
+        "n": 451,
+        "mean": 0.8245,
+        "std": 0.0095,
+        "min": 0.8107
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0122,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0522
+       ],
+       "n": 125,
+       "mean_rmse": 0.8272
+      },
+      "Q2": {
+       "range": [
+        0.0522,
+        0.0624
+       ],
+       "n": 125,
+       "mean_rmse": 0.8225
+      },
+      "Q3": {
+       "range": [
+        0.0624,
+        0.1345
+       ],
+       "n": 125,
+       "mean_rmse": 0.8255
+      },
+      "Q4": {
+       "range": [
+        0.1345,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8276
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        34.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.8256
+      },
+      "Q2": {
+       "range": [
+        34.0,
+        62.0
+       ],
+       "n": 129,
+       "mean_rmse": 0.8248
+      },
+      "Q3": {
+       "range": [
+        62.0,
+        111.25
+       ],
+       "n": 126,
+       "mean_rmse": 0.827
+      },
+      "Q4": {
+       "range": [
+        111.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8255
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 76,
+       "mean_rmse": 0.8333
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 50,
+       "mean_rmse": 0.8258
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 213,
+       "mean_rmse": 0.8232
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 161,
+       "mean_rmse": 0.8254
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.8303
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        26.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.8209
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        29.0
+       ],
+       "n": 127,
+       "mean_rmse": 0.8201
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 141,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8285
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8219
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.8251
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8274
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0326
+       ],
+       "n": 125,
+       "mean_rmse": 0.8297
+      },
+      "Q2": {
+       "range": [
+        0.0326,
+        0.2789
+       ],
+       "n": 125,
+       "mean_rmse": 0.824
+      },
+      "Q3": {
+       "range": [
+        0.2789,
+        0.7212
+       ],
+       "n": 125,
+       "mean_rmse": 0.8226
+      },
+      "Q4": {
+       "range": [
+        0.7212,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8267
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6902
+       ],
+       "n": 125,
+       "mean_rmse": 0.8308
+      },
+      "Q2": {
+       "range": [
+        0.6902,
+        0.7157
+       ],
+       "n": 125,
+       "mean_rmse": 0.8229
+      },
+      "Q3": {
+       "range": [
+        0.7157,
+        0.7414
+       ],
+       "n": 125,
+       "mean_rmse": 0.8228
+      },
+      "Q4": {
+       "range": [
+        0.7414,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8264
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.714
+       ],
+       "n": 125,
+       "mean_rmse": 0.8252
+      },
+      "Q2": {
+       "range": [
+        0.714,
+        0.7585
+       ],
+       "n": 125,
+       "mean_rmse": 0.8236
+      },
+      "Q3": {
+       "range": [
+        0.7585,
+        0.8531
+       ],
+       "n": 125,
+       "mean_rmse": 0.826
+      },
+      "Q4": {
+       "range": [
+        0.8531,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8281
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 57.3,
+    "holdout": {
+     "holdout_rmse": 1.5226687380857817,
+     "retrain_s": 0.0421,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.8107286066108289
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_fred_gdp_report.md
+++ b/bench_results/wide_v081/ds_fred_gdp_report.md
@@ -1,0 +1,527 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['fred_gdp'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| fred_gdp | naive-lightgbm | **1.54205** ± 0.02596 | 0.80281 | 0.0% | 0.03 |
+| fred_gdp | moe | **1.49429** ± 0.00982 | 0.81894 | 0.0% | 2.17 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| fred_gdp@s42 | naive-lightgbm | 0.8046 | 0.8281 | 0.014 | 47 |
+| fred_gdp@s42 | moe | 0.8089 | 0.8703 | 1.079 | 2385 |
+| fred_gdp@s43 | naive-lightgbm | 0.7992 | 0.8210 | 0.018 | 57 |
+| fred_gdp@s43 | moe | 0.8206 | 0.8563 | 0.160 | 1284 |
+| fred_gdp@s44 | naive-lightgbm | 0.8046 | 0.8285 | 0.015 | 53 |
+| fred_gdp@s44 | moe | 0.8274 | 0.9190 | 0.383 | 1299 |
+
+
+
+---
+
+## fred_gdp@s42  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.50612** (winner retrained in 0.02s, cv score of winner: 0.8046)
+- cv best RMSE: 0.8046, median: 0.8281, p10: 0.8114
+- train: median 0.014s/fold, mean 0.014s, p90 0.018s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.937 |
+| `bagging_freq` | 0.016 |
+| `bagging_fraction` | 0.011 |
+| `feature_fraction` | 0.011 |
+| `learning_rate` | 0.011 |
+| `max_depth` | 0.008 |
+| `num_leaves` | 0.006 |
+| `extra_trees` | 0.001 |
+| `lambda_l1` | 0.000 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.8283 | 0.0163 | 0.8046 |
+| True | 32 | 0.8383 | 0.0102 | 0.8200 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8345 | 0.8271 | 0.8245 | 0.8296 | **Q3** [0.2547, 0.2776] |
+| `num_leaves` | 0.8253 | 0.8257 | 0.8297 | 0.8342 | **Q1** [None, 11.0] |
+| `max_depth` | 0.8307 | 0.8262 | 0.8318 | 0.8299 | **Q2** [5.0, 6.0] |
+| `min_data_in_leaf` | 0.8402 | 0.8213 | 0.8230 | 0.8311 | **Q2** [19.0, 22.0] |
+| `lambda_l1` | 0.8320 | 0.8271 | 0.8272 | 0.8293 | **Q2** [0.0, 0.0001] |
+| `lambda_l2` | 0.8279 | 0.8277 | 0.8265 | 0.8336 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 0.8353 | 0.8268 | 0.8256 | 0.8280 | **Q3** [0.8907, 0.916] |
+| `bagging_fraction` | 0.8302 | 0.8278 | 0.8254 | 0.8322 | **Q3** [0.8248, 0.8635] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/naive-lightgbm](slice_fred_gdp@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.49056** (winner retrained in 1.73s, cv score of winner: 0.8089)
+- cv best RMSE: 0.8089, median: 0.8703, p10: 0.8302
+- train: median 1.079s/fold, mean 0.943s, p90 1.748s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.962 |
+| `mixture_balance_factor` | 0.009 |
+| `extra_trees` | 0.007 |
+| `mixture_load_balance_alpha` | 0.004 |
+| `mixture_e_step_mode` | 0.004 |
+| `lambda_l2` | 0.003 |
+| `mixture_init` | 0.002 |
+| `max_depth` | 0.001 |
+| `bagging_fraction` | 0.001 |
+| `feature_fraction` | 0.001 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **none** | 0.8830 (n=372) | leaf_reuse | Δ +0.0500 | p=0.00e+00 |
+| `mixture_routing_mode` | **token_choice** | 0.8858 (n=330) | expert_choice | Δ +0.0326 | p=2.00e-06 |
+| `mixture_e_step_mode` | **gate_only** | 0.8867 (n=381) | loss_only | Δ +0.0407 | p=6.90e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 372 | 0.8830 | 0.0645 | 0.8089 |
+| leaf_reuse | 95 | 0.9330 | 0.0841 | 0.8385 |
+| gbdt | 33 | 0.9490 | 0.0635 | 0.8531 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 330 | 0.8858 | 0.0704 | 0.8089 |
+| expert_choice | 170 | 0.9184 | 0.0720 | 0.8270 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 381 | 0.8867 | 0.0681 | 0.8089 |
+| loss_only | 62 | 0.9274 | 0.0705 | 0.8241 |
+| em | 57 | 0.9315 | 0.0835 | 0.8322 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 286 | 0.8817 | 0.0666 | 0.8089 |
+| gmm_features | 52 | 0.9016 | 0.0751 | 0.8160 |
+| uniform | 101 | 0.9082 | 0.0699 | 0.8270 |
+| random | 18 | 0.9357 | 0.0745 | 0.8415 |
+| tree_hierarchical | 18 | 0.9486 | 0.0840 | 0.8358 |
+| kmeans_features | 25 | 0.9487 | 0.0725 | 0.8455 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 300 | 0.8860 | 0.0688 | 0.8089 |
+| none | 142 | 0.8999 | 0.0706 | 0.8270 |
+| ema | 58 | 0.9457 | 0.0760 | 0.8375 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 422 | 0.8901 | 0.0715 | 0.8089 |
+| True | 78 | 0.9333 | 0.0678 | 0.8445 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 459 | 0.8909 | 0.0703 | 0.8089 |
+| False | 41 | 0.9631 | 0.0649 | 0.8457 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9437 | — | 0.8909 | 0.9060 | **Q3** [3.0, 5.0] |
+| `mixture_diversity_lambda` | 0.8725 | 0.8809 | 0.9028 | 0.9312 | **Q1** [None, 0.0224] |
+| `mixture_warmup_iters` | 0.9149 | 0.8815 | 0.8898 | 0.9015 | **Q2** [37.0, 40.0] |
+| `mixture_balance_factor` | 0.8973 | 0.8905 | 0.8901 | 0.9077 | **Q3** [5.0, 8.0] |
+| `learning_rate` | 0.9169 | 0.8878 | 0.8881 | 0.8946 | **Q2** [0.0581, 0.1033] |
+| `num_leaves` | 0.8985 | 0.8900 | 0.8795 | 0.9171 | **Q3** [37.0, 43.0] |
+| `max_depth` | 0.8971 | 0.8976 | 0.8758 | 0.9258 | **Q3** [6.0, 7.0] |
+| `min_data_in_leaf` | 0.8586 | 0.8522 | 0.8890 | 0.9843 | **Q2** [7.0, 9.5] |
+
+#### E. Slice plot
+
+![fred_gdp@s42/moe](slice_fred_gdp@s42_moe.png)
+
+
+---
+
+## fred_gdp@s43  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.55352** (winner retrained in 0.04s, cv score of winner: 0.7992)
+- cv best RMSE: 0.7992, median: 0.8210, p10: 0.8083
+- train: median 0.018s/fold, mean 0.018s, p90 0.024s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.891 |
+| `bagging_fraction` | 0.078 |
+| `learning_rate` | 0.010 |
+| `bagging_freq` | 0.006 |
+| `feature_fraction` | 0.005 |
+| `num_leaves` | 0.005 |
+| `max_depth` | 0.002 |
+| `lambda_l1` | 0.002 |
+| `extra_trees` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.8272 | 0.0245 | 0.7992 |
+| True | 32 | 0.8436 | 0.0255 | 0.8129 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8323 | 0.8261 | 0.8259 | 0.8286 | **Q3** [0.2488, 0.274] |
+| `num_leaves` | 0.8262 | 0.8299 | 0.8285 | 0.8281 | **Q1** [None, 16.0] |
+| `max_depth` | 0.8344 | 0.8316 | 0.8301 | 0.8229 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.8551 | 0.8172 | 0.8191 | 0.8289 | **Q2** [14.0, 18.0] |
+| `lambda_l1` | 0.8282 | 0.8229 | 0.8276 | 0.8342 | **Q2** [0.0001, 0.0005] |
+| `lambda_l2` | 0.8345 | 0.8257 | 0.8249 | 0.8278 | **Q3** [0.0001, 0.0004] |
+| `feature_fraction` | 0.8314 | 0.8236 | 0.8256 | 0.8323 | **Q2** [0.6343, 0.6578] |
+| `bagging_fraction` | 0.8373 | 0.8242 | 0.8225 | 0.8288 | **Q3** [0.8706, 0.8901] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/naive-lightgbm](slice_fred_gdp@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.50774** (winner retrained in 3.83s, cv score of winner: 0.8206)
+- cv best RMSE: 0.8206, median: 0.8563, p10: 0.8322
+- train: median 0.160s/fold, mean 0.502s, p90 1.863s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.922 |
+| `extra_trees` | 0.022 |
+| `lambda_l1` | 0.009 |
+| `mixture_balance_factor` | 0.006 |
+| `lambda_l2` | 0.005 |
+| `mixture_warmup_iters` | 0.005 |
+| `mixture_init` | 0.005 |
+| `mixture_load_balance_alpha` | 0.005 |
+| `num_leaves` | 0.004 |
+| `mixture_e_step_mode` | 0.003 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **none** | 0.8801 (n=363) | gbdt | Δ +0.0243 | p=4.98e-03 |
+| `mixture_routing_mode` | **expert_choice** | 0.8808 (n=418) | token_choice | Δ +0.0552 | p=0.00e+00 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 363 | 0.8801 | 0.0645 | 0.8228 |
+| gbdt | 114 | 0.9044 | 0.0830 | 0.8206 |
+| leaf_reuse | 23 | 0.9722 | 0.0950 | 0.8567 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 418 | 0.8808 | 0.0682 | 0.8206 |
+| token_choice | 82 | 0.9360 | 0.0829 | 0.8345 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 274 | 0.8837 | 0.0697 | 0.8228 |
+| em | 162 | 0.8859 | 0.0729 | 0.8206 |
+| gate_only | 64 | 0.9263 | 0.0818 | 0.8413 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm_features | 290 | 0.8774 | 0.0651 | 0.8228 |
+| kmeans_features | 81 | 0.8846 | 0.0563 | 0.8302 |
+| gmm | 42 | 0.9040 | 0.0923 | 0.8206 |
+| uniform | 17 | 0.9100 | 0.0598 | 0.8526 |
+| random | 53 | 0.9281 | 0.0879 | 0.8377 |
+| tree_hierarchical | 17 | 0.9543 | 0.1065 | 0.8402 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 360 | 0.8806 | 0.0662 | 0.8228 |
+| markov | 75 | 0.9014 | 0.0842 | 0.8206 |
+| none | 65 | 0.9279 | 0.0851 | 0.8413 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 423 | 0.8804 | 0.0672 | 0.8206 |
+| False | 77 | 0.9417 | 0.0854 | 0.8372 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 469 | 0.8857 | 0.0707 | 0.8206 |
+| False | 31 | 0.9535 | 0.0880 | 0.8539 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9082 | — | — | 0.8854 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 0.8935 | 0.8875 | 0.9020 | 0.8764 | **Q4** [0.4764, ∞) |
+| `mixture_warmup_iters` | 0.9143 | 0.8864 | 0.8845 | 0.8801 | **Q4** [39.0, ∞) |
+| `mixture_balance_factor` | 0.8797 | 0.8829 | 0.8788 | 0.9192 | **Q3** [6.0, 7.0] |
+| `learning_rate` | 0.9088 | 0.8786 | 0.8751 | 0.8971 | **Q3** [0.0582, 0.075] |
+| `num_leaves` | 0.9079 | 0.8708 | 0.8880 | 0.8928 | **Q2** [38.0, 47.0] |
+| `max_depth` | 0.9212 | 0.8908 | — | 0.8777 | **Q4** [10.0, ∞) |
+| `min_data_in_leaf` | 0.8672 | 0.8437 | 0.8551 | 0.9803 | **Q2** [7.0, 9.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s43/moe](slice_fred_gdp@s43_moe.png)
+
+
+---
+
+## fred_gdp@s44  (search X=[249, 12], holdout n=62)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.56652** (winner retrained in 0.02s, cv score of winner: 0.8046)
+- cv best RMSE: 0.8046, median: 0.8285, p10: 0.8183
+- train: median 0.015s/fold, mean 0.017s, p90 0.024s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.868 |
+| `learning_rate` | 0.056 |
+| `bagging_fraction` | 0.036 |
+| `lambda_l2` | 0.009 |
+| `num_leaves` | 0.006 |
+| `max_depth` | 0.006 |
+| `bagging_freq` | 0.006 |
+| `extra_trees` | 0.006 |
+| `feature_fraction` | 0.005 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 463 | 0.8302 | 0.0120 | 0.8046 |
+| True | 37 | 0.8362 | 0.0092 | 0.8218 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.8333 | 0.8306 | 0.8288 | 0.8297 | **Q3** [0.0718, 0.1145] |
+| `num_leaves` | 0.8291 | 0.8288 | 0.8320 | 0.8322 | **Q2** [20.0, 29.0] |
+| `max_depth` | 0.8292 | 0.8298 | — | 0.8315 | **Q1** [None, 6.0] |
+| `min_data_in_leaf` | 0.8362 | 0.8257 | 0.8258 | 0.8357 | **Q2** [14.0, 18.0] |
+| `lambda_l1` | 0.8329 | 0.8299 | 0.8287 | 0.8309 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.8348 | 0.8312 | 0.8293 | 0.8271 | **Q4** [0.8764, ∞) |
+| `feature_fraction` | 0.8371 | 0.8291 | 0.8287 | 0.8275 | **Q4** [0.9381, ∞) |
+| `bagging_fraction` | 0.8313 | 0.8281 | 0.8316 | 0.8315 | **Q2** [0.5466, 0.5716] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/naive-lightgbm](slice_fred_gdp@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.48456** (winner retrained in 0.95s, cv score of winner: 0.8274)
+- cv best RMSE: 0.8274, median: 0.9190, p10: 0.8459
+- train: median 0.383s/fold, mean 0.507s, p90 0.629s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.902 |
+| `lambda_l1` | 0.047 |
+| `extra_trees` | 0.015 |
+| `mixture_hard_m_step` | 0.012 |
+| `mixture_expert_dropout_rate` | 0.004 |
+| `mixture_init` | 0.004 |
+| `max_depth` | 0.003 |
+| `mixture_diversity_lambda` | 0.003 |
+| `mixture_e_step_mode` | 0.002 |
+| `mixture_balance_factor` | 0.002 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_e_step_mode` | **loss_only** | 0.9014 (n=358) | em | Δ +0.0285 | p=1.01e-04 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 448 | 0.9074 | 0.0596 | 0.8274 |
+| leaf_reuse | 26 | 0.9291 | 0.0780 | 0.8405 |
+| none | 26 | 0.9517 | 0.0965 | 0.8417 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 426 | 0.9101 | 0.0628 | 0.8274 |
+| expert_choice | 74 | 0.9153 | 0.0706 | 0.8342 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 358 | 0.9014 | 0.0569 | 0.8274 |
+| em | 114 | 0.9299 | 0.0689 | 0.8309 |
+| gate_only | 28 | 0.9543 | 0.0891 | 0.8493 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 364 | 0.9022 | 0.0580 | 0.8274 |
+| gmm | 24 | 0.9142 | 0.0400 | 0.8510 |
+| tree_hierarchical | 33 | 0.9248 | 0.0778 | 0.8315 |
+| gmm_features | 26 | 0.9296 | 0.0644 | 0.8382 |
+| random | 20 | 0.9432 | 0.0845 | 0.8513 |
+| kmeans_features | 33 | 0.9559 | 0.0787 | 0.8415 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 440 | 0.9068 | 0.0606 | 0.8274 |
+| ema | 35 | 0.9374 | 0.0793 | 0.8405 |
+| markov | 25 | 0.9444 | 0.0783 | 0.8432 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 465 | 0.9064 | 0.0615 | 0.8274 |
+| False | 35 | 0.9703 | 0.0671 | 0.8519 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 469 | 0.9063 | 0.0620 | 0.8274 |
+| False | 31 | 0.9800 | 0.0541 | 0.9018 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9255 | — | 0.9068 | 0.9118 | **Q3** [4.0, 5.0] |
+| `mixture_diversity_lambda` | 0.9174 | 0.9029 | 0.9051 | 0.9180 | **Q2** [0.1945, 0.2441] |
+| `mixture_warmup_iters` | 0.9095 | 0.9033 | 0.9207 | 0.9117 | **Q2** [23.0, 28.0] |
+| `mixture_balance_factor` | 0.9188 | — | 0.9062 | 0.9151 | **Q3** [4.0, 6.0] |
+| `learning_rate` | 0.9197 | 0.9012 | 0.9169 | 0.9056 | **Q2** [0.0422, 0.0516] |
+| `num_leaves` | 0.9156 | 0.8977 | 0.9061 | 0.9235 | **Q2** [69.0, 83.0] |
+| `max_depth` | 0.9046 | 0.9052 | — | 0.9164 | **Q1** [None, 7.0] |
+| `min_data_in_leaf` | 0.8806 | 0.8576 | 0.9357 | 0.9711 | **Q2** [9.0, 12.0] |
+
+#### E. Slice plot
+
+![fred_gdp@s44/moe](slice_fred_gdp@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| fred_gdp@s42 | `mixture_gate_type` | **none** | +0.0500 | 0.00e+00 |
+| fred_gdp@s42 | `mixture_routing_mode` | **token_choice** | +0.0326 | 2.00e-06 |
+| fred_gdp@s42 | `mixture_e_step_mode` | **gate_only** | +0.0407 | 6.90e-05 |
+| fred_gdp@s43 | `mixture_gate_type` | **none** | +0.0243 | 4.98e-03 |
+| fred_gdp@s43 | `mixture_routing_mode` | **expert_choice** | +0.0552 | 0.00e+00 |
+| fred_gdp@s44 | `mixture_e_step_mode` | **loss_only** | +0.0285 | 1.01e-04 |

--- a/bench_results/wide_v081/ds_fred_gdp_summary.json
+++ b/bench_results/wide_v081/ds_fred_gdp_summary.json
@@ -1,0 +1,2847 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "fred_gdp"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "fred_gdp": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.5061180109801906,
+      "cv_best": 0.8045707992835883,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0207
+     },
+     "43": {
+      "holdout_rmse": 1.5535232842937101,
+      "cv_best": 0.7992196638224648,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0438
+     },
+     "44": {
+      "holdout_rmse": 1.5665230673331163,
+      "cv_best": 0.8046364624953496,
+      "crash_rate": 0.0,
+      "retrain_s": 0.024
+     }
+    },
+    "holdout_mean": 1.542055,
+    "holdout_std": 0.025959,
+    "cv_best_mean": 0.802809
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.490560715128644,
+      "cv_best": 0.808854371718979,
+      "crash_rate": 0.0,
+      "retrain_s": 1.7294
+     },
+     "43": {
+      "holdout_rmse": 1.5077363818249705,
+      "cv_best": 0.8205589076945501,
+      "crash_rate": 0.0,
+      "retrain_s": 3.8287
+     },
+     "44": {
+      "holdout_rmse": 1.4845627611147816,
+      "cv_best": 0.8273949974767832,
+      "crash_rate": 0.0,
+      "retrain_s": 0.9489
+     }
+    },
+    "holdout_mean": 1.494287,
+    "holdout_std": 0.009821,
+    "cv_best_mean": 0.818936
+   }
+  }
+ },
+ "runs": {
+  "fred_gdp@s42": {
+   "dataset": "fred_gdp",
+   "seed": 42,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.8045707992835883,
+    "rmse_p10": 0.8113742099648885,
+    "rmse_median": 0.828097677061593,
+    "train_s_median": 0.0140413086861372,
+    "train_s_mean": 0.014393482962250709,
+    "train_s_p90": 0.018181265853345393,
+    "best_params": {
+     "learning_rate": 0.26813269780124827,
+     "num_leaves": 10,
+     "max_depth": 3,
+     "min_data_in_leaf": 22,
+     "lambda_l1": 0.12967856053900614,
+     "lambda_l2": 1.4845794718946206e-06,
+     "feature_fraction": 0.9131884423534623,
+     "bagging_fraction": 0.8419513249064565,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9369,
+     "bagging_freq": 0.0163,
+     "bagging_fraction": 0.0108,
+     "feature_fraction": 0.0106,
+     "learning_rate": 0.0105,
+     "max_depth": 0.0077,
+     "num_leaves": 0.0064,
+     "extra_trees": 0.0005,
+     "lambda_l1": 0.0003,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 0.8383,
+        "std": 0.0102,
+        "min": 0.82
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.8283,
+        "std": 0.0163,
+        "min": 0.8046
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.01,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2249
+       ],
+       "n": 125,
+       "mean_rmse": 0.8345
+      },
+      "Q2": {
+       "range": [
+        0.2249,
+        0.2547
+       ],
+       "n": 125,
+       "mean_rmse": 0.8271
+      },
+      "Q3": {
+       "range": [
+        0.2547,
+        0.2776
+       ],
+       "n": 125,
+       "mean_rmse": 0.8245
+      },
+      "Q4": {
+       "range": [
+        0.2776,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8296
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 96,
+       "mean_rmse": 0.8253
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        15.0
+       ],
+       "n": 134,
+       "mean_rmse": 0.8257
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        22.0
+       ],
+       "n": 144,
+       "mean_rmse": 0.8297
+      },
+      "Q4": {
+       "range": [
+        22.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 0.8342
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8307
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 168,
+       "mean_rmse": 0.8262
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 43,
+       "mean_rmse": 0.8318
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 214,
+       "mean_rmse": 0.8299
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.8402
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        22.0
+       ],
+       "n": 101,
+       "mean_rmse": 0.8213
+      },
+      "Q3": {
+       "range": [
+        22.0,
+        26.0
+       ],
+       "n": 141,
+       "mean_rmse": 0.823
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 144,
+       "mean_rmse": 0.8311
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.832
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.8271
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0006
+       ],
+       "n": 125,
+       "mean_rmse": 0.8272
+      },
+      "Q4": {
+       "range": [
+        0.0006,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8293
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8279
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8277
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8265
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8336
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8461
+       ],
+       "n": 125,
+       "mean_rmse": 0.8353
+      },
+      "Q2": {
+       "range": [
+        0.8461,
+        0.8907
+       ],
+       "n": 125,
+       "mean_rmse": 0.8268
+      },
+      "Q3": {
+       "range": [
+        0.8907,
+        0.916
+       ],
+       "n": 125,
+       "mean_rmse": 0.8256
+      },
+      "Q4": {
+       "range": [
+        0.916,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.828
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7605
+       ],
+       "n": 125,
+       "mean_rmse": 0.8302
+      },
+      "Q2": {
+       "range": [
+        0.7605,
+        0.8248
+       ],
+       "n": 125,
+       "mean_rmse": 0.8278
+      },
+      "Q3": {
+       "range": [
+        0.8248,
+        0.8635
+       ],
+       "n": 125,
+       "mean_rmse": 0.8254
+      },
+      "Q4": {
+       "range": [
+        0.8635,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8322
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 46.6,
+    "holdout": {
+     "holdout_rmse": 1.5061180109801906,
+     "retrain_s": 0.0207,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8045707992835883
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.808854371718979,
+    "rmse_p10": 0.8301769173322204,
+    "rmse_median": 0.8703086464472224,
+    "train_s_median": 1.079328020848334,
+    "train_s_mean": 0.9428448724254965,
+    "train_s_p90": 1.747809067629279,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.11631795214816022,
+     "num_leaves": 38,
+     "max_depth": 6,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 0.14928573389653352,
+     "lambda_l2": 4.9371630038267895,
+     "feature_fraction": 0.858732124953738,
+     "bagging_fraction": 0.5896865947090731,
+     "bagging_freq": 1,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 37,
+     "mixture_balance_factor": 5,
+     "mixture_smoothing_lambda": 0.5944178839645791,
+     "mixture_diversity_lambda": 0.029255264058614505,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.03378901004573801,
+     "mixture_load_balance_alpha": 0.4037998091790989,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.0981797626904028,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 1,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9616,
+     "mixture_balance_factor": 0.0094,
+     "extra_trees": 0.0066,
+     "mixture_load_balance_alpha": 0.0042,
+     "mixture_e_step_mode": 0.0037,
+     "lambda_l2": 0.0025,
+     "mixture_init": 0.0022,
+     "max_depth": 0.0012,
+     "bagging_fraction": 0.001,
+     "feature_fraction": 0.001,
+     "mixture_r_smoothing": 0.001,
+     "num_leaves": 0.001,
+     "mixture_warmup_iters": 0.0009,
+     "mixture_num_experts": 0.0008,
+     "learning_rate": 0.0006,
+     "mixture_diversity_lambda": 0.0005,
+     "mixture_hard_m_step": 0.0004,
+     "lambda_l1": 0.0004,
+     "mixture_expert_dropout_rate": 0.0004,
+     "bagging_freq": 0.0003,
+     "mixture_gate_type": 0.0001,
+     "mixture_refit_leaves": 0.0001,
+     "mixture_routing_mode": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 95,
+        "mean": 0.933,
+        "std": 0.0841,
+        "min": 0.8385
+       },
+       "none": {
+        "n": 372,
+        "mean": 0.883,
+        "std": 0.0645,
+        "min": 0.8089
+       },
+       "gbdt": {
+        "n": 33,
+        "mean": 0.949,
+        "std": 0.0635,
+        "min": 0.8531
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.05,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 330,
+        "mean": 0.8858,
+        "std": 0.0704,
+        "min": 0.8089
+       },
+       "expert_choice": {
+        "n": 170,
+        "mean": 0.9184,
+        "std": 0.072,
+        "min": 0.827
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0326,
+       "p_value": 2e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 381,
+        "mean": 0.8867,
+        "std": 0.0681,
+        "min": 0.8089
+       },
+       "loss_only": {
+        "n": 62,
+        "mean": 0.9274,
+        "std": 0.0705,
+        "min": 0.8241
+       },
+       "em": {
+        "n": 57,
+        "mean": 0.9315,
+        "std": 0.0835,
+        "min": 0.8322
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0407,
+       "p_value": 6.9e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 101,
+        "mean": 0.9082,
+        "std": 0.0699,
+        "min": 0.827
+       },
+       "gmm": {
+        "n": 286,
+        "mean": 0.8817,
+        "std": 0.0666,
+        "min": 0.8089
+       },
+       "random": {
+        "n": 18,
+        "mean": 0.9357,
+        "std": 0.0745,
+        "min": 0.8415
+       },
+       "gmm_features": {
+        "n": 52,
+        "mean": 0.9016,
+        "std": 0.0751,
+        "min": 0.816
+       },
+       "kmeans_features": {
+        "n": 25,
+        "mean": 0.9487,
+        "std": 0.0725,
+        "min": 0.8455
+       },
+       "tree_hierarchical": {
+        "n": 18,
+        "mean": 0.9486,
+        "std": 0.084,
+        "min": 0.8358
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "gmm_features",
+       "delta_mean": 0.0199,
+       "p_value": 0.081258,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 58,
+        "mean": 0.9457,
+        "std": 0.076,
+        "min": 0.8375
+       },
+       "markov": {
+        "n": 300,
+        "mean": 0.886,
+        "std": 0.0688,
+        "min": 0.8089
+       },
+       "none": {
+        "n": 142,
+        "mean": 0.8999,
+        "std": 0.0706,
+        "min": 0.827
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.0139,
+       "p_value": 0.053676,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 422,
+        "mean": 0.8901,
+        "std": 0.0715,
+        "min": 0.8089
+       },
+       "True": {
+        "n": 78,
+        "mean": 0.9333,
+        "std": 0.0678,
+        "min": 0.8445
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0432,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 459,
+        "mean": 0.8909,
+        "std": 0.0703,
+        "min": 0.8089
+       },
+       "False": {
+        "n": 41,
+        "mean": 0.9631,
+        "std": 0.0649,
+        "min": 0.8457
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0722,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 11,
+       "mean_rmse": 0.9437
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 330,
+       "mean_rmse": 0.8909
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 159,
+       "mean_rmse": 0.906
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0224
+       ],
+       "n": 125,
+       "mean_rmse": 0.8725
+      },
+      "Q2": {
+       "range": [
+        0.0224,
+        0.0404
+       ],
+       "n": 125,
+       "mean_rmse": 0.8809
+      },
+      "Q3": {
+       "range": [
+        0.0404,
+        0.1594
+       ],
+       "n": 125,
+       "mean_rmse": 0.9028
+      },
+      "Q4": {
+       "range": [
+        0.1594,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.9312
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        37.0
+       ],
+       "n": 122,
+       "mean_rmse": 0.9149
+      },
+      "Q2": {
+       "range": [
+        37.0,
+        40.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.8815
+      },
+      "Q3": {
+       "range": [
+        40.0,
+        46.0
+       ],
+       "n": 127,
+       "mean_rmse": 0.8898
+      },
+      "Q4": {
+       "range": [
+        46.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 0.9015
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.8973
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.8905
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        8.0
+       ],
+       "n": 200,
+       "mean_rmse": 0.8901
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 160,
+       "mean_rmse": 0.9077
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0581
+       ],
+       "n": 125,
+       "mean_rmse": 0.9169
+      },
+      "Q2": {
+       "range": [
+        0.0581,
+        0.1033
+       ],
+       "n": 125,
+       "mean_rmse": 0.8878
+      },
+      "Q3": {
+       "range": [
+        0.1033,
+        0.126
+       ],
+       "n": 125,
+       "mean_rmse": 0.8881
+      },
+      "Q4": {
+       "range": [
+        0.126,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8946
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        29.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.8985
+      },
+      "Q2": {
+       "range": [
+        29.0,
+        37.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.89
+      },
+      "Q3": {
+       "range": [
+        37.0,
+        43.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.8795
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 0.9171
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 33,
+       "mean_rmse": 0.8971
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.8976
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 201,
+       "mean_rmse": 0.8758
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 143,
+       "mean_rmse": 0.9258
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 69,
+       "mean_rmse": 0.8586
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.5
+       ],
+       "n": 181,
+       "mean_rmse": 0.8522
+      },
+      "Q3": {
+       "range": [
+        9.5,
+        13.0
+       ],
+       "n": 117,
+       "mean_rmse": 0.889
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 0.9843
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2384.6,
+    "holdout": {
+     "holdout_rmse": 1.490560715128644,
+     "retrain_s": 1.7294,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.808854371718979
+    }
+   }
+  },
+  "fred_gdp@s43": {
+   "dataset": "fred_gdp",
+   "seed": 43,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.7992196638224648,
+    "rmse_p10": 0.8083237962885158,
+    "rmse_median": 0.8210352186786376,
+    "train_s_median": 0.017960270121693614,
+    "train_s_mean": 0.018223329339921476,
+    "train_s_p90": 0.024116545505821707,
+    "best_params": {
+     "learning_rate": 0.28855427282259166,
+     "num_leaves": 25,
+     "max_depth": 10,
+     "min_data_in_leaf": 17,
+     "lambda_l1": 0.0001244718758928286,
+     "lambda_l2": 0.00010625701033692853,
+     "feature_fraction": 0.6507202557716241,
+     "bagging_fraction": 0.8604126994569147,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8915,
+     "bagging_fraction": 0.0776,
+     "learning_rate": 0.01,
+     "bagging_freq": 0.006,
+     "feature_fraction": 0.0052,
+     "num_leaves": 0.0046,
+     "max_depth": 0.0021,
+     "lambda_l1": 0.0018,
+     "extra_trees": 0.0012,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 0.8436,
+        "std": 0.0255,
+        "min": 0.8129
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.8272,
+        "std": 0.0245,
+        "min": 0.7992
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0164,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2084
+       ],
+       "n": 125,
+       "mean_rmse": 0.8323
+      },
+      "Q2": {
+       "range": [
+        0.2084,
+        0.2488
+       ],
+       "n": 125,
+       "mean_rmse": 0.8261
+      },
+      "Q3": {
+       "range": [
+        0.2488,
+        0.274
+       ],
+       "n": 125,
+       "mean_rmse": 0.8259
+      },
+      "Q4": {
+       "range": [
+        0.274,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8286
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.8262
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        26.0
+       ],
+       "n": 126,
+       "mean_rmse": 0.8299
+      },
+      "Q3": {
+       "range": [
+        26.0,
+        42.0
+       ],
+       "n": 131,
+       "mean_rmse": 0.8285
+      },
+      "Q4": {
+       "range": [
+        42.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 0.8281
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 108,
+       "mean_rmse": 0.8344
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 112,
+       "mean_rmse": 0.8316
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 61,
+       "mean_rmse": 0.8301
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 219,
+       "mean_rmse": 0.8229
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 96,
+       "mean_rmse": 0.8551
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 145,
+       "mean_rmse": 0.8172
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        22.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.8191
+      },
+      "Q4": {
+       "range": [
+        22.0,
+        null
+       ],
+       "n": 141,
+       "mean_rmse": 0.8289
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.8282
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0005
+       ],
+       "n": 125,
+       "mean_rmse": 0.8229
+      },
+      "Q3": {
+       "range": [
+        0.0005,
+        0.0037
+       ],
+       "n": 125,
+       "mean_rmse": 0.8276
+      },
+      "Q4": {
+       "range": [
+        0.0037,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8342
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8345
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.8257
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0004
+       ],
+       "n": 125,
+       "mean_rmse": 0.8249
+      },
+      "Q4": {
+       "range": [
+        0.0004,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8278
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6343
+       ],
+       "n": 125,
+       "mean_rmse": 0.8314
+      },
+      "Q2": {
+       "range": [
+        0.6343,
+        0.6578
+       ],
+       "n": 125,
+       "mean_rmse": 0.8236
+      },
+      "Q3": {
+       "range": [
+        0.6578,
+        0.6834
+       ],
+       "n": 125,
+       "mean_rmse": 0.8256
+      },
+      "Q4": {
+       "range": [
+        0.6834,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8323
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8493
+       ],
+       "n": 125,
+       "mean_rmse": 0.8373
+      },
+      "Q2": {
+       "range": [
+        0.8493,
+        0.8706
+       ],
+       "n": 125,
+       "mean_rmse": 0.8242
+      },
+      "Q3": {
+       "range": [
+        0.8706,
+        0.8901
+       ],
+       "n": 125,
+       "mean_rmse": 0.8225
+      },
+      "Q4": {
+       "range": [
+        0.8901,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8288
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 56.8,
+    "holdout": {
+     "holdout_rmse": 1.5535232842937101,
+     "retrain_s": 0.0438,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.7992196638224648
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.8205589076945501,
+    "rmse_p10": 0.832201824138119,
+    "rmse_median": 0.856267991180067,
+    "train_s_median": 0.15976837892085316,
+    "train_s_mean": 0.5015008871302008,
+    "train_s_p90": 1.8626699736714372,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.04942340914510613,
+     "num_leaves": 53,
+     "max_depth": 7,
+     "min_data_in_leaf": 8,
+     "lambda_l1": 3.560001005570302e-06,
+     "lambda_l2": 0.023885784239599472,
+     "feature_fraction": 0.9267947171209768,
+     "bagging_fraction": 0.6129364030529837,
+     "bagging_freq": 4,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 37,
+     "mixture_balance_factor": 8,
+     "mixture_smoothing_lambda": 0.8732332806191196,
+     "mixture_diversity_lambda": 0.3496224388305501,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.0621493689938586,
+     "mixture_load_balance_alpha": 0.001997915668773693,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 38,
+     "mixture_gate_learning_rate": 0.032849577738689524,
+     "mixture_gate_lambda_l2": 0.026491611506346577,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_entropy_lambda": 0.05770669077963925,
+     "mixture_gate_temperature_init": 2.3837204686047713,
+     "gate_temp_final_ratio": 0.9244017028972027,
+     "mixture_expert_capacity_factor": 1.4481594143564689,
+     "mixture_expert_choice_boost": 26.835863538888653,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.23129341985891763,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 2,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9223,
+     "extra_trees": 0.0223,
+     "lambda_l1": 0.0085,
+     "mixture_balance_factor": 0.0058,
+     "lambda_l2": 0.0055,
+     "mixture_warmup_iters": 0.0053,
+     "mixture_init": 0.005,
+     "mixture_load_balance_alpha": 0.0049,
+     "num_leaves": 0.0043,
+     "mixture_e_step_mode": 0.0027,
+     "mixture_num_experts": 0.0026,
+     "feature_fraction": 0.0024,
+     "mixture_expert_dropout_rate": 0.002,
+     "mixture_gate_type": 0.0014,
+     "mixture_diversity_lambda": 0.001,
+     "bagging_fraction": 0.0008,
+     "mixture_hard_m_step": 0.0007,
+     "bagging_freq": 0.0006,
+     "max_depth": 0.0006,
+     "learning_rate": 0.0005,
+     "mixture_r_smoothing": 0.0004,
+     "mixture_refit_leaves": 0.0003,
+     "mixture_routing_mode": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 114,
+        "mean": 0.9044,
+        "std": 0.083,
+        "min": 0.8206
+       },
+       "leaf_reuse": {
+        "n": 23,
+        "mean": 0.9722,
+        "std": 0.095,
+        "min": 0.8567
+       },
+       "none": {
+        "n": 363,
+        "mean": 0.8801,
+        "std": 0.0645,
+        "min": 0.8228
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 0.0243,
+       "p_value": 0.004978,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 418,
+        "mean": 0.8808,
+        "std": 0.0682,
+        "min": 0.8206
+       },
+       "token_choice": {
+        "n": 82,
+        "mean": 0.936,
+        "std": 0.0829,
+        "min": 0.8345
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0552,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 274,
+        "mean": 0.8837,
+        "std": 0.0697,
+        "min": 0.8228
+       },
+       "gate_only": {
+        "n": 64,
+        "mean": 0.9263,
+        "std": 0.0818,
+        "min": 0.8413
+       },
+       "em": {
+        "n": 162,
+        "mean": 0.8859,
+        "std": 0.0729,
+        "min": 0.8206
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0022,
+       "p_value": 0.759973,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 42,
+        "mean": 0.904,
+        "std": 0.0923,
+        "min": 0.8206
+       },
+       "tree_hierarchical": {
+        "n": 17,
+        "mean": 0.9543,
+        "std": 0.1065,
+        "min": 0.8402
+       },
+       "uniform": {
+        "n": 17,
+        "mean": 0.91,
+        "std": 0.0598,
+        "min": 0.8526
+       },
+       "kmeans_features": {
+        "n": 81,
+        "mean": 0.8846,
+        "std": 0.0563,
+        "min": 0.8302
+       },
+       "gmm_features": {
+        "n": 290,
+        "mean": 0.8774,
+        "std": 0.0651,
+        "min": 0.8228
+       },
+       "random": {
+        "n": 53,
+        "mean": 0.9281,
+        "std": 0.0879,
+        "min": 0.8377
+       }
+      },
+      "best": {
+       "value": "gmm_features",
+       "runner_up": "kmeans_features",
+       "delta_mean": 0.0072,
+       "p_value": 0.331423,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 360,
+        "mean": 0.8806,
+        "std": 0.0662,
+        "min": 0.8228
+       },
+       "none": {
+        "n": 65,
+        "mean": 0.9279,
+        "std": 0.0851,
+        "min": 0.8413
+       },
+       "markov": {
+        "n": 75,
+        "mean": 0.9014,
+        "std": 0.0842,
+        "min": 0.8206
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.0208,
+       "p_value": 0.048668,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 77,
+        "mean": 0.9417,
+        "std": 0.0854,
+        "min": 0.8372
+       },
+       "True": {
+        "n": 423,
+        "mean": 0.8804,
+        "std": 0.0672,
+        "min": 0.8206
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0613,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 31,
+        "mean": 0.9535,
+        "std": 0.088,
+        "min": 0.8539
+       },
+       "True": {
+        "n": 469,
+        "mean": 0.8857,
+        "std": 0.0707,
+        "min": 0.8206
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0678,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 98,
+       "mean_rmse": 0.9082
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 402,
+       "mean_rmse": 0.8854
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2852
+       ],
+       "n": 125,
+       "mean_rmse": 0.8935
+      },
+      "Q2": {
+       "range": [
+        0.2852,
+        0.355
+       ],
+       "n": 125,
+       "mean_rmse": 0.8875
+      },
+      "Q3": {
+       "range": [
+        0.355,
+        0.4764
+       ],
+       "n": 125,
+       "mean_rmse": 0.902
+      },
+      "Q4": {
+       "range": [
+        0.4764,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8764
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        33.0
+       ],
+       "n": 106,
+       "mean_rmse": 0.9143
+      },
+      "Q2": {
+       "range": [
+        33.0,
+        37.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.8864
+      },
+      "Q3": {
+       "range": [
+        37.0,
+        39.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.8845
+      },
+      "Q4": {
+       "range": [
+        39.0,
+        null
+       ],
+       "n": 156,
+       "mean_rmse": 0.8801
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 104,
+       "mean_rmse": 0.8797
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 46,
+       "mean_rmse": 0.8829
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 220,
+       "mean_rmse": 0.8788
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 0.9192
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0456
+       ],
+       "n": 125,
+       "mean_rmse": 0.9088
+      },
+      "Q2": {
+       "range": [
+        0.0456,
+        0.0582
+       ],
+       "n": 125,
+       "mean_rmse": 0.8786
+      },
+      "Q3": {
+       "range": [
+        0.0582,
+        0.075
+       ],
+       "n": 125,
+       "mean_rmse": 0.8751
+      },
+      "Q4": {
+       "range": [
+        0.075,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8971
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        38.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.9079
+      },
+      "Q2": {
+       "range": [
+        38.0,
+        47.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.8708
+      },
+      "Q3": {
+       "range": [
+        47.0,
+        56.25
+       ],
+       "n": 129,
+       "mean_rmse": 0.888
+      },
+      "Q4": {
+       "range": [
+        56.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8928
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 98,
+       "mean_rmse": 0.9212
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 139,
+       "mean_rmse": 0.8908
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 263,
+       "mean_rmse": 0.8777
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 79,
+       "mean_rmse": 0.8672
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 139,
+       "mean_rmse": 0.8437
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        12.0
+       ],
+       "n": 138,
+       "mean_rmse": 0.8551
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 144,
+       "mean_rmse": 0.9803
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1284.2,
+    "holdout": {
+     "holdout_rmse": 1.5077363818249705,
+     "retrain_s": 3.8287,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 0.8205589076945501
+    }
+   }
+  },
+  "fred_gdp@s44": {
+   "dataset": "fred_gdp",
+   "seed": 44,
+   "X_search_shape": [
+    249,
+    12
+   ],
+   "n_holdout": 62,
+   "y_stats": {
+    "mean": 0.8078939938191193,
+    "std": 0.9812875281189065
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.8046364624953496,
+    "rmse_p10": 0.818320968350491,
+    "rmse_median": 0.8285375145318119,
+    "train_s_median": 0.01532070841640234,
+    "train_s_mean": 0.016755605767667294,
+    "train_s_p90": 0.024296270310878755,
+    "best_params": {
+     "learning_rate": 0.18465522919126187,
+     "num_leaves": 64,
+     "max_depth": 6,
+     "min_data_in_leaf": 21,
+     "lambda_l1": 1.2688785382368184e-05,
+     "lambda_l2": 3.0855202008176144,
+     "feature_fraction": 0.9567868083025717,
+     "bagging_fraction": 0.6690209794535309,
+     "bagging_freq": 6,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8682,
+     "learning_rate": 0.0562,
+     "bagging_fraction": 0.0363,
+     "lambda_l2": 0.0087,
+     "num_leaves": 0.0065,
+     "max_depth": 0.0064,
+     "bagging_freq": 0.0061,
+     "extra_trees": 0.006,
+     "feature_fraction": 0.0055,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 463,
+        "mean": 0.8302,
+        "std": 0.012,
+        "min": 0.8046
+       },
+       "True": {
+        "n": 37,
+        "mean": 0.8362,
+        "std": 0.0092,
+        "min": 0.8218
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.006,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.03
+       ],
+       "n": 125,
+       "mean_rmse": 0.8333
+      },
+      "Q2": {
+       "range": [
+        0.03,
+        0.0718
+       ],
+       "n": 125,
+       "mean_rmse": 0.8306
+      },
+      "Q3": {
+       "range": [
+        0.0718,
+        0.1145
+       ],
+       "n": 125,
+       "mean_rmse": 0.8288
+      },
+      "Q4": {
+       "range": [
+        0.1145,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8297
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.8291
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        29.0
+       ],
+       "n": 116,
+       "mean_rmse": 0.8288
+      },
+      "Q3": {
+       "range": [
+        29.0,
+        54.25
+       ],
+       "n": 139,
+       "mean_rmse": 0.832
+      },
+      "Q4": {
+       "range": [
+        54.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8322
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.8292
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 104,
+       "mean_rmse": 0.8298
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 278,
+       "mean_rmse": 0.8315
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        14.0
+       ],
+       "n": 109,
+       "mean_rmse": 0.8362
+      },
+      "Q2": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 127,
+       "mean_rmse": 0.8257
+      },
+      "Q3": {
+       "range": [
+        18.0,
+        22.0
+       ],
+       "n": 133,
+       "mean_rmse": 0.8258
+      },
+      "Q4": {
+       "range": [
+        22.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 0.8357
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8329
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8299
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.8287
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8309
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.019
+       ],
+       "n": 125,
+       "mean_rmse": 0.8348
+      },
+      "Q2": {
+       "range": [
+        0.019,
+        0.1741
+       ],
+       "n": 125,
+       "mean_rmse": 0.8312
+      },
+      "Q3": {
+       "range": [
+        0.1741,
+        0.8764
+       ],
+       "n": 125,
+       "mean_rmse": 0.8293
+      },
+      "Q4": {
+       "range": [
+        0.8764,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8271
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6918
+       ],
+       "n": 125,
+       "mean_rmse": 0.8371
+      },
+      "Q2": {
+       "range": [
+        0.6918,
+        0.8949
+       ],
+       "n": 125,
+       "mean_rmse": 0.8291
+      },
+      "Q3": {
+       "range": [
+        0.8949,
+        0.9381
+       ],
+       "n": 125,
+       "mean_rmse": 0.8287
+      },
+      "Q4": {
+       "range": [
+        0.9381,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8275
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5466
+       ],
+       "n": 125,
+       "mean_rmse": 0.8313
+      },
+      "Q2": {
+       "range": [
+        0.5466,
+        0.5716
+       ],
+       "n": 125,
+       "mean_rmse": 0.8281
+      },
+      "Q3": {
+       "range": [
+        0.5716,
+        0.6524
+       ],
+       "n": 125,
+       "mean_rmse": 0.8316
+      },
+      "Q4": {
+       "range": [
+        0.6524,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8315
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 53.3,
+    "holdout": {
+     "holdout_rmse": 1.5665230673331163,
+     "retrain_s": 0.024,
+     "predict_s": 0.0001,
+     "cv_rmse_of_winner": 0.8046364624953496
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.8273949974767832,
+    "rmse_p10": 0.8459224642247463,
+    "rmse_median": 0.9189973759433441,
+    "train_s_median": 0.38273387812077997,
+    "train_s_mean": 0.5074817726165056,
+    "train_s_p90": 0.6285792865231634,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.04905868364144782,
+     "num_leaves": 82,
+     "max_depth": 7,
+     "min_data_in_leaf": 11,
+     "lambda_l1": 0.00021606165159764425,
+     "lambda_l2": 5.374977361206578e-07,
+     "feature_fraction": 0.8085114308122305,
+     "bagging_fraction": 0.985683178454127,
+     "bagging_freq": 7,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 22,
+     "mixture_balance_factor": 4,
+     "mixture_diversity_lambda": 0.21903693242171846,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.18360131383765474,
+     "mixture_load_balance_alpha": 0.37469081353662703,
+     "mixture_gate_max_depth": 9,
+     "mixture_gate_num_leaves": 50,
+     "mixture_gate_learning_rate": 0.05113847680486562,
+     "mixture_gate_lambda_l2": 0.023251327770882013,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_entropy_lambda": 0.18633103116958333,
+     "mixture_gate_temperature_init": 2.918873201616071,
+     "gate_temp_final_ratio": 0.6764501841368159,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.9024,
+     "lambda_l1": 0.0467,
+     "extra_trees": 0.0146,
+     "mixture_hard_m_step": 0.012,
+     "mixture_expert_dropout_rate": 0.0036,
+     "mixture_init": 0.0035,
+     "max_depth": 0.0028,
+     "mixture_diversity_lambda": 0.0026,
+     "mixture_e_step_mode": 0.0018,
+     "mixture_balance_factor": 0.0017,
+     "bagging_fraction": 0.0015,
+     "feature_fraction": 0.0013,
+     "learning_rate": 0.0013,
+     "mixture_warmup_iters": 0.0011,
+     "bagging_freq": 0.0006,
+     "mixture_num_experts": 0.0006,
+     "mixture_refit_leaves": 0.0004,
+     "mixture_r_smoothing": 0.0004,
+     "lambda_l2": 0.0003,
+     "num_leaves": 0.0003,
+     "mixture_load_balance_alpha": 0.0002,
+     "mixture_gate_type": 0.0001,
+     "mixture_routing_mode": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 448,
+        "mean": 0.9074,
+        "std": 0.0596,
+        "min": 0.8274
+       },
+       "none": {
+        "n": 26,
+        "mean": 0.9517,
+        "std": 0.0965,
+        "min": 0.8417
+       },
+       "leaf_reuse": {
+        "n": 26,
+        "mean": 0.9291,
+        "std": 0.078,
+        "min": 0.8405
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0217,
+       "p_value": 0.183333,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 426,
+        "mean": 0.9101,
+        "std": 0.0628,
+        "min": 0.8274
+       },
+       "expert_choice": {
+        "n": 74,
+        "mean": 0.9153,
+        "std": 0.0706,
+        "min": 0.8342
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0052,
+       "p_value": 0.551091,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 114,
+        "mean": 0.9299,
+        "std": 0.0689,
+        "min": 0.8309
+       },
+       "gate_only": {
+        "n": 28,
+        "mean": 0.9543,
+        "std": 0.0891,
+        "min": 0.8493
+       },
+       "loss_only": {
+        "n": 358,
+        "mean": 0.9014,
+        "std": 0.0569,
+        "min": 0.8274
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0285,
+       "p_value": 0.000101,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 33,
+        "mean": 0.9559,
+        "std": 0.0787,
+        "min": 0.8415
+       },
+       "tree_hierarchical": {
+        "n": 33,
+        "mean": 0.9248,
+        "std": 0.0778,
+        "min": 0.8315
+       },
+       "random": {
+        "n": 20,
+        "mean": 0.9432,
+        "std": 0.0845,
+        "min": 0.8513
+       },
+       "gmm": {
+        "n": 24,
+        "mean": 0.9142,
+        "std": 0.04,
+        "min": 0.851
+       },
+       "gmm_features": {
+        "n": 26,
+        "mean": 0.9296,
+        "std": 0.0644,
+        "min": 0.8382
+       },
+       "uniform": {
+        "n": 364,
+        "mean": 0.9022,
+        "std": 0.058,
+        "min": 0.8274
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "gmm",
+       "delta_mean": 0.012,
+       "p_value": 0.184452,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 440,
+        "mean": 0.9068,
+        "std": 0.0606,
+        "min": 0.8274
+       },
+       "ema": {
+        "n": 35,
+        "mean": 0.9374,
+        "std": 0.0793,
+        "min": 0.8405
+       },
+       "markov": {
+        "n": 25,
+        "mean": 0.9444,
+        "std": 0.0783,
+        "min": 0.8432
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.0306,
+       "p_value": 0.034314,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 35,
+        "mean": 0.9703,
+        "std": 0.0671,
+        "min": 0.8519
+       },
+       "True": {
+        "n": 465,
+        "mean": 0.9064,
+        "std": 0.0615,
+        "min": 0.8274
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0639,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 469,
+        "mean": 0.9063,
+        "std": 0.062,
+        "min": 0.8274
+       },
+       "False": {
+        "n": 31,
+        "mean": 0.98,
+        "std": 0.0541,
+        "min": 0.9018
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0737,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 60,
+       "mean_rmse": 0.9255
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 258,
+       "mean_rmse": 0.9068
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 182,
+       "mean_rmse": 0.9118
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1945
+       ],
+       "n": 125,
+       "mean_rmse": 0.9174
+      },
+      "Q2": {
+       "range": [
+        0.1945,
+        0.2441
+       ],
+       "n": 125,
+       "mean_rmse": 0.9029
+      },
+      "Q3": {
+       "range": [
+        0.2441,
+        0.2837
+       ],
+       "n": 125,
+       "mean_rmse": 0.9051
+      },
+      "Q4": {
+       "range": [
+        0.2837,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.918
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        23.0
+       ],
+       "n": 101,
+       "mean_rmse": 0.9095
+      },
+      "Q2": {
+       "range": [
+        23.0,
+        28.0
+       ],
+       "n": 144,
+       "mean_rmse": 0.9033
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        43.0
+       ],
+       "n": 111,
+       "mean_rmse": 0.9207
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 144,
+       "mean_rmse": 0.9117
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 95,
+       "mean_rmse": 0.9188
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        6.0
+       ],
+       "n": 279,
+       "mean_rmse": 0.9062
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 0.9151
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0422
+       ],
+       "n": 125,
+       "mean_rmse": 0.9197
+      },
+      "Q2": {
+       "range": [
+        0.0422,
+        0.0516
+       ],
+       "n": 125,
+       "mean_rmse": 0.9012
+      },
+      "Q3": {
+       "range": [
+        0.0516,
+        0.0922
+       ],
+       "n": 125,
+       "mean_rmse": 0.9169
+      },
+      "Q4": {
+       "range": [
+        0.0922,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.9056
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        69.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.9156
+      },
+      "Q2": {
+       "range": [
+        69.0,
+        83.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.8977
+      },
+      "Q3": {
+       "range": [
+        83.0,
+        92.0
+       ],
+       "n": 132,
+       "mean_rmse": 0.9061
+      },
+      "Q4": {
+       "range": [
+        92.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 0.9235
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 85,
+       "mean_rmse": 0.9046
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 159,
+       "mean_rmse": 0.9052
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 256,
+       "mean_rmse": 0.9164
+      },
+      "best_quartile": "Q1"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 87,
+       "mean_rmse": 0.8806
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        12.0
+       ],
+       "n": 160,
+       "mean_rmse": 0.8576
+      },
+      "Q3": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.9357
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 138,
+       "mean_rmse": 0.9711
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1299.3,
+    "holdout": {
+     "holdout_rmse": 1.4845627611147816,
+     "retrain_s": 0.9489,
+     "predict_s": 0.0007,
+     "cv_rmse_of_winner": 0.8273949974767832
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_hmm_ensemble_report.md
+++ b/bench_results/wide_v081/ds_hmm_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['hmm'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| hmm | naive-ensemble | **2.20801** ± 0.24193 | 2.26486 | 0.0% | 0.11 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| hmm@s42 | naive-ensemble | 2.2955 | 2.3133 | 0.071 | 191 |
+| hmm@s43 | naive-ensemble | 2.3714 | 2.3870 | 0.085 | 243 |
+| hmm@s44 | naive-ensemble | 2.1277 | 2.1354 | 0.079 | 213 |
+
+
+
+---
+
+## hmm@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.88558** (winner retrained in 0.10s, cv score of winner: 2.2955)
+- cv best RMSE: 2.2955, median: 2.3133, p10: 2.3049
+- train: median 0.071s/fold, mean 0.073s, p90 0.097s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.466 |
+| `learning_rate` | 0.269 |
+| `min_data_in_leaf` | 0.090 |
+| `feature_fraction` | 0.060 |
+| `bagging_fraction` | 0.042 |
+| `max_depth` | 0.037 |
+| `num_leaves` | 0.024 |
+| `bagging_freq` | 0.006 |
+| `lambda_l1` | 0.005 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 466 | 2.3151 | 0.0133 | 2.2955 |
+| False | 34 | 2.3503 | 0.0160 | 2.3146 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.3271 | 2.3147 | 2.3138 | 2.3143 | **Q3** [0.2563, 0.2789] |
+| `num_leaves` | 2.3211 | 2.3142 | 2.3143 | 2.3197 | **Q2** [94.75, 100.0] |
+| `max_depth` | 2.3271 | 2.3208 | — | 2.3152 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | 2.3206 | 2.3162 | 2.3130 | 2.3210 | **Q3** [30.0, 34.0] |
+| `lambda_l1` | 2.3128 | 2.3165 | 2.3201 | 2.3205 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.3194 | 2.3195 | 2.3161 | 2.3150 | **Q4** [0.0624, ∞) |
+| `feature_fraction` | 2.3227 | 2.3144 | 2.3155 | 2.3173 | **Q2** [0.7238, 0.8281] |
+| `bagging_fraction` | 2.3225 | 2.3153 | 2.3139 | 2.3182 | **Q3** [0.836, 0.8524] |
+
+#### E. Slice plot
+
+![hmm@s42/naive-ensemble](slice_hmm@s42_naive-ensemble.png)
+
+
+---
+
+## hmm@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.46832** (winner retrained in 0.12s, cv score of winner: 2.3714)
+- cv best RMSE: 2.3714, median: 2.3870, p10: 2.3786
+- train: median 0.085s/fold, mean 0.094s, p90 0.150s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.624 |
+| `learning_rate` | 0.183 |
+| `min_data_in_leaf` | 0.147 |
+| `bagging_fraction` | 0.011 |
+| `num_leaves` | 0.009 |
+| `lambda_l1` | 0.008 |
+| `max_depth` | 0.006 |
+| `bagging_freq` | 0.005 |
+| `feature_fraction` | 0.004 |
+| `n_models` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 469 | 2.3904 | 0.0168 | 2.3714 |
+| False | 31 | 2.4579 | 0.0271 | 2.4190 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.4056 | 2.3905 | 2.3905 | 2.3918 | **Q2** [0.2092, 0.248] |
+| `num_leaves` | 2.3930 | 2.3936 | 2.3916 | 2.3994 | **Q3** [24.0, 29.0] |
+| `max_depth` | 2.4069 | 2.3950 | — | 2.3914 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 2.3983 | 2.3886 | 2.3903 | 2.4035 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 2.4100 | 2.3921 | 2.3872 | 2.3891 | **Q3** [3.7629, 5.7976] |
+| `lambda_l2` | 2.3949 | 2.3903 | 2.3933 | 2.4000 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 2.4005 | 2.3949 | 2.3915 | 2.3916 | **Q3** [0.9684, 0.9836] |
+| `bagging_fraction` | 2.3939 | 2.3973 | 2.3905 | 2.3968 | **Q3** [0.7394, 0.7662] |
+
+#### E. Slice plot
+
+![hmm@s43/naive-ensemble](slice_hmm@s43_naive-ensemble.png)
+
+
+---
+
+## hmm@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 2.27014** (winner retrained in 0.10s, cv score of winner: 2.1277)
+- cv best RMSE: 2.1277, median: 2.1354, p10: 2.1308
+- train: median 0.079s/fold, mean 0.082s, p90 0.103s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.441 |
+| `learning_rate` | 0.259 |
+| `min_data_in_leaf` | 0.207 |
+| `lambda_l1` | 0.028 |
+| `num_leaves` | 0.016 |
+| `feature_fraction` | 0.015 |
+| `bagging_fraction` | 0.014 |
+| `max_depth` | 0.010 |
+| `bagging_freq` | 0.010 |
+| `n_models` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 468 | 2.1389 | 0.0134 | 2.1277 |
+| False | 32 | 2.1809 | 0.0195 | 2.1591 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.1526 | 2.1387 | 2.1361 | 2.1391 | **Q3** [0.1463, 0.168] |
+| `num_leaves` | 2.1407 | 2.1408 | 2.1390 | 2.1457 | **Q3** [62.0, 69.0] |
+| `max_depth` | — | — | 2.1380 | 2.1479 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.1375 | 2.1358 | 2.1384 | 2.1525 | **Q2** [7.0, 9.0] |
+| `lambda_l1` | 2.1494 | 2.1398 | 2.1386 | 2.1386 | **Q3** [3.38, 5.9232] |
+| `lambda_l2` | 2.1398 | 2.1376 | 2.1419 | 2.1471 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 2.1460 | 2.1413 | 2.1396 | 2.1395 | **Q4** [0.8134, ∞) |
+| `bagging_fraction` | 2.1461 | 2.1394 | 2.1385 | 2.1425 | **Q3** [0.7137, 0.7534] |
+
+#### E. Slice plot
+
+![hmm@s44/naive-ensemble](slice_hmm@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_hmm_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_hmm_ensemble_summary.json
@@ -1,0 +1,1161 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "hmm"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "hmm": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.8855786920464555,
+      "cv_best": 2.295473003437415,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0992
+     },
+     "43": {
+      "holdout_rmse": 2.468321459773216,
+      "cv_best": 2.3713740066088644,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1198
+     },
+     "44": {
+      "holdout_rmse": 2.270135201884749,
+      "cv_best": 2.127728787727874,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0988
+     }
+    },
+    "holdout_mean": 2.208012,
+    "holdout_std": 0.241925,
+    "cv_best_mean": 2.264859
+   }
+  }
+ },
+ "runs": {
+  "hmm@s42": {
+   "dataset": "hmm",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.045793656680186444,
+    "std": 2.4137364484700643
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.295473003437415,
+    "rmse_p10": 2.3048672133861183,
+    "rmse_median": 2.313329537732945,
+    "train_s_median": 0.07146065905690194,
+    "train_s_mean": 0.07303198625594377,
+    "train_s_p90": 0.0972004267573357,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.2735553207246474,
+     "num_leaves": 100,
+     "max_depth": 11,
+     "min_data_in_leaf": 32,
+     "lambda_l1": 5.4867114993007284e-08,
+     "lambda_l2": 0.025740081056207047,
+     "feature_fraction": 0.8622267756963871,
+     "bagging_fraction": 0.8397630512682251,
+     "bagging_freq": 6,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.466,
+     "learning_rate": 0.2694,
+     "min_data_in_leaf": 0.0903,
+     "feature_fraction": 0.0599,
+     "bagging_fraction": 0.0415,
+     "max_depth": 0.0374,
+     "num_leaves": 0.024,
+     "bagging_freq": 0.0059,
+     "lambda_l1": 0.0047,
+     "lambda_l2": 0.0005,
+     "n_models": 0.0005
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 34,
+        "mean": 2.3503,
+        "std": 0.016,
+        "min": 2.3146
+       },
+       "True": {
+        "n": 466,
+        "mean": 2.3151,
+        "std": 0.0133,
+        "min": 2.2955
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0352,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2245
+       ],
+       "n": 125,
+       "mean_rmse": 2.3271
+      },
+      "Q2": {
+       "range": [
+        0.2245,
+        0.2563
+       ],
+       "n": 125,
+       "mean_rmse": 2.3147
+      },
+      "Q3": {
+       "range": [
+        0.2563,
+        0.2789
+       ],
+       "n": 125,
+       "mean_rmse": 2.3138
+      },
+      "Q4": {
+       "range": [
+        0.2789,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3143
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        94.75
+       ],
+       "n": 125,
+       "mean_rmse": 2.3211
+      },
+      "Q2": {
+       "range": [
+        94.75,
+        100.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.3142
+      },
+      "Q3": {
+       "range": [
+        100.0,
+        104.0
+       ],
+       "n": 114,
+       "mean_rmse": 2.3143
+      },
+      "Q4": {
+       "range": [
+        104.0,
+        null
+       ],
+       "n": 140,
+       "mean_rmse": 2.3197
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 68,
+       "mean_rmse": 2.3271
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 59,
+       "mean_rmse": 2.3208
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 373,
+       "mean_rmse": 2.3152
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        26.0
+       ],
+       "n": 114,
+       "mean_rmse": 2.3206
+      },
+      "Q2": {
+       "range": [
+        26.0,
+        30.0
+       ],
+       "n": 101,
+       "mean_rmse": 2.3162
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        34.0
+       ],
+       "n": 153,
+       "mean_rmse": 2.313
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 2.321
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.3128
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.3165
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.1671
+       ],
+       "n": 125,
+       "mean_rmse": 2.3201
+      },
+      "Q4": {
+       "range": [
+        0.1671,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3205
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 125,
+       "mean_rmse": 2.3194
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.0092
+       ],
+       "n": 125,
+       "mean_rmse": 2.3195
+      },
+      "Q3": {
+       "range": [
+        0.0092,
+        0.0624
+       ],
+       "n": 125,
+       "mean_rmse": 2.3161
+      },
+      "Q4": {
+       "range": [
+        0.0624,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.315
+      },
+      "best_quartile": "Q4"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7238
+       ],
+       "n": 125,
+       "mean_rmse": 2.3227
+      },
+      "Q2": {
+       "range": [
+        0.7238,
+        0.8281
+       ],
+       "n": 125,
+       "mean_rmse": 2.3144
+      },
+      "Q3": {
+       "range": [
+        0.8281,
+        0.8731
+       ],
+       "n": 125,
+       "mean_rmse": 2.3155
+      },
+      "Q4": {
+       "range": [
+        0.8731,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3173
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8074
+       ],
+       "n": 125,
+       "mean_rmse": 2.3225
+      },
+      "Q2": {
+       "range": [
+        0.8074,
+        0.836
+       ],
+       "n": 125,
+       "mean_rmse": 2.3153
+      },
+      "Q3": {
+       "range": [
+        0.836,
+        0.8524
+       ],
+       "n": 125,
+       "mean_rmse": 2.3139
+      },
+      "Q4": {
+       "range": [
+        0.8524,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3182
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 191.0,
+    "holdout": {
+     "holdout_rmse": 1.8855786920464555,
+     "retrain_s": 0.0992,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.295473003437415
+    }
+   }
+  },
+  "hmm@s43": {
+   "dataset": "hmm",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.4217584667381496,
+    "std": 2.6151502465431355
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.3713740066088644,
+    "rmse_p10": 2.3786362609999854,
+    "rmse_median": 2.3869802000789155,
+    "train_s_median": 0.08475463334470987,
+    "train_s_mean": 0.09398230639621614,
+    "train_s_p90": 0.14960895400494345,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.26827866538965883,
+     "num_leaves": 22,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 3.989364962708576,
+     "lambda_l2": 2.0544835890672413e-07,
+     "feature_fraction": 0.9736787062976803,
+     "bagging_fraction": 0.7480720358550634,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.624,
+     "learning_rate": 0.1826,
+     "min_data_in_leaf": 0.1474,
+     "bagging_fraction": 0.011,
+     "num_leaves": 0.0088,
+     "lambda_l1": 0.0083,
+     "max_depth": 0.0063,
+     "bagging_freq": 0.0052,
+     "feature_fraction": 0.0039,
+     "n_models": 0.0015,
+     "lambda_l2": 0.0011
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 31,
+        "mean": 2.4579,
+        "std": 0.0271,
+        "min": 2.419
+       },
+       "True": {
+        "n": 469,
+        "mean": 2.3904,
+        "std": 0.0168,
+        "min": 2.3714
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0675,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2092
+       ],
+       "n": 125,
+       "mean_rmse": 2.4056
+      },
+      "Q2": {
+       "range": [
+        0.2092,
+        0.248
+       ],
+       "n": 125,
+       "mean_rmse": 2.3905
+      },
+      "Q3": {
+       "range": [
+        0.248,
+        0.2683
+       ],
+       "n": 125,
+       "mean_rmse": 2.3905
+      },
+      "Q4": {
+       "range": [
+        0.2683,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3918
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        19.0
+       ],
+       "n": 106,
+       "mean_rmse": 2.393
+      },
+      "Q2": {
+       "range": [
+        19.0,
+        24.0
+       ],
+       "n": 134,
+       "mean_rmse": 2.3936
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        29.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.3916
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 140,
+       "mean_rmse": 2.3994
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 83,
+       "mean_rmse": 2.4069
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 93,
+       "mean_rmse": 2.395
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 324,
+       "mean_rmse": 2.3914
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.3983
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 128,
+       "mean_rmse": 2.3886
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 161,
+       "mean_rmse": 2.3903
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 2.4035
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        1.6952
+       ],
+       "n": 125,
+       "mean_rmse": 2.41
+      },
+      "Q2": {
+       "range": [
+        1.6952,
+        3.7629
+       ],
+       "n": 125,
+       "mean_rmse": 2.3921
+      },
+      "Q3": {
+       "range": [
+        3.7629,
+        5.7976
+       ],
+       "n": 125,
+       "mean_rmse": 2.3872
+      },
+      "Q4": {
+       "range": [
+        5.7976,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3891
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.3949
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.3903
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.3933
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.4
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9422
+       ],
+       "n": 125,
+       "mean_rmse": 2.4005
+      },
+      "Q2": {
+       "range": [
+        0.9422,
+        0.9684
+       ],
+       "n": 125,
+       "mean_rmse": 2.3949
+      },
+      "Q3": {
+       "range": [
+        0.9684,
+        0.9836
+       ],
+       "n": 125,
+       "mean_rmse": 2.3915
+      },
+      "Q4": {
+       "range": [
+        0.9836,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3916
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7155
+       ],
+       "n": 125,
+       "mean_rmse": 2.3939
+      },
+      "Q2": {
+       "range": [
+        0.7155,
+        0.7394
+       ],
+       "n": 125,
+       "mean_rmse": 2.3973
+      },
+      "Q3": {
+       "range": [
+        0.7394,
+        0.7662
+       ],
+       "n": 125,
+       "mean_rmse": 2.3905
+      },
+      "Q4": {
+       "range": [
+        0.7662,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3968
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 243.2,
+    "holdout": {
+     "holdout_rmse": 2.468321459773216,
+     "retrain_s": 0.1198,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.3713740066088644
+    }
+   }
+  },
+  "hmm@s44": {
+   "dataset": "hmm",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.3382988881406865,
+    "std": 2.4175724001792345
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.127728787727874,
+    "rmse_p10": 2.130804995421002,
+    "rmse_median": 2.1354446175708808,
+    "train_s_median": 0.07865239698439837,
+    "train_s_mean": 0.08193231795579196,
+    "train_s_p90": 0.1032689527049661,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.16569956281239753,
+     "num_leaves": 59,
+     "max_depth": 3,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 9.907830679723652,
+     "lambda_l2": 2.7659138551280714e-08,
+     "feature_fraction": 0.8451924129416013,
+     "bagging_fraction": 0.6674093152363674,
+     "bagging_freq": 2,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4413,
+     "learning_rate": 0.259,
+     "min_data_in_leaf": 0.2074,
+     "lambda_l1": 0.0275,
+     "num_leaves": 0.0156,
+     "feature_fraction": 0.0148,
+     "bagging_fraction": 0.0137,
+     "max_depth": 0.0101,
+     "bagging_freq": 0.0096,
+     "n_models": 0.0009,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 468,
+        "mean": 2.1389,
+        "std": 0.0134,
+        "min": 2.1277
+       },
+       "False": {
+        "n": 32,
+        "mean": 2.1809,
+        "std": 0.0195,
+        "min": 2.1591
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.042,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1194
+       ],
+       "n": 125,
+       "mean_rmse": 2.1526
+      },
+      "Q2": {
+       "range": [
+        0.1194,
+        0.1463
+       ],
+       "n": 125,
+       "mean_rmse": 2.1387
+      },
+      "Q3": {
+       "range": [
+        0.1463,
+        0.168
+       ],
+       "n": 125,
+       "mean_rmse": 2.1361
+      },
+      "Q4": {
+       "range": [
+        0.168,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1391
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        56.75
+       ],
+       "n": 125,
+       "mean_rmse": 2.1407
+      },
+      "Q2": {
+       "range": [
+        56.75,
+        62.0
+       ],
+       "n": 100,
+       "mean_rmse": 2.1408
+      },
+      "Q3": {
+       "range": [
+        62.0,
+        69.0
+       ],
+       "n": 140,
+       "mean_rmse": 2.139
+      },
+      "Q4": {
+       "range": [
+        69.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 2.1457
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 318,
+       "mean_rmse": 2.138
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 182,
+       "mean_rmse": 2.1479
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 86,
+       "mean_rmse": 2.1375
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.1358
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 151,
+       "mean_rmse": 2.1384
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 2.1525
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        1.0507
+       ],
+       "n": 125,
+       "mean_rmse": 2.1494
+      },
+      "Q2": {
+       "range": [
+        1.0507,
+        3.38
+       ],
+       "n": 125,
+       "mean_rmse": 2.1398
+      },
+      "Q3": {
+       "range": [
+        3.38,
+        5.9232
+       ],
+       "n": 125,
+       "mean_rmse": 2.1386
+      },
+      "Q4": {
+       "range": [
+        5.9232,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1386
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.1398
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.1376
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.1419
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1471
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6486
+       ],
+       "n": 125,
+       "mean_rmse": 2.146
+      },
+      "Q2": {
+       "range": [
+        0.6486,
+        0.7632
+       ],
+       "n": 125,
+       "mean_rmse": 2.1413
+      },
+      "Q3": {
+       "range": [
+        0.7632,
+        0.8134
+       ],
+       "n": 125,
+       "mean_rmse": 2.1396
+      },
+      "Q4": {
+       "range": [
+        0.8134,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1395
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6708
+       ],
+       "n": 125,
+       "mean_rmse": 2.1461
+      },
+      "Q2": {
+       "range": [
+        0.6708,
+        0.7137
+       ],
+       "n": 125,
+       "mean_rmse": 2.1394
+      },
+      "Q3": {
+       "range": [
+        0.7137,
+        0.7534
+       ],
+       "n": 125,
+       "mean_rmse": 2.1385
+      },
+      "Q4": {
+       "range": [
+        0.7534,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1425
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 213.2,
+    "holdout": {
+     "holdout_rmse": 2.270135201884749,
+     "retrain_s": 0.0988,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.127728787727874
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_hmm_report.md
+++ b/bench_results/wide_v081/ds_hmm_report.md
@@ -1,0 +1,525 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['hmm'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| hmm | naive-lightgbm | **2.21586** ± 0.24444 | 2.26814 | 0.0% | 0.06 |
+| hmm | moe | **2.25508** ± 0.22943 | 2.24145 | 0.0% | 2.39 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| hmm@s42 | naive-lightgbm | 2.2992 | 2.3144 | 0.035 | 101 |
+| hmm@s42 | moe | 2.2708 | 2.3161 | 0.243 | 764 |
+| hmm@s43 | naive-lightgbm | 2.3781 | 2.3928 | 0.052 | 150 |
+| hmm@s43 | moe | 2.3271 | 2.3816 | 0.360 | 4384 |
+| hmm@s44 | naive-lightgbm | 2.1272 | 2.1405 | 0.044 | 134 |
+| hmm@s44 | moe | 2.1265 | 2.1455 | 0.493 | 1429 |
+
+
+
+---
+
+## hmm@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.88834** (winner retrained in 0.05s, cv score of winner: 2.2992)
+- cv best RMSE: 2.2992, median: 2.3144, p10: 2.3078
+- train: median 0.035s/fold, mean 0.036s, p90 0.042s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.442 |
+| `learning_rate` | 0.305 |
+| `min_data_in_leaf` | 0.122 |
+| `max_depth` | 0.048 |
+| `feature_fraction` | 0.028 |
+| `bagging_fraction` | 0.023 |
+| `num_leaves` | 0.021 |
+| `lambda_l1` | 0.007 |
+| `bagging_freq` | 0.003 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 470 | 2.3166 | 0.0122 | 2.2992 |
+| False | 30 | 2.3478 | 0.0201 | 2.3261 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.3224 | 2.3143 | 2.3155 | 2.3215 | **Q2** [0.0617, 0.0706] |
+| `num_leaves` | 2.3190 | 2.3188 | 2.3181 | 2.3179 | **Q4** [120.0, ∞) |
+| `max_depth` | — | — | 2.3160 | 2.3256 | **Q3** [3.0, 5.0] |
+| `min_data_in_leaf` | 2.3202 | 2.3156 | 2.3152 | 2.3225 | **Q3** [30.0, 34.0] |
+| `lambda_l1` | 2.3260 | 2.3163 | 2.3157 | 2.3159 | **Q3** [1.6462, 3.6754] |
+| `lambda_l2` | 2.3202 | 2.3191 | 2.3168 | 2.3177 | **Q3** [0.0277, 0.2475] |
+| `feature_fraction` | 2.3243 | 2.3177 | 2.3141 | 2.3177 | **Q3** [0.9027, 0.9273] |
+| `bagging_fraction` | 2.3256 | 2.3181 | 2.3146 | 2.3154 | **Q3** [0.9369, 0.9666] |
+
+#### E. Slice plot
+
+![hmm@s42/naive-lightgbm](slice_hmm@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.95174** (winner retrained in 0.43s, cv score of winner: 2.2708)
+- cv best RMSE: 2.2708, median: 2.3161, p10: 2.2847
+- train: median 0.243s/fold, mean 0.292s, p90 0.384s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.504 |
+| `mixture_init` | 0.138 |
+| `mixture_expert_dropout_rate` | 0.041 |
+| `learning_rate` | 0.041 |
+| `mixture_hard_m_step` | 0.031 |
+| `mixture_diversity_lambda` | 0.029 |
+| `mixture_load_balance_alpha` | 0.029 |
+| `feature_fraction` | 0.027 |
+| `min_data_in_leaf` | 0.023 |
+| `bagging_fraction` | 0.021 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 2.3184 (n=421) | leaf_reuse | Δ +0.0526 | p=0.00e+00 |
+| `mixture_init` | **tree_hierarchical** | 2.3161 (n=384) | gmm_features | Δ +0.0384 | p=4.00e-05 |
+| `mixture_r_smoothing` | **markov** | 2.3222 (n=375) | none | Δ +0.0180 | p=1.45e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 421 | 2.3184 | 0.0335 | 2.2708 |
+| leaf_reuse | 39 | 2.3710 | 0.0332 | 2.3240 |
+| none | 40 | 2.3930 | 0.0516 | 2.3315 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 328 | 2.3271 | 0.0449 | 2.2708 |
+| token_choice | 172 | 2.3310 | 0.0373 | 2.2797 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 341 | 2.3227 | 0.0424 | 2.2708 |
+| gate_only | 94 | 2.3298 | 0.0372 | 2.2797 |
+| em | 65 | 2.3570 | 0.0376 | 2.2836 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 384 | 2.3161 | 0.0379 | 2.2708 |
+| gmm_features | 19 | 2.3545 | 0.0303 | 2.3185 |
+| uniform | 37 | 2.3641 | 0.0279 | 2.3315 |
+| gmm | 21 | 2.3741 | 0.0289 | 2.3330 |
+| random | 21 | 2.3758 | 0.0290 | 2.3411 |
+| kmeans_features | 18 | 2.3835 | 0.0132 | 2.3546 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 375 | 2.3222 | 0.0415 | 2.2708 |
+| none | 55 | 2.3402 | 0.0369 | 2.2910 |
+| ema | 70 | 2.3529 | 0.0408 | 2.2789 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 436 | 2.3234 | 0.0404 | 2.2708 |
+| True | 64 | 2.3630 | 0.0398 | 2.2783 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 464 | 2.3251 | 0.0414 | 2.2708 |
+| False | 36 | 2.3721 | 0.0287 | 2.3311 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.3666 | — | — | 2.3264 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 2.3290 | 2.3159 | 2.3270 | 2.3420 | **Q2** [0.115, 0.1415] |
+| `mixture_warmup_iters` | 2.3528 | 2.3244 | 2.3192 | 2.3206 | **Q3** [48.0, 49.0] |
+| `mixture_balance_factor` | — | — | 2.3212 | 2.3495 | **Q3** [2.0, 5.0] |
+| `learning_rate` | 2.3318 | 2.3261 | 2.3254 | 2.3305 | **Q3** [0.1106, 0.1314] |
+| `num_leaves` | 2.3448 | 2.3230 | 2.3222 | 2.3241 | **Q3** [118.0, 124.0] |
+| `max_depth` | 2.3430 | — | 2.3246 | 2.3274 | **Q3** [6.0, 7.0] |
+| `min_data_in_leaf` | 2.3383 | 2.3267 | 2.3190 | 2.3312 | **Q3** [41.0, 47.0] |
+
+#### E. Slice plot
+
+![hmm@s42/moe](slice_hmm@s42_moe.png)
+
+
+---
+
+## hmm@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.47543** (winner retrained in 0.08s, cv score of winner: 2.3781)
+- cv best RMSE: 2.3781, median: 2.3928, p10: 2.3835
+- train: median 0.052s/fold, mean 0.055s, p90 0.074s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.504 |
+| `extra_trees` | 0.350 |
+| `learning_rate` | 0.032 |
+| `lambda_l1` | 0.030 |
+| `bagging_fraction` | 0.027 |
+| `num_leaves` | 0.025 |
+| `feature_fraction` | 0.018 |
+| `max_depth` | 0.006 |
+| `bagging_freq` | 0.005 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 468 | 2.3959 | 0.0146 | 2.3781 |
+| False | 32 | 2.4482 | 0.0290 | 2.4035 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.4027 | 2.3943 | 2.3958 | 2.4040 | **Q2** [0.0537, 0.0613] |
+| `num_leaves` | 2.3947 | 2.3997 | 2.4003 | 2.4020 | **Q1** [None, 16.0] |
+| `max_depth` | 2.4045 | 2.3962 | 2.3971 | 2.4015 | **Q2** [8.0, 8.5] |
+| `min_data_in_leaf` | 2.3981 | 2.3936 | 2.3944 | 2.4122 | **Q2** [7.0, 11.0] |
+| `lambda_l1` | 2.4082 | 2.3971 | 2.3950 | 2.3965 | **Q3** [2.6671, 4.7197] |
+| `lambda_l2` | 2.4061 | 2.3972 | 2.3967 | 2.3968 | **Q3** [0.3291, 1.0941] |
+| `feature_fraction` | 2.4091 | 2.3965 | 2.3965 | 2.3947 | **Q4** [0.9791, ∞) |
+| `bagging_fraction` | 2.4064 | 2.3977 | 2.3948 | 2.3979 | **Q3** [0.8822, 0.9203] |
+
+#### E. Slice plot
+
+![hmm@s43/naive-lightgbm](slice_hmm@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.50647** (winner retrained in 6.30s, cv score of winner: 2.3271)
+- cv best RMSE: 2.3271, median: 2.3816, p10: 2.3567
+- train: median 0.360s/fold, mean 1.742s, p90 4.397s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.294 |
+| `feature_fraction` | 0.197 |
+| `learning_rate` | 0.078 |
+| `min_data_in_leaf` | 0.072 |
+| `mixture_balance_factor` | 0.067 |
+| `mixture_warmup_iters` | 0.056 |
+| `mixture_expert_dropout_rate` | 0.043 |
+| `extra_trees` | 0.037 |
+| `bagging_freq` | 0.024 |
+| `mixture_diversity_lambda` | 0.024 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 2.3811 (n=189) | none | Δ +0.0142 | p=1.80e-05 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 189 | 2.3811 | 0.0319 | 2.3271 |
+| none | 288 | 2.3953 | 0.0393 | 2.3449 |
+| leaf_reuse | 23 | 2.4369 | 0.0763 | 2.3716 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 358 | 2.3918 | 0.0342 | 2.3271 |
+| expert_choice | 142 | 2.3919 | 0.0547 | 2.3318 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 188 | 2.3864 | 0.0455 | 2.3271 |
+| gate_only | 29 | 2.3943 | 0.0382 | 2.3354 |
+| em | 283 | 2.3952 | 0.0377 | 2.3487 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm_features | 277 | 2.3827 | 0.0360 | 2.3271 |
+| uniform | 152 | 2.3880 | 0.0196 | 2.3607 |
+| random | 18 | 2.4000 | 0.0224 | 2.3716 |
+| kmeans_features | 17 | 2.4069 | 0.0349 | 2.3710 |
+| gmm | 18 | 2.4635 | 0.0582 | 2.3950 |
+| tree_hierarchical | 18 | 2.4715 | 0.0738 | 2.3676 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 92 | 2.3895 | 0.0473 | 2.3354 |
+| markov | 372 | 2.3904 | 0.0370 | 2.3271 |
+| ema | 36 | 2.4124 | 0.0561 | 2.3727 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 166 | 2.3897 | 0.0422 | 2.3318 |
+| False | 334 | 2.3929 | 0.0405 | 2.3271 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 460 | 2.3879 | 0.0349 | 2.3271 |
+| True | 40 | 2.4375 | 0.0694 | 2.3462 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.4339 | — | — | 2.3870 | **Q4** [6.0, ∞) |
+| `mixture_diversity_lambda` | 2.3773 | 2.3946 | 2.3926 | 2.4028 | **Q1** [None, 0.1223] |
+| `mixture_warmup_iters` | 2.3784 | 2.3980 | 2.3908 | 2.3981 | **Q1** [None, 13.0] |
+| `mixture_balance_factor` | 2.4092 | 2.3822 | 2.3840 | 2.3971 | **Q2** [5.0, 6.0] |
+| `learning_rate` | 2.4011 | 2.3933 | 2.3849 | 2.3880 | **Q3** [0.0661, 0.1146] |
+| `num_leaves` | 2.3901 | 2.3816 | 2.3912 | 2.4041 | **Q2** [16.0, 25.0] |
+| `max_depth` | 2.3942 | 2.4148 | 2.3814 | 2.3898 | **Q3** [9.0, 11.0] |
+| `min_data_in_leaf` | 2.3938 | 2.3835 | 2.3818 | 2.4076 | **Q3** [40.0, 45.0] |
+
+#### E. Slice plot
+
+![hmm@s43/moe](slice_hmm@s43_moe.png)
+
+
+---
+
+## hmm@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 2.28381** (winner retrained in 0.05s, cv score of winner: 2.1272)
+- cv best RMSE: 2.1272, median: 2.1405, p10: 2.1334
+- train: median 0.044s/fold, mean 0.049s, p90 0.062s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.570 |
+| `max_depth` | 0.137 |
+| `learning_rate` | 0.090 |
+| `min_data_in_leaf` | 0.088 |
+| `bagging_fraction` | 0.054 |
+| `feature_fraction` | 0.041 |
+| `num_leaves` | 0.018 |
+| `bagging_freq` | 0.002 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 468 | 2.1429 | 0.0124 | 2.1272 |
+| False | 32 | 2.1808 | 0.0224 | 2.1570 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.1483 | 2.1404 | 2.1433 | 2.1493 | **Q2** [0.0373, 0.044] |
+| `num_leaves` | 2.1502 | 2.1440 | 2.1426 | 2.1448 | **Q3** [105.0, 113.0] |
+| `max_depth` | — | — | — | 2.1453 | **Q4** [3.0, ∞) |
+| `min_data_in_leaf` | 2.1381 | 2.1425 | 2.1448 | 2.1551 | **Q1** [None, 6.0] |
+| `lambda_l1` | 2.1476 | 2.1440 | 2.1446 | 2.1450 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 2.1432 | 2.1439 | 2.1436 | 2.1506 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.1478 | 2.1417 | 2.1470 | 2.1447 | **Q2** [0.7242, 0.753] |
+| `bagging_fraction` | 2.1528 | 2.1417 | 2.1425 | 2.1442 | **Q2** [0.8804, 0.9196] |
+
+#### E. Slice plot
+
+![hmm@s44/naive-lightgbm](slice_hmm@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 2.30703** (winner retrained in 0.45s, cv score of winner: 2.1265)
+- cv best RMSE: 2.1265, median: 2.1455, p10: 2.1365
+- train: median 0.493s/fold, mean 0.556s, p90 0.606s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_init` | 0.383 |
+| `learning_rate` | 0.197 |
+| `bagging_fraction` | 0.079 |
+| `mixture_expert_dropout_rate` | 0.049 |
+| `num_leaves` | 0.048 |
+| `mixture_load_balance_alpha` | 0.048 |
+| `mixture_diversity_lambda` | 0.034 |
+| `mixture_warmup_iters` | 0.034 |
+| `bagging_freq` | 0.029 |
+| `min_data_in_leaf` | 0.024 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 2.1579 (n=468) | token_choice | Δ +0.0264 | p=8.45e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 435 | 2.1565 | 0.0352 | 2.1265 |
+| leaf_reuse | 40 | 2.1683 | 0.0432 | 2.1352 |
+| none | 25 | 2.1999 | 0.0673 | 2.1428 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 468 | 2.1579 | 0.0378 | 2.1265 |
+| token_choice | 32 | 2.1843 | 0.0517 | 2.1406 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 153 | 2.1559 | 0.0381 | 2.1265 |
+| em | 288 | 2.1598 | 0.0375 | 2.1321 |
+| loss_only | 59 | 2.1681 | 0.0486 | 2.1379 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 82 | 2.1494 | 0.0279 | 2.1265 |
+| random | 349 | 2.1528 | 0.0280 | 2.1315 |
+| kmeans_features | 18 | 2.1766 | 0.0403 | 2.1455 |
+| gmm_features | 17 | 2.1883 | 0.0466 | 2.1455 |
+| gmm | 17 | 2.2276 | 0.0749 | 2.1496 |
+| tree_hierarchical | 17 | 2.2329 | 0.0600 | 2.1465 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 278 | 2.1572 | 0.0335 | 2.1321 |
+| none | 194 | 2.1593 | 0.0425 | 2.1265 |
+| ema | 28 | 2.1860 | 0.0567 | 2.1403 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 170 | 2.1556 | 0.0351 | 2.1265 |
+| False | 330 | 2.1617 | 0.0412 | 2.1354 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 469 | 2.1568 | 0.0378 | 2.1265 |
+| False | 31 | 2.2021 | 0.0367 | 2.1623 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 2.1848 | — | — | 2.1575 | **Q4** [5.0, ∞) |
+| `mixture_diversity_lambda` | 2.1544 | 2.1588 | 2.1658 | 2.1594 | **Q1** [None, 0.0499] |
+| `mixture_warmup_iters` | 2.1533 | 2.1623 | 2.1551 | 2.1646 | **Q1** [None, 11.0] |
+| `mixture_balance_factor` | 2.1753 | 2.1562 | — | 2.1565 | **Q2** [6.0, 7.0] |
+| `learning_rate` | 2.1760 | 2.1534 | 2.1581 | 2.1510 | **Q4** [0.2021, ∞) |
+| `num_leaves` | 2.1589 | 2.1548 | 2.1522 | 2.1730 | **Q3** [50.0, 72.25] |
+| `max_depth` | 2.1688 | 2.1512 | 2.1640 | 2.1589 | **Q2** [7.0, 8.0] |
+| `min_data_in_leaf` | 2.1598 | 2.1575 | 2.1562 | 2.1641 | **Q3** [63.0, 68.0] |
+
+#### E. Slice plot
+
+![hmm@s44/moe](slice_hmm@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| hmm@s42 | `mixture_gate_type` | **gbdt** | +0.0526 | 0.00e+00 |
+| hmm@s42 | `mixture_init` | **tree_hierarchical** | +0.0384 | 4.00e-05 |
+| hmm@s42 | `mixture_r_smoothing` | **markov** | +0.0180 | 1.45e-03 |
+| hmm@s43 | `mixture_gate_type` | **gbdt** | +0.0142 | 1.80e-05 |
+| hmm@s44 | `mixture_routing_mode` | **expert_choice** | +0.0264 | 8.45e-03 |

--- a/bench_results/wide_v081/ds_hmm_summary.json
+++ b/bench_results/wide_v081/ds_hmm_summary.json
@@ -1,0 +1,2795 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "hmm"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "hmm": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.888342906785671,
+      "cv_best": 2.2991586479654282,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0539
+     },
+     "43": {
+      "holdout_rmse": 2.4754259707929074,
+      "cv_best": 2.378092221443367,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0829
+     },
+     "44": {
+      "holdout_rmse": 2.2838051335628475,
+      "cv_best": 2.1271534647717236,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0525
+     }
+    },
+    "holdout_mean": 2.215858,
+    "holdout_std": 0.244444,
+    "cv_best_mean": 2.268135
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.9517406688269165,
+      "cv_best": 2.2708004745954296,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4262
+     },
+     "43": {
+      "holdout_rmse": 2.506465690894265,
+      "cv_best": 2.327065980049187,
+      "crash_rate": 0.0,
+      "retrain_s": 6.3001
+     },
+     "44": {
+      "holdout_rmse": 2.307028723992136,
+      "cv_best": 2.1264727059024153,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4534
+     }
+    },
+    "holdout_mean": 2.255078,
+    "holdout_std": 0.229426,
+    "cv_best_mean": 2.241446
+   }
+  }
+ },
+ "runs": {
+  "hmm@s42": {
+   "dataset": "hmm",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.045793656680186444,
+    "std": 2.4137364484700643
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.2991586479654282,
+    "rmse_p10": 2.307848174431704,
+    "rmse_median": 2.314351449781726,
+    "train_s_median": 0.034535938315093516,
+    "train_s_mean": 0.03589634808748961,
+    "train_s_p90": 0.042158241271972666,
+    "best_params": {
+     "learning_rate": 0.09493440081364529,
+     "num_leaves": 125,
+     "max_depth": 5,
+     "min_data_in_leaf": 41,
+     "lambda_l1": 0.7722375890086123,
+     "lambda_l2": 1.9149345992899975,
+     "feature_fraction": 0.8426373035251148,
+     "bagging_fraction": 0.9850867005699576,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.4417,
+     "learning_rate": 0.3051,
+     "min_data_in_leaf": 0.1225,
+     "max_depth": 0.0482,
+     "feature_fraction": 0.0281,
+     "bagging_fraction": 0.0232,
+     "num_leaves": 0.0206,
+     "lambda_l1": 0.0071,
+     "bagging_freq": 0.0027,
+     "lambda_l2": 0.0007
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 470,
+        "mean": 2.3166,
+        "std": 0.0122,
+        "min": 2.2992
+       },
+       "False": {
+        "n": 30,
+        "mean": 2.3478,
+        "std": 0.0201,
+        "min": 2.3261
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0312,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0617
+       ],
+       "n": 125,
+       "mean_rmse": 2.3224
+      },
+      "Q2": {
+       "range": [
+        0.0617,
+        0.0706
+       ],
+       "n": 125,
+       "mean_rmse": 2.3143
+      },
+      "Q3": {
+       "range": [
+        0.0706,
+        0.0825
+       ],
+       "n": 125,
+       "mean_rmse": 2.3155
+      },
+      "Q4": {
+       "range": [
+        0.0825,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3215
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        62.0
+       ],
+       "n": 116,
+       "mean_rmse": 2.319
+      },
+      "Q2": {
+       "range": [
+        62.0,
+        107.0
+       ],
+       "n": 133,
+       "mean_rmse": 2.3188
+      },
+      "Q3": {
+       "range": [
+        107.0,
+        120.0
+       ],
+       "n": 122,
+       "mean_rmse": 2.3181
+      },
+      "Q4": {
+       "range": [
+        120.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 2.3179
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 374,
+       "mean_rmse": 2.316
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 2.3256
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        25.0
+       ],
+       "n": 99,
+       "mean_rmse": 2.3202
+      },
+      "Q2": {
+       "range": [
+        25.0,
+        30.0
+       ],
+       "n": 143,
+       "mean_rmse": 2.3156
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        34.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.3152
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 145,
+       "mean_rmse": 2.3225
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.5516
+       ],
+       "n": 125,
+       "mean_rmse": 2.326
+      },
+      "Q2": {
+       "range": [
+        0.5516,
+        1.6462
+       ],
+       "n": 125,
+       "mean_rmse": 2.3163
+      },
+      "Q3": {
+       "range": [
+        1.6462,
+        3.6754
+       ],
+       "n": 125,
+       "mean_rmse": 2.3157
+      },
+      "Q4": {
+       "range": [
+        3.6754,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3159
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0003
+       ],
+       "n": 125,
+       "mean_rmse": 2.3202
+      },
+      "Q2": {
+       "range": [
+        0.0003,
+        0.0277
+       ],
+       "n": 125,
+       "mean_rmse": 2.3191
+      },
+      "Q3": {
+       "range": [
+        0.0277,
+        0.2475
+       ],
+       "n": 125,
+       "mean_rmse": 2.3168
+      },
+      "Q4": {
+       "range": [
+        0.2475,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3177
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8583
+       ],
+       "n": 125,
+       "mean_rmse": 2.3243
+      },
+      "Q2": {
+       "range": [
+        0.8583,
+        0.9027
+       ],
+       "n": 125,
+       "mean_rmse": 2.3177
+      },
+      "Q3": {
+       "range": [
+        0.9027,
+        0.9273
+       ],
+       "n": 125,
+       "mean_rmse": 2.3141
+      },
+      "Q4": {
+       "range": [
+        0.9273,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3177
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.905
+       ],
+       "n": 125,
+       "mean_rmse": 2.3256
+      },
+      "Q2": {
+       "range": [
+        0.905,
+        0.9369
+       ],
+       "n": 125,
+       "mean_rmse": 2.3181
+      },
+      "Q3": {
+       "range": [
+        0.9369,
+        0.9666
+       ],
+       "n": 125,
+       "mean_rmse": 2.3146
+      },
+      "Q4": {
+       "range": [
+        0.9666,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3154
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 101.0,
+    "holdout": {
+     "holdout_rmse": 1.888342906785671,
+     "retrain_s": 0.0539,
+     "predict_s": 0.0004,
+     "cv_rmse_of_winner": 2.2991586479654282
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.2708004745954296,
+    "rmse_p10": 2.284654698188826,
+    "rmse_median": 2.3161365637566393,
+    "train_s_median": 0.24311415757983923,
+    "train_s_mean": 0.2923812007561326,
+    "train_s_p90": 0.3841160487383604,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.13651758410242731,
+     "num_leaves": 117,
+     "max_depth": 6,
+     "min_data_in_leaf": 38,
+     "lambda_l1": 0.08546727029026738,
+     "lambda_l2": 3.48838358362373e-06,
+     "feature_fraction": 0.7387098551122194,
+     "bagging_fraction": 0.7260162894464749,
+     "bagging_freq": 7,
+     "extra_trees": true,
+     "mixture_init": "tree_hierarchical",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 48,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.6905274816385084,
+     "mixture_diversity_lambda": 0.1814196042272162,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.020608850836608197,
+     "mixture_load_balance_alpha": 0.3146599093311057,
+     "mixture_gate_max_depth": 5,
+     "mixture_gate_num_leaves": 40,
+     "mixture_gate_learning_rate": 0.17609823545767145,
+     "mixture_gate_lambda_l2": 9.972822111747114,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_entropy_lambda": 0.13604080132644994,
+     "mixture_gate_temperature_init": 1.2922130077751381,
+     "gate_temp_final_ratio": 0.35970559441207334,
+     "mixture_expert_capacity_factor": 0.9855738483717472,
+     "mixture_expert_choice_boost": 15.7041711423466,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.5042,
+     "mixture_init": 0.1378,
+     "mixture_expert_dropout_rate": 0.0411,
+     "learning_rate": 0.0411,
+     "mixture_hard_m_step": 0.0311,
+     "mixture_diversity_lambda": 0.0293,
+     "mixture_load_balance_alpha": 0.0289,
+     "feature_fraction": 0.027,
+     "min_data_in_leaf": 0.0229,
+     "bagging_fraction": 0.0205,
+     "extra_trees": 0.0194,
+     "num_leaves": 0.0173,
+     "mixture_warmup_iters": 0.0149,
+     "mixture_routing_mode": 0.0143,
+     "bagging_freq": 0.012,
+     "mixture_num_experts": 0.0116,
+     "max_depth": 0.0078,
+     "lambda_l2": 0.0053,
+     "mixture_r_smoothing": 0.004,
+     "mixture_e_step_mode": 0.0034,
+     "lambda_l1": 0.0027,
+     "mixture_balance_factor": 0.0023,
+     "mixture_refit_leaves": 0.001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 39,
+        "mean": 2.371,
+        "std": 0.0332,
+        "min": 2.324
+       },
+       "none": {
+        "n": 40,
+        "mean": 2.393,
+        "std": 0.0516,
+        "min": 2.3315
+       },
+       "gbdt": {
+        "n": 421,
+        "mean": 2.3184,
+        "std": 0.0335,
+        "min": 2.2708
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0526,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 172,
+        "mean": 2.331,
+        "std": 0.0373,
+        "min": 2.2797
+       },
+       "expert_choice": {
+        "n": 328,
+        "mean": 2.3271,
+        "std": 0.0449,
+        "min": 2.2708
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0039,
+       "p_value": 0.301696,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 94,
+        "mean": 2.3298,
+        "std": 0.0372,
+        "min": 2.2797
+       },
+       "loss_only": {
+        "n": 341,
+        "mean": 2.3227,
+        "std": 0.0424,
+        "min": 2.2708
+       },
+       "em": {
+        "n": 65,
+        "mean": 2.357,
+        "std": 0.0376,
+        "min": 2.2836
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0071,
+       "p_value": 0.112506,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 37,
+        "mean": 2.3641,
+        "std": 0.0279,
+        "min": 2.3315
+       },
+       "gmm": {
+        "n": 21,
+        "mean": 2.3741,
+        "std": 0.0289,
+        "min": 2.333
+       },
+       "random": {
+        "n": 21,
+        "mean": 2.3758,
+        "std": 0.029,
+        "min": 2.3411
+       },
+       "gmm_features": {
+        "n": 19,
+        "mean": 2.3545,
+        "std": 0.0303,
+        "min": 2.3185
+       },
+       "tree_hierarchical": {
+        "n": 384,
+        "mean": 2.3161,
+        "std": 0.0379,
+        "min": 2.2708
+       },
+       "kmeans_features": {
+        "n": 18,
+        "mean": 2.3835,
+        "std": 0.0132,
+        "min": 2.3546
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "gmm_features",
+       "delta_mean": 0.0384,
+       "p_value": 4e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 70,
+        "mean": 2.3529,
+        "std": 0.0408,
+        "min": 2.2789
+       },
+       "markov": {
+        "n": 375,
+        "mean": 2.3222,
+        "std": 0.0415,
+        "min": 2.2708
+       },
+       "none": {
+        "n": 55,
+        "mean": 2.3402,
+        "std": 0.0369,
+        "min": 2.291
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.018,
+       "p_value": 0.001454,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 436,
+        "mean": 2.3234,
+        "std": 0.0404,
+        "min": 2.2708
+       },
+       "True": {
+        "n": 64,
+        "mean": 2.363,
+        "std": 0.0398,
+        "min": 2.2783
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0396,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 464,
+        "mean": 2.3251,
+        "std": 0.0414,
+        "min": 2.2708
+       },
+       "False": {
+        "n": 36,
+        "mean": 2.3721,
+        "std": 0.0287,
+        "min": 2.3311
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.047,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 26,
+       "mean_rmse": 2.3666
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 474,
+       "mean_rmse": 2.3264
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.115
+       ],
+       "n": 125,
+       "mean_rmse": 2.329
+      },
+      "Q2": {
+       "range": [
+        0.115,
+        0.1415
+       ],
+       "n": 125,
+       "mean_rmse": 2.3159
+      },
+      "Q3": {
+       "range": [
+        0.1415,
+        0.1711
+       ],
+       "n": 125,
+       "mean_rmse": 2.327
+      },
+      "Q4": {
+       "range": [
+        0.1711,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.342
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        46.0
+       ],
+       "n": 115,
+       "mean_rmse": 2.3528
+      },
+      "Q2": {
+       "range": [
+        46.0,
+        48.0
+       ],
+       "n": 91,
+       "mean_rmse": 2.3244
+      },
+      "Q3": {
+       "range": [
+        48.0,
+        49.0
+       ],
+       "n": 88,
+       "mean_rmse": 2.3192
+      },
+      "Q4": {
+       "range": [
+        49.0,
+        null
+       ],
+       "n": 206,
+       "mean_rmse": 2.3206
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        5.0
+       ],
+       "n": 372,
+       "mean_rmse": 2.3212
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 2.3495
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0802
+       ],
+       "n": 125,
+       "mean_rmse": 2.3318
+      },
+      "Q2": {
+       "range": [
+        0.0802,
+        0.1106
+       ],
+       "n": 125,
+       "mean_rmse": 2.3261
+      },
+      "Q3": {
+       "range": [
+        0.1106,
+        0.1314
+       ],
+       "n": 125,
+       "mean_rmse": 2.3254
+      },
+      "Q4": {
+       "range": [
+        0.1314,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3305
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        103.0
+       ],
+       "n": 124,
+       "mean_rmse": 2.3448
+      },
+      "Q2": {
+       "range": [
+        103.0,
+        118.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.323
+      },
+      "Q3": {
+       "range": [
+        118.0,
+        124.0
+       ],
+       "n": 136,
+       "mean_rmse": 2.3222
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 2.3241
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 82,
+       "mean_rmse": 2.343
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 259,
+       "mean_rmse": 2.3246
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 159,
+       "mean_rmse": 2.3274
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 109,
+       "mean_rmse": 2.3383
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        41.0
+       ],
+       "n": 134,
+       "mean_rmse": 2.3267
+      },
+      "Q3": {
+       "range": [
+        41.0,
+        47.0
+       ],
+       "n": 126,
+       "mean_rmse": 2.319
+      },
+      "Q4": {
+       "range": [
+        47.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 2.3312
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 763.7,
+    "holdout": {
+     "holdout_rmse": 1.9517406688269165,
+     "retrain_s": 0.4262,
+     "predict_s": 0.0013,
+     "cv_rmse_of_winner": 2.2708004745954296
+    }
+   }
+  },
+  "hmm@s43": {
+   "dataset": "hmm",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.4217584667381496,
+    "std": 2.6151502465431355
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.378092221443367,
+    "rmse_p10": 2.3835104849177613,
+    "rmse_median": 2.3928461986627796,
+    "train_s_median": 0.05200385227799416,
+    "train_s_mean": 0.05514906472414732,
+    "train_s_p90": 0.0742715221643448,
+    "best_params": {
+     "learning_rate": 0.0596166293759171,
+     "num_leaves": 20,
+     "max_depth": 10,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 4.732904711377434,
+     "lambda_l2": 0.294713889002553,
+     "feature_fraction": 0.9756540267510739,
+     "bagging_fraction": 0.8657200733115793,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.5044,
+     "extra_trees": 0.3505,
+     "learning_rate": 0.0316,
+     "lambda_l1": 0.0296,
+     "bagging_fraction": 0.0274,
+     "num_leaves": 0.0247,
+     "feature_fraction": 0.0183,
+     "max_depth": 0.0065,
+     "bagging_freq": 0.0053,
+     "lambda_l2": 0.0017
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 468,
+        "mean": 2.3959,
+        "std": 0.0146,
+        "min": 2.3781
+       },
+       "False": {
+        "n": 32,
+        "mean": 2.4482,
+        "std": 0.029,
+        "min": 2.4035
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0523,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0537
+       ],
+       "n": 125,
+       "mean_rmse": 2.4027
+      },
+      "Q2": {
+       "range": [
+        0.0537,
+        0.0613
+       ],
+       "n": 125,
+       "mean_rmse": 2.3943
+      },
+      "Q3": {
+       "range": [
+        0.0613,
+        0.0738
+       ],
+       "n": 125,
+       "mean_rmse": 2.3958
+      },
+      "Q4": {
+       "range": [
+        0.0738,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.404
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.3947
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        29.0
+       ],
+       "n": 124,
+       "mean_rmse": 2.3997
+      },
+      "Q3": {
+       "range": [
+        29.0,
+        68.25
+       ],
+       "n": 128,
+       "mean_rmse": 2.4003
+      },
+      "Q4": {
+       "range": [
+        68.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.402
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.4045
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        8.5
+       ],
+       "n": 171,
+       "mean_rmse": 2.3962
+      },
+      "Q3": {
+       "range": [
+        8.5,
+        10.0
+       ],
+       "n": 109,
+       "mean_rmse": 2.3971
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 141,
+       "mean_rmse": 2.4015
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 73,
+       "mean_rmse": 2.3981
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 176,
+       "mean_rmse": 2.3936
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        16.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.3944
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 2.4122
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        1.1312
+       ],
+       "n": 125,
+       "mean_rmse": 2.4082
+      },
+      "Q2": {
+       "range": [
+        1.1312,
+        2.6671
+       ],
+       "n": 125,
+       "mean_rmse": 2.3971
+      },
+      "Q3": {
+       "range": [
+        2.6671,
+        4.7197
+       ],
+       "n": 125,
+       "mean_rmse": 2.395
+      },
+      "Q4": {
+       "range": [
+        4.7197,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3965
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0667
+       ],
+       "n": 125,
+       "mean_rmse": 2.4061
+      },
+      "Q2": {
+       "range": [
+        0.0667,
+        0.3291
+       ],
+       "n": 125,
+       "mean_rmse": 2.3972
+      },
+      "Q3": {
+       "range": [
+        0.3291,
+        1.0941
+       ],
+       "n": 125,
+       "mean_rmse": 2.3967
+      },
+      "Q4": {
+       "range": [
+        1.0941,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3968
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9326
+       ],
+       "n": 125,
+       "mean_rmse": 2.4091
+      },
+      "Q2": {
+       "range": [
+        0.9326,
+        0.9616
+       ],
+       "n": 125,
+       "mean_rmse": 2.3965
+      },
+      "Q3": {
+       "range": [
+        0.9616,
+        0.9791
+       ],
+       "n": 125,
+       "mean_rmse": 2.3965
+      },
+      "Q4": {
+       "range": [
+        0.9791,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3947
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8524
+       ],
+       "n": 125,
+       "mean_rmse": 2.4064
+      },
+      "Q2": {
+       "range": [
+        0.8524,
+        0.8822
+       ],
+       "n": 125,
+       "mean_rmse": 2.3977
+      },
+      "Q3": {
+       "range": [
+        0.8822,
+        0.9203
+       ],
+       "n": 125,
+       "mean_rmse": 2.3948
+      },
+      "Q4": {
+       "range": [
+        0.9203,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.3979
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 150.0,
+    "holdout": {
+     "holdout_rmse": 2.4754259707929074,
+     "retrain_s": 0.0829,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 2.378092221443367
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.327065980049187,
+    "rmse_p10": 2.356721299198962,
+    "rmse_median": 2.3815870444735454,
+    "train_s_median": 0.35976736787706615,
+    "train_s_mean": 1.7415947631016375,
+    "train_s_p90": 4.396589683778584,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 6,
+     "learning_rate": 0.08142527545974222,
+     "num_leaves": 30,
+     "max_depth": 11,
+     "min_data_in_leaf": 40,
+     "lambda_l1": 0.0020241262362768447,
+     "lambda_l2": 0.0001947080828122125,
+     "feature_fraction": 0.95084762920045,
+     "bagging_fraction": 0.9225690099742202,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "gmm_features",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 11,
+     "mixture_balance_factor": 6,
+     "mixture_smoothing_lambda": 0.869669552673553,
+     "mixture_diversity_lambda": 0.12149185915211719,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.19528566765185348,
+     "mixture_load_balance_alpha": 0.17116589714482086,
+     "mixture_gate_max_depth": 10,
+     "mixture_gate_num_leaves": 6,
+     "mixture_gate_learning_rate": 0.08378588184727058,
+     "mixture_gate_lambda_l2": 2.4705901197988167,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_entropy_lambda": 0.19794888085829734,
+     "mixture_gate_temperature_init": 2.3458450047225465,
+     "gate_temp_final_ratio": 0.30114024377268,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.442022057717567,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_init": 0.2945,
+     "feature_fraction": 0.197,
+     "learning_rate": 0.0776,
+     "min_data_in_leaf": 0.0717,
+     "mixture_balance_factor": 0.0668,
+     "mixture_warmup_iters": 0.0557,
+     "mixture_expert_dropout_rate": 0.0431,
+     "extra_trees": 0.0375,
+     "bagging_freq": 0.0242,
+     "mixture_diversity_lambda": 0.0235,
+     "bagging_fraction": 0.0222,
+     "mixture_gate_type": 0.0157,
+     "mixture_load_balance_alpha": 0.0135,
+     "max_depth": 0.0108,
+     "mixture_refit_leaves": 0.0107,
+     "mixture_num_experts": 0.0094,
+     "num_leaves": 0.0081,
+     "mixture_r_smoothing": 0.0075,
+     "mixture_hard_m_step": 0.0053,
+     "mixture_routing_mode": 0.0037,
+     "mixture_e_step_mode": 0.0016,
+     "lambda_l1": 0.0,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 189,
+        "mean": 2.3811,
+        "std": 0.0319,
+        "min": 2.3271
+       },
+       "leaf_reuse": {
+        "n": 23,
+        "mean": 2.4369,
+        "std": 0.0763,
+        "min": 2.3716
+       },
+       "none": {
+        "n": 288,
+        "mean": 2.3953,
+        "std": 0.0393,
+        "min": 2.3449
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "none",
+       "delta_mean": 0.0142,
+       "p_value": 1.8e-05,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 142,
+        "mean": 2.3919,
+        "std": 0.0547,
+        "min": 2.3318
+       },
+       "token_choice": {
+        "n": 358,
+        "mean": 2.3918,
+        "std": 0.0342,
+        "min": 2.3271
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0001,
+       "p_value": 0.980209,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 188,
+        "mean": 2.3864,
+        "std": 0.0455,
+        "min": 2.3271
+       },
+       "gate_only": {
+        "n": 29,
+        "mean": 2.3943,
+        "std": 0.0382,
+        "min": 2.3354
+       },
+       "em": {
+        "n": 283,
+        "mean": 2.3952,
+        "std": 0.0377,
+        "min": 2.3487
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.0079,
+       "p_value": 0.326534,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 18,
+        "mean": 2.4635,
+        "std": 0.0582,
+        "min": 2.395
+       },
+       "tree_hierarchical": {
+        "n": 18,
+        "mean": 2.4715,
+        "std": 0.0738,
+        "min": 2.3676
+       },
+       "uniform": {
+        "n": 152,
+        "mean": 2.388,
+        "std": 0.0196,
+        "min": 2.3607
+       },
+       "kmeans_features": {
+        "n": 17,
+        "mean": 2.4069,
+        "std": 0.0349,
+        "min": 2.371
+       },
+       "gmm_features": {
+        "n": 277,
+        "mean": 2.3827,
+        "std": 0.036,
+        "min": 2.3271
+       },
+       "random": {
+        "n": 18,
+        "mean": 2.4,
+        "std": 0.0224,
+        "min": 2.3716
+       }
+      },
+      "best": {
+       "value": "gmm_features",
+       "runner_up": "uniform",
+       "delta_mean": 0.0053,
+       "p_value": 0.050295,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 36,
+        "mean": 2.4124,
+        "std": 0.0561,
+        "min": 2.3727
+       },
+       "none": {
+        "n": 92,
+        "mean": 2.3895,
+        "std": 0.0473,
+        "min": 2.3354
+       },
+       "markov": {
+        "n": 372,
+        "mean": 2.3904,
+        "std": 0.037,
+        "min": 2.3271
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.0009,
+       "p_value": 0.85458,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 334,
+        "mean": 2.3929,
+        "std": 0.0405,
+        "min": 2.3271
+       },
+       "True": {
+        "n": 166,
+        "mean": 2.3897,
+        "std": 0.0422,
+        "min": 2.3318
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0032,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 460,
+        "mean": 2.3879,
+        "std": 0.0349,
+        "min": 2.3271
+       },
+       "True": {
+        "n": 40,
+        "mean": 2.4375,
+        "std": 0.0694,
+        "min": 2.3462
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0496,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 52,
+       "mean_rmse": 2.4339
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 448,
+       "mean_rmse": 2.387
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1223
+       ],
+       "n": 125,
+       "mean_rmse": 2.3773
+      },
+      "Q2": {
+       "range": [
+        0.1223,
+        0.283
+       ],
+       "n": 125,
+       "mean_rmse": 2.3946
+      },
+      "Q3": {
+       "range": [
+        0.283,
+        0.336
+       ],
+       "n": 125,
+       "mean_rmse": 2.3926
+      },
+      "Q4": {
+       "range": [
+        0.336,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.4028
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 117,
+       "mean_rmse": 2.3784
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        37.0
+       ],
+       "n": 129,
+       "mean_rmse": 2.398
+      },
+      "Q3": {
+       "range": [
+        37.0,
+        42.0
+       ],
+       "n": 112,
+       "mean_rmse": 2.3908
+      },
+      "Q4": {
+       "range": [
+        42.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 2.3981
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 37,
+       "mean_rmse": 2.4092
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 101,
+       "mean_rmse": 2.3822
+      },
+      "Q3": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.384
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 242,
+       "mean_rmse": 2.3971
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0463
+       ],
+       "n": 125,
+       "mean_rmse": 2.4011
+      },
+      "Q2": {
+       "range": [
+        0.0463,
+        0.0661
+       ],
+       "n": 125,
+       "mean_rmse": 2.3933
+      },
+      "Q3": {
+       "range": [
+        0.0661,
+        0.1146
+       ],
+       "n": 125,
+       "mean_rmse": 2.3849
+      },
+      "Q4": {
+       "range": [
+        0.1146,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.388
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 114,
+       "mean_rmse": 2.3901
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        25.0
+       ],
+       "n": 122,
+       "mean_rmse": 2.3816
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        66.5
+       ],
+       "n": 139,
+       "mean_rmse": 2.3912
+      },
+      "Q4": {
+       "range": [
+        66.5,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.4041
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 118,
+       "mean_rmse": 2.3942
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        9.0
+       ],
+       "n": 72,
+       "mean_rmse": 2.4148
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 155,
+       "mean_rmse": 2.3814
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 155,
+       "mean_rmse": 2.3898
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        34.0
+       ],
+       "n": 111,
+       "mean_rmse": 2.3938
+      },
+      "Q2": {
+       "range": [
+        34.0,
+        40.0
+       ],
+       "n": 135,
+       "mean_rmse": 2.3835
+      },
+      "Q3": {
+       "range": [
+        40.0,
+        45.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.3818
+      },
+      "Q4": {
+       "range": [
+        45.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 2.4076
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 4383.9,
+    "holdout": {
+     "holdout_rmse": 2.506465690894265,
+     "retrain_s": 6.3001,
+     "predict_s": 0.0024,
+     "cv_rmse_of_winner": 2.327065980049187
+    }
+   }
+  },
+  "hmm@s44": {
+   "dataset": "hmm",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": 0.3382988881406865,
+    "std": 2.4175724001792345
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.1271534647717236,
+    "rmse_p10": 2.133395948134742,
+    "rmse_median": 2.1404944389293643,
+    "train_s_median": 0.04428222514688969,
+    "train_s_mean": 0.04880614392980933,
+    "train_s_p90": 0.062134178914129735,
+    "best_params": {
+     "learning_rate": 0.037392144771270085,
+     "num_leaves": 105,
+     "max_depth": 3,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0005110469168765049,
+     "lambda_l2": 1.820163089970785e-08,
+     "feature_fraction": 0.9606712560072594,
+     "bagging_fraction": 0.8848707151635273,
+     "bagging_freq": 7,
+     "extra_trees": true
+    },
+    "importance": {
+     "extra_trees": 0.5698,
+     "max_depth": 0.1367,
+     "learning_rate": 0.0903,
+     "min_data_in_leaf": 0.0881,
+     "bagging_fraction": 0.054,
+     "feature_fraction": 0.0405,
+     "num_leaves": 0.018,
+     "bagging_freq": 0.0022,
+     "lambda_l2": 0.0002,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 32,
+        "mean": 2.1808,
+        "std": 0.0224,
+        "min": 2.157
+       },
+       "True": {
+        "n": 468,
+        "mean": 2.1429,
+        "std": 0.0124,
+        "min": 2.1272
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0379,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0373
+       ],
+       "n": 125,
+       "mean_rmse": 2.1483
+      },
+      "Q2": {
+       "range": [
+        0.0373,
+        0.044
+       ],
+       "n": 125,
+       "mean_rmse": 2.1404
+      },
+      "Q3": {
+       "range": [
+        0.044,
+        0.053
+       ],
+       "n": 125,
+       "mean_rmse": 2.1433
+      },
+      "Q4": {
+       "range": [
+        0.053,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1493
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        94.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.1502
+      },
+      "Q2": {
+       "range": [
+        94.0,
+        105.0
+       ],
+       "n": 114,
+       "mean_rmse": 2.144
+      },
+      "Q3": {
+       "range": [
+        105.0,
+        113.0
+       ],
+       "n": 139,
+       "mean_rmse": 2.1426
+      },
+      "Q4": {
+       "range": [
+        113.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 2.1448
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 500,
+       "mean_rmse": 2.1453
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.1381
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.1425
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 134,
+       "mean_rmse": 2.1448
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 2.1551
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.1476
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.144
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0008
+       ],
+       "n": 125,
+       "mean_rmse": 2.1446
+      },
+      "Q4": {
+       "range": [
+        0.0008,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.145
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.1432
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 2.1439
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0014
+       ],
+       "n": 125,
+       "mean_rmse": 2.1436
+      },
+      "Q4": {
+       "range": [
+        0.0014,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1506
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7242
+       ],
+       "n": 125,
+       "mean_rmse": 2.1478
+      },
+      "Q2": {
+       "range": [
+        0.7242,
+        0.753
+       ],
+       "n": 125,
+       "mean_rmse": 2.1417
+      },
+      "Q3": {
+       "range": [
+        0.753,
+        0.8899
+       ],
+       "n": 125,
+       "mean_rmse": 2.147
+      },
+      "Q4": {
+       "range": [
+        0.8899,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1447
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8804
+       ],
+       "n": 125,
+       "mean_rmse": 2.1528
+      },
+      "Q2": {
+       "range": [
+        0.8804,
+        0.9196
+       ],
+       "n": 125,
+       "mean_rmse": 2.1417
+      },
+      "Q3": {
+       "range": [
+        0.9196,
+        0.9497
+       ],
+       "n": 125,
+       "mean_rmse": 2.1425
+      },
+      "Q4": {
+       "range": [
+        0.9497,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1442
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 134.1,
+    "holdout": {
+     "holdout_rmse": 2.2838051335628475,
+     "retrain_s": 0.0525,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.1271534647717236
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.1264727059024153,
+    "rmse_p10": 2.1365408696315207,
+    "rmse_median": 2.1455215711140556,
+    "train_s_median": 0.4932110980153084,
+    "train_s_mean": 0.5560662543006242,
+    "train_s_p90": 0.6062613102048635,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 5,
+     "learning_rate": 0.27029841765329576,
+     "num_leaves": 67,
+     "max_depth": 10,
+     "min_data_in_leaf": 44,
+     "lambda_l1": 3.5392870755163505e-08,
+     "lambda_l2": 1.1076850707650216e-06,
+     "feature_fraction": 0.6613530061362637,
+     "bagging_fraction": 0.6314737353939329,
+     "bagging_freq": 2,
+     "extra_trees": true,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 5,
+     "mixture_balance_factor": 7,
+     "mixture_diversity_lambda": 0.36414651066167025,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.08584499807627002,
+     "mixture_load_balance_alpha": 0.1650437712161654,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 27,
+     "mixture_gate_learning_rate": 0.032653346817998606,
+     "mixture_gate_lambda_l2": 1.3296470167559145,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_entropy_lambda": 0.25330533781631603,
+     "mixture_gate_temperature_init": 0.8430598942235095,
+     "gate_temp_final_ratio": 0.8996936605285469,
+     "mixture_expert_capacity_factor": 1.2078092530613929,
+     "mixture_expert_choice_boost": 9.00010385002612,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_init": 0.3831,
+     "learning_rate": 0.1967,
+     "bagging_fraction": 0.079,
+     "mixture_expert_dropout_rate": 0.0493,
+     "num_leaves": 0.0475,
+     "mixture_load_balance_alpha": 0.0475,
+     "mixture_diversity_lambda": 0.0343,
+     "mixture_warmup_iters": 0.0339,
+     "bagging_freq": 0.0287,
+     "min_data_in_leaf": 0.0243,
+     "mixture_gate_type": 0.0171,
+     "feature_fraction": 0.0131,
+     "extra_trees": 0.0128,
+     "max_depth": 0.0097,
+     "mixture_r_smoothing": 0.006,
+     "mixture_num_experts": 0.0053,
+     "mixture_balance_factor": 0.0039,
+     "mixture_routing_mode": 0.0025,
+     "mixture_e_step_mode": 0.0017,
+     "mixture_hard_m_step": 0.0014,
+     "mixture_refit_leaves": 0.0011,
+     "lambda_l2": 0.0009,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 435,
+        "mean": 2.1565,
+        "std": 0.0352,
+        "min": 2.1265
+       },
+       "none": {
+        "n": 25,
+        "mean": 2.1999,
+        "std": 0.0673,
+        "min": 2.1428
+       },
+       "leaf_reuse": {
+        "n": 40,
+        "mean": 2.1683,
+        "std": 0.0432,
+        "min": 2.1352
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0118,
+       "p_value": 0.103693,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 32,
+        "mean": 2.1843,
+        "std": 0.0517,
+        "min": 2.1406
+       },
+       "expert_choice": {
+        "n": 468,
+        "mean": 2.1579,
+        "std": 0.0378,
+        "min": 2.1265
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.0264,
+       "p_value": 0.008449,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 288,
+        "mean": 2.1598,
+        "std": 0.0375,
+        "min": 2.1321
+       },
+       "gate_only": {
+        "n": 153,
+        "mean": 2.1559,
+        "std": 0.0381,
+        "min": 2.1265
+       },
+       "loss_only": {
+        "n": 59,
+        "mean": 2.1681,
+        "std": 0.0486,
+        "min": 2.1379
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0039,
+       "p_value": 0.307666,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 18,
+        "mean": 2.1766,
+        "std": 0.0403,
+        "min": 2.1455
+       },
+       "tree_hierarchical": {
+        "n": 17,
+        "mean": 2.2329,
+        "std": 0.06,
+        "min": 2.1465
+       },
+       "random": {
+        "n": 349,
+        "mean": 2.1528,
+        "std": 0.028,
+        "min": 2.1315
+       },
+       "gmm": {
+        "n": 17,
+        "mean": 2.2276,
+        "std": 0.0749,
+        "min": 2.1496
+       },
+       "gmm_features": {
+        "n": 17,
+        "mean": 2.1883,
+        "std": 0.0466,
+        "min": 2.1455
+       },
+       "uniform": {
+        "n": 82,
+        "mean": 2.1494,
+        "std": 0.0279,
+        "min": 2.1265
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "random",
+       "delta_mean": 0.0034,
+       "p_value": 0.326879,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 194,
+        "mean": 2.1593,
+        "std": 0.0425,
+        "min": 2.1265
+       },
+       "ema": {
+        "n": 28,
+        "mean": 2.186,
+        "std": 0.0567,
+        "min": 2.1403
+       },
+       "markov": {
+        "n": 278,
+        "mean": 2.1572,
+        "std": 0.0335,
+        "min": 2.1321
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.0021,
+       "p_value": 0.557107,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 330,
+        "mean": 2.1617,
+        "std": 0.0412,
+        "min": 2.1354
+       },
+       "True": {
+        "n": 170,
+        "mean": 2.1556,
+        "std": 0.0351,
+        "min": 2.1265
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0061,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 469,
+        "mean": 2.1568,
+        "std": 0.0378,
+        "min": 2.1265
+       },
+       "False": {
+        "n": 31,
+        "mean": 2.2021,
+        "std": 0.0367,
+        "min": 2.1623
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.0453,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 38,
+       "mean_rmse": 2.1848
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 462,
+       "mean_rmse": 2.1575
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0499
+       ],
+       "n": 125,
+       "mean_rmse": 2.1544
+      },
+      "Q2": {
+       "range": [
+        0.0499,
+        0.0817
+       ],
+       "n": 125,
+       "mean_rmse": 2.1588
+      },
+      "Q3": {
+       "range": [
+        0.0817,
+        0.2743
+       ],
+       "n": 125,
+       "mean_rmse": 2.1658
+      },
+      "Q4": {
+       "range": [
+        0.2743,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.1594
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 112,
+       "mean_rmse": 2.1533
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        24.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.1623
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        27.0
+       ],
+       "n": 101,
+       "mean_rmse": 2.1551
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 164,
+       "mean_rmse": 2.1646
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 84,
+       "mean_rmse": 2.1753
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 141,
+       "mean_rmse": 2.1562
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 275,
+       "mean_rmse": 2.1565
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1282
+       ],
+       "n": 125,
+       "mean_rmse": 2.176
+      },
+      "Q2": {
+       "range": [
+        0.1282,
+        0.1534
+       ],
+       "n": 125,
+       "mean_rmse": 2.1534
+      },
+      "Q3": {
+       "range": [
+        0.1534,
+        0.2021
+       ],
+       "n": 125,
+       "mean_rmse": 2.1581
+      },
+      "Q4": {
+       "range": [
+        0.2021,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.151
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        35.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.1589
+      },
+      "Q2": {
+       "range": [
+        35.0,
+        50.0
+       ],
+       "n": 134,
+       "mean_rmse": 2.1548
+      },
+      "Q3": {
+       "range": [
+        50.0,
+        72.25
+       ],
+       "n": 128,
+       "mean_rmse": 2.1522
+      },
+      "Q4": {
+       "range": [
+        72.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.173
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 78,
+       "mean_rmse": 2.1688
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 122,
+       "mean_rmse": 2.1512
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 100,
+       "mean_rmse": 2.164
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 200,
+       "mean_rmse": 2.1589
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        52.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.1598
+      },
+      "Q2": {
+       "range": [
+        52.0,
+        63.0
+       ],
+       "n": 126,
+       "mean_rmse": 2.1575
+      },
+      "Q3": {
+       "range": [
+        63.0,
+        68.0
+       ],
+       "n": 115,
+       "mean_rmse": 2.1562
+      },
+      "Q4": {
+       "range": [
+        68.0,
+        null
+       ],
+       "n": 139,
+       "mean_rmse": 2.1641
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1428.6,
+    "holdout": {
+     "holdout_rmse": 2.307028723992136,
+     "retrain_s": 0.4534,
+     "predict_s": 0.003,
+     "cv_rmse_of_winner": 2.1264727059024153
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_houses_ensemble_report.md
+++ b/bench_results/wide_v081/ds_houses_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['houses'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `4e208d83bace`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| houses | naive-ensemble | **48816.10629** ± 1005.30253 | 50343.50687 | 0.0% | 0.82 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| houses@s42 | naive-ensemble | 50578.9081 | 50951.9468 | 0.698 | 1632 |
+| houses@s43 | naive-ensemble | 50306.1130 | 50702.0156 | 0.728 | 1746 |
+| houses@s44 | naive-ensemble | 50145.4995 | 50954.3367 | 0.474 | 1289 |
+
+
+
+---
+
+## houses@s42  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 50074.59416** (winner retrained in 1.06s, cv score of winner: 50578.9081)
+- cv best RMSE: 50578.9081, median: 50951.9468, p10: 50717.1793
+- train: median 0.698s/fold, mean 0.649s, p90 0.834s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.508 |
+| `extra_trees` | 0.424 |
+| `min_data_in_leaf` | 0.032 |
+| `feature_fraction` | 0.019 |
+| `num_leaves` | 0.009 |
+| `max_depth` | 0.005 |
+| `bagging_freq` | 0.002 |
+| `bagging_fraction` | 0.001 |
+| `n_models` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 51594.7709 | 2643.8710 | 50578.9081 |
+| True | 30 | 63778.4860 | 6109.2892 | 55924.7269 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54204.7761 | 51750.1474 | 51377.5294 | 51970.7223 | **Q3** [0.0831, 0.0948] |
+| `num_leaves` | 53042.0465 | 51689.8978 | 51846.7040 | 52657.1079 | **Q2** [71.0, 83.0] |
+| `max_depth` | 54288.1637 | — | — | 51685.5511 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 52261.9589 | 51830.1195 | 51485.8547 | 53754.5170 | **Q3** [19.0, 23.0] |
+| `lambda_l1` | 51672.6462 | 51891.9411 | 52053.4803 | 53685.1076 | **Q1** [None, 0.0] |
+| `lambda_l2` | 52646.7672 | 52202.5099 | 52081.3806 | 52372.5175 | **Q3** [0.0, 0.0002] |
+| `feature_fraction` | 52387.0316 | 51485.4577 | 51785.7763 | 53644.9096 | **Q2** [0.6942, 0.7128] |
+| `bagging_fraction` | 53170.8605 | 51442.8143 | 52158.2332 | 52531.2672 | **Q2** [0.8469, 0.8744] |
+
+#### E. Slice plot
+
+![houses@s42/naive-ensemble](slice_houses@s42_naive-ensemble.png)
+
+
+---
+
+## houses@s43  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 48759.66773** (winner retrained in 0.87s, cv score of winner: 50306.1130)
+- cv best RMSE: 50306.1130, median: 50702.0156, p10: 50474.1811
+- train: median 0.728s/fold, mean 0.695s, p90 0.982s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.592 |
+| `learning_rate` | 0.336 |
+| `max_depth` | 0.030 |
+| `num_leaves` | 0.015 |
+| `min_data_in_leaf` | 0.014 |
+| `feature_fraction` | 0.007 |
+| `bagging_fraction` | 0.006 |
+| `bagging_freq` | 0.001 |
+| `lambda_l1` | 0.001 |
+| `n_models` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 51471.3325 | 2532.4147 | 50306.1130 |
+| True | 32 | 63284.2766 | 5030.1460 | 55828.6091 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54094.8771 | 51331.9991 | 51329.5088 | 52153.0586 | **Q3** [0.0825, 0.0939] |
+| `num_leaves` | 52380.7887 | 51717.7594 | 51660.8736 | 53155.7956 | **Q3** [64.0, 78.0] |
+| `max_depth` | 55227.3532 | 51843.9037 | — | 51773.4144 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 51854.8172 | 51725.1498 | 51475.5275 | 53789.6855 | **Q3** [14.0, 19.0] |
+| `lambda_l1` | 52051.3419 | 51796.3011 | 52216.9901 | 52844.8105 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 52793.0268 | 51433.9140 | 51719.5379 | 52962.9649 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 52335.7167 | 51606.0057 | 51354.5583 | 53613.1630 | **Q3** [0.606, 0.6534] |
+| `bagging_fraction` | 52982.7074 | 51918.4886 | 51625.3643 | 52382.8833 | **Q3** [0.8237, 0.8477] |
+
+#### E. Slice plot
+
+![houses@s43/naive-ensemble](slice_houses@s43_naive-ensemble.png)
+
+
+---
+
+## houses@s44  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 47614.05700** (winner retrained in 0.55s, cv score of winner: 50145.4995)
+- cv best RMSE: 50145.4995, median: 50954.3367, p10: 50372.8465
+- train: median 0.474s/fold, mean 0.513s, p90 0.746s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.585 |
+| `learning_rate` | 0.366 |
+| `max_depth` | 0.016 |
+| `lambda_l2` | 0.008 |
+| `feature_fraction` | 0.006 |
+| `bagging_fraction` | 0.006 |
+| `min_data_in_leaf` | 0.004 |
+| `num_leaves` | 0.003 |
+| `n_models` | 0.003 |
+| `bagging_freq` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 51497.8930 | 2778.7443 | 50145.4995 |
+| True | 30 | 62522.4075 | 5194.3681 | 57054.2326 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 53617.9055 | 51671.2877 | 51267.9287 | 52080.3335 | **Q3** [0.1024, 0.1189] |
+| `num_leaves` | 51926.1866 | 51834.7773 | 51795.8666 | 53068.0959 | **Q3** [57.0, 66.0] |
+| `max_depth` | 54427.0738 | 51902.7651 | 51787.3592 | 51792.4584 | **Q3** [11.0, 12.0] |
+| `min_data_in_leaf` | 51325.1800 | 51261.6039 | 52526.0846 | 53182.8759 | **Q2** [10.0, 13.0] |
+| `lambda_l1` | 51969.8261 | 52222.2471 | 51744.5557 | 52700.8266 | **Q3** [0.0, 0.0095] |
+| `lambda_l2` | 53318.9367 | 51687.9985 | 51705.6903 | 51924.8300 | **Q2** [0.0013, 0.0252] |
+| `feature_fraction` | 51587.4868 | 52393.7908 | 52109.2860 | 52546.8918 | **Q1** [None, 0.5411] |
+| `bagging_fraction` | 52385.4380 | 52059.5029 | 51978.2825 | 52214.2320 | **Q3** [0.8248, 0.9275] |
+
+#### E. Slice plot
+
+![houses@s44/naive-ensemble](slice_houses@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_houses_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_houses_ensemble_summary.json
@@ -1,0 +1,1169 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "houses"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "4e208d83baceaa5a1ebd0eccaa975a01d7361bd2",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "houses": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 50074.594155623854,
+      "cv_best": 50578.908104620496,
+      "crash_rate": 0.0,
+      "retrain_s": 1.0566
+     },
+     "43": {
+      "holdout_rmse": 48759.667730362875,
+      "cv_best": 50306.11297474954,
+      "crash_rate": 0.0,
+      "retrain_s": 0.868
+     },
+     "44": {
+      "holdout_rmse": 47614.05699738665,
+      "cv_best": 50145.499530338195,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5499
+     }
+    },
+    "holdout_mean": 48816.106294,
+    "holdout_std": 1005.302528,
+    "cv_best_mean": 50343.50687
+   }
+  }
+ },
+ "runs": {
+  "houses@s42": {
+   "dataset": "houses",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 206067.006875,
+    "std": 114867.76939213117
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50578.908104620496,
+    "rmse_p10": 50717.179294947535,
+    "rmse_median": 50951.946780385304,
+    "train_s_median": 0.6978414658457041,
+    "train_s_mean": 0.6491514935642481,
+    "train_s_p90": 0.8338167826458812,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.07889191593103738,
+     "num_leaves": 91,
+     "max_depth": 12,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 0.03680457646379009,
+     "lambda_l2": 1.4051239839834946e-05,
+     "feature_fraction": 0.6989720470459899,
+     "bagging_fraction": 0.8895979396238413,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5076,
+     "extra_trees": 0.4238,
+     "min_data_in_leaf": 0.0321,
+     "feature_fraction": 0.0193,
+     "num_leaves": 0.0094,
+     "max_depth": 0.0049,
+     "bagging_freq": 0.0022,
+     "bagging_fraction": 0.0005,
+     "n_models": 0.0,
+     "lambda_l1": 0.0,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 51594.7709,
+        "std": 2643.871,
+        "min": 50578.9081
+       },
+       "True": {
+        "n": 30,
+        "mean": 63778.486,
+        "std": 6109.2892,
+        "min": 55924.7269
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12183.7151,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0722
+       ],
+       "n": 125,
+       "mean_rmse": 54204.7761
+      },
+      "Q2": {
+       "range": [
+        0.0722,
+        0.0831
+       ],
+       "n": 125,
+       "mean_rmse": 51750.1474
+      },
+      "Q3": {
+       "range": [
+        0.0831,
+        0.0948
+       ],
+       "n": 125,
+       "mean_rmse": 51377.5294
+      },
+      "Q4": {
+       "range": [
+        0.0948,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 51970.7223
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        71.0
+       ],
+       "n": 120,
+       "mean_rmse": 53042.0465
+      },
+      "Q2": {
+       "range": [
+        71.0,
+        83.0
+       ],
+       "n": 121,
+       "mean_rmse": 51689.8978
+      },
+      "Q3": {
+       "range": [
+        83.0,
+        90.0
+       ],
+       "n": 117,
+       "mean_rmse": 51846.704
+      },
+      "Q4": {
+       "range": [
+        90.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 52657.1079
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 123,
+       "mean_rmse": 54288.1637
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 377,
+       "mean_rmse": 51685.5511
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 107,
+       "mean_rmse": 52261.9589
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        19.0
+       ],
+       "n": 122,
+       "mean_rmse": 51830.1195
+      },
+      "Q3": {
+       "range": [
+        19.0,
+        23.0
+       ],
+       "n": 141,
+       "mean_rmse": 51485.8547
+      },
+      "Q4": {
+       "range": [
+        23.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 53754.517
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 51672.6462
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 51891.9411
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52053.4803
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 53685.1076
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52646.7672
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52202.5099
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 125,
+       "mean_rmse": 52081.3806
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52372.5175
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6942
+       ],
+       "n": 125,
+       "mean_rmse": 52387.0316
+      },
+      "Q2": {
+       "range": [
+        0.6942,
+        0.7128
+       ],
+       "n": 125,
+       "mean_rmse": 51485.4577
+      },
+      "Q3": {
+       "range": [
+        0.7128,
+        0.7372
+       ],
+       "n": 125,
+       "mean_rmse": 51785.7763
+      },
+      "Q4": {
+       "range": [
+        0.7372,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 53644.9096
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8469
+       ],
+       "n": 125,
+       "mean_rmse": 53170.8605
+      },
+      "Q2": {
+       "range": [
+        0.8469,
+        0.8744
+       ],
+       "n": 125,
+       "mean_rmse": 51442.8143
+      },
+      "Q3": {
+       "range": [
+        0.8744,
+        0.895
+       ],
+       "n": 125,
+       "mean_rmse": 52158.2332
+      },
+      "Q4": {
+       "range": [
+        0.895,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52531.2672
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1631.9,
+    "holdout": {
+     "holdout_rmse": 50074.594155623854,
+     "retrain_s": 1.0566,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 50578.908104620496
+    }
+   }
+  },
+  "houses@s43": {
+   "dataset": "houses",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 207292.308625,
+    "std": 114725.69189141605
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50306.11297474954,
+    "rmse_p10": 50474.18108266463,
+    "rmse_median": 50702.015553560355,
+    "train_s_median": 0.7282238200306892,
+    "train_s_mean": 0.6951155022889376,
+    "train_s_p90": 0.9820828234031796,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.08544545295008583,
+     "num_leaves": 67,
+     "max_depth": 12,
+     "min_data_in_leaf": 16,
+     "lambda_l1": 0.00015640270703219834,
+     "lambda_l2": 7.797793695239226e-05,
+     "feature_fraction": 0.5765802661307833,
+     "bagging_fraction": 0.8255836856222023,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.5916,
+     "learning_rate": 0.3355,
+     "max_depth": 0.0303,
+     "num_leaves": 0.0148,
+     "min_data_in_leaf": 0.0137,
+     "feature_fraction": 0.0067,
+     "bagging_fraction": 0.0057,
+     "bagging_freq": 0.0009,
+     "lambda_l1": 0.0005,
+     "n_models": 0.0004,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 51471.3325,
+        "std": 2532.4147,
+        "min": 50306.113
+       },
+       "True": {
+        "n": 32,
+        "mean": 63284.2766,
+        "std": 5030.146,
+        "min": 55828.6091
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11812.9441,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.072
+       ],
+       "n": 125,
+       "mean_rmse": 54094.8771
+      },
+      "Q2": {
+       "range": [
+        0.072,
+        0.0825
+       ],
+       "n": 125,
+       "mean_rmse": 51331.9991
+      },
+      "Q3": {
+       "range": [
+        0.0825,
+        0.0939
+       ],
+       "n": 125,
+       "mean_rmse": 51329.5088
+      },
+      "Q4": {
+       "range": [
+        0.0939,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52153.0586
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        53.0
+       ],
+       "n": 122,
+       "mean_rmse": 52380.7887
+      },
+      "Q2": {
+       "range": [
+        53.0,
+        64.0
+       ],
+       "n": 124,
+       "mean_rmse": 51717.7594
+      },
+      "Q3": {
+       "range": [
+        64.0,
+        78.0
+       ],
+       "n": 128,
+       "mean_rmse": 51660.8736
+      },
+      "Q4": {
+       "range": [
+        78.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 53155.7956
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 62,
+       "mean_rmse": 55227.3532
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 182,
+       "mean_rmse": 51843.9037
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 256,
+       "mean_rmse": 51773.4144
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 114,
+       "mean_rmse": 51854.8172
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        14.0
+       ],
+       "n": 109,
+       "mean_rmse": 51725.1498
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        19.0
+       ],
+       "n": 145,
+       "mean_rmse": 51475.5275
+      },
+      "Q4": {
+       "range": [
+        19.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 53789.6855
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52051.3419
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 51796.3011
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 125,
+       "mean_rmse": 52216.9901
+      },
+      "Q4": {
+       "range": [
+        0.0002,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52844.8105
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52793.0268
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 51433.914
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 51719.5379
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52962.9649
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5781
+       ],
+       "n": 125,
+       "mean_rmse": 52335.7167
+      },
+      "Q2": {
+       "range": [
+        0.5781,
+        0.606
+       ],
+       "n": 125,
+       "mean_rmse": 51606.0057
+      },
+      "Q3": {
+       "range": [
+        0.606,
+        0.6534
+       ],
+       "n": 125,
+       "mean_rmse": 51354.5583
+      },
+      "Q4": {
+       "range": [
+        0.6534,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 53613.163
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7907
+       ],
+       "n": 125,
+       "mean_rmse": 52982.7074
+      },
+      "Q2": {
+       "range": [
+        0.7907,
+        0.8237
+       ],
+       "n": 125,
+       "mean_rmse": 51918.4886
+      },
+      "Q3": {
+       "range": [
+        0.8237,
+        0.8477
+       ],
+       "n": 125,
+       "mean_rmse": 51625.3643
+      },
+      "Q4": {
+       "range": [
+        0.8477,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52382.8833
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1746.5,
+    "holdout": {
+     "holdout_rmse": 48759.667730362875,
+     "retrain_s": 0.868,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 50306.11297474954
+    }
+   }
+  },
+  "houses@s44": {
+   "dataset": "houses",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 205256.982,
+    "std": 114405.72363980168
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50145.499530338195,
+    "rmse_p10": 50372.846475124396,
+    "rmse_median": 50954.336703808694,
+    "train_s_median": 0.47353713642805817,
+    "train_s_mean": 0.5126614901013672,
+    "train_s_p90": 0.7461856585741043,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.11818443791813674,
+     "num_leaves": 51,
+     "max_depth": 10,
+     "min_data_in_leaf": 18,
+     "lambda_l1": 0.07592963149177262,
+     "lambda_l2": 0.0003126420607166217,
+     "feature_fraction": 0.529804274177655,
+     "bagging_fraction": 0.9334562110153479,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.5852,
+     "learning_rate": 0.3661,
+     "max_depth": 0.016,
+     "lambda_l2": 0.0081,
+     "feature_fraction": 0.006,
+     "bagging_fraction": 0.0059,
+     "min_data_in_leaf": 0.0044,
+     "num_leaves": 0.0033,
+     "n_models": 0.0032,
+     "bagging_freq": 0.0017,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 30,
+        "mean": 62522.4075,
+        "std": 5194.3681,
+        "min": 57054.2326
+       },
+       "False": {
+        "n": 470,
+        "mean": 51497.893,
+        "std": 2778.7443,
+        "min": 50145.4995
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11024.5145,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0865
+       ],
+       "n": 125,
+       "mean_rmse": 53617.9055
+      },
+      "Q2": {
+       "range": [
+        0.0865,
+        0.1024
+       ],
+       "n": 125,
+       "mean_rmse": 51671.2877
+      },
+      "Q3": {
+       "range": [
+        0.1024,
+        0.1189
+       ],
+       "n": 125,
+       "mean_rmse": 51267.9287
+      },
+      "Q4": {
+       "range": [
+        0.1189,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52080.3335
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        50.0
+       ],
+       "n": 116,
+       "mean_rmse": 51926.1866
+      },
+      "Q2": {
+       "range": [
+        50.0,
+        57.0
+       ],
+       "n": 130,
+       "mean_rmse": 51834.7773
+      },
+      "Q3": {
+       "range": [
+        57.0,
+        66.0
+       ],
+       "n": 127,
+       "mean_rmse": 51795.8666
+      },
+      "Q4": {
+       "range": [
+        66.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 53068.0959
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 63,
+       "mean_rmse": 54427.0738
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 162,
+       "mean_rmse": 51902.7651
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 78,
+       "mean_rmse": 51787.3592
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 197,
+       "mean_rmse": 51792.4584
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 124,
+       "mean_rmse": 51325.18
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        13.0
+       ],
+       "n": 101,
+       "mean_rmse": 51261.6039
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        18.0
+       ],
+       "n": 133,
+       "mean_rmse": 52526.0846
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 53182.8759
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 51969.8261
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52222.2471
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0095
+       ],
+       "n": 125,
+       "mean_rmse": 51744.5557
+      },
+      "Q4": {
+       "range": [
+        0.0095,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52700.8266
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0013
+       ],
+       "n": 125,
+       "mean_rmse": 53318.9367
+      },
+      "Q2": {
+       "range": [
+        0.0013,
+        0.0252
+       ],
+       "n": 125,
+       "mean_rmse": 51687.9985
+      },
+      "Q3": {
+       "range": [
+        0.0252,
+        0.8585
+       ],
+       "n": 125,
+       "mean_rmse": 51705.6903
+      },
+      "Q4": {
+       "range": [
+        0.8585,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 51924.83
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5411
+       ],
+       "n": 125,
+       "mean_rmse": 51587.4868
+      },
+      "Q2": {
+       "range": [
+        0.5411,
+        0.6795
+       ],
+       "n": 125,
+       "mean_rmse": 52393.7908
+      },
+      "Q3": {
+       "range": [
+        0.6795,
+        0.7818
+       ],
+       "n": 125,
+       "mean_rmse": 52109.286
+      },
+      "Q4": {
+       "range": [
+        0.7818,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52546.8918
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7437
+       ],
+       "n": 125,
+       "mean_rmse": 52385.438
+      },
+      "Q2": {
+       "range": [
+        0.7437,
+        0.8248
+       ],
+       "n": 125,
+       "mean_rmse": 52059.5029
+      },
+      "Q3": {
+       "range": [
+        0.8248,
+        0.9275
+       ],
+       "n": 125,
+       "mean_rmse": 51978.2825
+      },
+      "Q4": {
+       "range": [
+        0.9275,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52214.232
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1289.3,
+    "holdout": {
+     "holdout_rmse": 47614.05699738665,
+     "retrain_s": 0.5499,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 50145.499530338195
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_houses_report.md
+++ b/bench_results/wide_v081/ds_houses_report.md
@@ -1,0 +1,521 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['houses'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| houses | naive-lightgbm | **50108.73806** ± 901.62518 | 50708.02892 | 0.0% | 0.26 |
+| houses | moe | **48622.59264** ± 683.43205 | 50148.18266 | 0.0% | 16.15 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| houses@s42 | naive-lightgbm | 50493.3397 | 51154.2425 | 0.191 | 490 |
+| houses@s42 | moe | 50063.7533 | 51081.3391 | 1.184 | 3597 |
+| houses@s43 | naive-lightgbm | 50976.4089 | 51629.0269 | 0.356 | 863 |
+| houses@s43 | moe | 50032.1886 | 50957.3259 | 4.853 | 17889 |
+| houses@s44 | naive-lightgbm | 50654.3382 | 51120.2765 | 0.206 | 463 |
+| houses@s44 | moe | 50348.6061 | 51067.4774 | 1.472 | 4169 |
+
+
+
+---
+
+## houses@s42  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 50837.85512** (winner retrained in 0.17s, cv score of winner: 50493.3397)
+- cv best RMSE: 50493.3397, median: 51154.2425, p10: 50883.3160
+- train: median 0.191s/fold, mean 0.190s, p90 0.236s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.622 |
+| `extra_trees` | 0.325 |
+| `min_data_in_leaf` | 0.015 |
+| `feature_fraction` | 0.013 |
+| `max_depth` | 0.010 |
+| `num_leaves` | 0.009 |
+| `bagging_fraction` | 0.005 |
+| `bagging_freq` | 0.001 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 51746.4828 | 2793.8770 | 50493.3397 |
+| True | 32 | 64290.3048 | 8625.1273 | 57820.1777 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54781.7420 | 51578.3220 | 51574.0783 | 52263.0074 | **Q3** [0.0995, 0.1121] |
+| `num_leaves` | 52730.6402 | 52014.5142 | 51693.7554 | 53692.0510 | **Q3** [35.0, 40.0] |
+| `max_depth` | 55249.4566 | 52409.8563 | — | 51745.7003 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 52514.0039 | 51974.6581 | 52062.3832 | 53639.1470 | **Q2** [16.0, 20.0] |
+| `lambda_l1` | 52689.4904 | 52130.2930 | 52972.4713 | 52404.8950 | **Q2** [0.0, 0.0004] |
+| `lambda_l2` | 53832.3713 | 52038.4769 | 51838.7513 | 52487.5502 | **Q3** [0.1009, 0.3701] |
+| `feature_fraction` | 54015.5799 | 51563.4755 | 51891.5653 | 52726.5290 | **Q2** [0.7264, 0.7497] |
+| `bagging_fraction` | 52586.4592 | 52324.8414 | 52858.4815 | 52427.3677 | **Q2** [0.6783, 0.7446] |
+
+#### E. Slice plot
+
+![houses@s42/naive-lightgbm](slice_houses@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 49448.98956** (winner retrained in 1.92s, cv score of winner: 50063.7533)
+- cv best RMSE: 50063.7533, median: 51081.3391, p10: 50425.2539
+- train: median 1.184s/fold, mean 1.415s, p90 2.104s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.642 |
+| `extra_trees` | 0.155 |
+| `mixture_gate_type` | 0.093 |
+| `mixture_init` | 0.028 |
+| `bagging_fraction` | 0.013 |
+| `bagging_freq` | 0.012 |
+| `mixture_diversity_lambda` | 0.009 |
+| `min_data_in_leaf` | 0.009 |
+| `mixture_e_step_mode` | 0.007 |
+| `lambda_l1` | 0.007 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 54160.4088 (n=453) | expert_choice | Δ +6772.1273 | p=1.16e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 321 | 53851.6558 | 7583.0029 | 50063.7533 |
+| leaf_reuse | 157 | 54854.0059 | 13746.7022 | 50387.7777 |
+| none | 22 | 68183.3605 | 15483.9601 | 51929.4044 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 453 | 54160.4088 | 10271.8968 | 50063.7533 |
+| expert_choice | 47 | 60932.5361 | 12949.3021 | 51533.7082 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 436 | 53765.2295 | 8640.4830 | 50063.7533 |
+| loss_only | 39 | 57792.0083 | 10857.5253 | 51533.7082 |
+| em | 25 | 68118.6401 | 24683.5026 | 51089.0199 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 190 | 53027.1533 | 10068.3199 | 50387.7777 |
+| uniform | 209 | 53891.4833 | 6013.5774 | 50063.7533 |
+| gmm_features | 37 | 54025.7028 | 8156.2326 | 50729.6527 |
+| kmeans_features | 34 | 55256.2911 | 6831.3861 | 51076.9097 |
+| tree_hierarchical | 13 | 66717.7100 | 15218.0083 | 50559.7076 |
+| gmm | 17 | 77354.1243 | 27073.4725 | 51137.9576 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 70 | 53908.2782 | 8869.8399 | 50594.2988 |
+| none | 365 | 54772.8536 | 11171.0938 | 50063.7533 |
+| markov | 65 | 55889.5897 | 9954.5724 | 50881.7753 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 259 | 54330.6249 | 12550.7596 | 50387.7777 |
+| True | 241 | 55298.1848 | 8328.3174 | 50063.7533 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 53428.7546 | 7725.0691 | 50063.7533 |
+| True | 32 | 74807.4134 | 22369.5943 | 56293.7129 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 68459.8475 | — | — | 54197.9908 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 53740.4996 | 53843.9551 | 56915.7114 | 54687.7889 | **Q1** [None, 0.1405] |
+| `mixture_warmup_iters` | 55403.6587 | 53403.5448 | 56295.8581 | 55149.2912 | **Q2** [6.0, 8.0] |
+| `mixture_balance_factor` | 54573.7064 | 53951.4524 | 55778.0034 | 53914.5693 | **Q4** [9.0, ∞) |
+| `learning_rate` | 59187.7545 | 52203.5091 | 53139.8697 | 54656.8218 | **Q2** [0.1216, 0.1661] |
+| `num_leaves` | 57640.0757 | 53551.3946 | 54159.7571 | 53858.1199 | **Q2** [97.75, 118.0] |
+| `max_depth` | 60222.5688 | 54595.0013 | 55259.8675 | 53109.3432 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 54203.4623 | 54103.5091 | 52816.7240 | 57483.1833 | **Q3** [20.0, 26.0] |
+
+#### E. Slice plot
+
+![houses@s42/moe](slice_houses@s42_moe.png)
+
+
+---
+
+## houses@s43  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 50650.09521** (winner retrained in 0.33s, cv score of winner: 50976.4089)
+- cv best RMSE: 50976.4089, median: 51629.0269, p10: 51303.1013
+- train: median 0.356s/fold, mean 0.338s, p90 0.449s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.585 |
+| `learning_rate` | 0.305 |
+| `min_data_in_leaf` | 0.063 |
+| `feature_fraction` | 0.025 |
+| `max_depth` | 0.017 |
+| `bagging_fraction` | 0.003 |
+| `num_leaves` | 0.001 |
+| `bagging_freq` | 0.001 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 52168.2304 | 2334.6902 | 50976.4089 |
+| True | 30 | 63746.3169 | 5075.7170 | 57331.5582 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 53935.3332 | 52579.0710 | 52023.8399 | 52913.4185 | **Q3** [0.0668, 0.0788] |
+| `num_leaves` | 52920.8235 | 53441.8723 | 52517.0176 | 52569.0361 | **Q3** [101.5, 116.0] |
+| `max_depth` | 55668.9373 | 52305.1409 | 52743.1669 | 52680.7233 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 51997.5348 | 52801.3171 | 52270.6233 | 54208.1829 | **Q1** [None, 9.0] |
+| `lambda_l1` | 53341.0887 | 52435.9029 | 52987.9780 | 52686.6929 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 53545.8936 | 52884.3822 | 52504.6073 | 52516.7794 | **Q3** [0.5555, 2.3927] |
+| `feature_fraction` | 53422.5595 | 52289.6307 | 52469.9102 | 53269.5620 | **Q2** [0.741, 0.782] |
+| `bagging_fraction` | 53144.9239 | 52669.6318 | 52291.9041 | 53345.2027 | **Q3** [0.7877, 0.8594] |
+
+#### E. Slice plot
+
+![houses@s43/naive-lightgbm](slice_houses@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 48643.46809** (winner retrained in 44.24s, cv score of winner: 50032.1886)
+- cv best RMSE: 50032.1886, median: 50957.3259, p10: 50426.0756
+- train: median 4.853s/fold, mean 7.128s, p90 17.693s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.317 |
+| `mixture_diversity_lambda` | 0.226 |
+| `lambda_l2` | 0.141 |
+| `learning_rate` | 0.097 |
+| `bagging_fraction` | 0.076 |
+| `mixture_routing_mode` | 0.025 |
+| `mixture_warmup_iters` | 0.022 |
+| `feature_fraction` | 0.021 |
+| `mixture_init` | 0.016 |
+| `extra_trees` | 0.013 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 53630.6562 (n=449) | token_choice | Δ +13124.3606 | p=2.72e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 143 | 54071.6466 | 10898.4952 | 50286.1129 |
+| none | 134 | 54650.9092 | 9836.9510 | 50319.5920 |
+| gbdt | 223 | 55736.3371 | 19329.9573 | 50032.1886 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 449 | 53630.6562 | 11762.1476 | 50032.1886 |
+| token_choice | 51 | 66755.0168 | 29214.5955 | 50038.4021 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 69 | 54704.3690 | 8815.5175 | 50032.1886 |
+| em | 286 | 54847.0487 | 15842.0633 | 50038.4021 |
+| loss_only | 145 | 55336.6420 | 15836.7701 | 50286.1129 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| tree_hierarchical | 156 | 52488.3863 | 6821.7910 | 50187.0748 |
+| random | 103 | 53228.3811 | 7335.0664 | 50032.1886 |
+| kmeans_features | 68 | 54996.2863 | 10949.6795 | 50444.1114 |
+| gmm | 142 | 56955.0442 | 22295.2548 | 50195.5568 |
+| uniform | 17 | 62534.3639 | 26069.0675 | 50808.4965 |
+| gmm_features | 14 | 65965.0731 | 20606.0131 | 50738.5145 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 268 | 53909.9816 | 10818.9119 | 50187.0748 |
+| ema | 210 | 55297.8656 | 17696.1112 | 50032.1886 |
+| none | 22 | 64738.3478 | 25209.1516 | 50576.5624 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 54335.8159 | 14598.3506 | 50032.1886 |
+| True | 32 | 64234.6452 | 18425.3868 | 51092.1033 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 54424.3998 | 15231.1019 | 50032.1886 |
+| True | 30 | 63506.7524 | 8515.1764 | 57253.8543 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 59377.3346 | — | — | 54001.7326 | **Q4** [6.0, ∞) |
+| `mixture_diversity_lambda` | 55180.4023 | 53362.9569 | 53092.0466 | 58241.9581 | **Q3** [0.1073, 0.157] |
+| `mixture_warmup_iters` | 55839.6956 | 55686.0805 | 53201.8775 | 55108.9572 | **Q3** [17.0, 24.0] |
+| `mixture_balance_factor` | 59404.2610 | 55584.5889 | 52957.5405 | 53655.9899 | **Q3** [8.0, 10.0] |
+| `learning_rate` | 59809.8159 | 54342.5300 | 53438.2420 | 52286.7758 | **Q4** [0.1136, ∞) |
+| `num_leaves` | 54170.7331 | 53408.3415 | 55795.5767 | 56494.4281 | **Q2** [38.0, 48.0] |
+| `max_depth` | 58813.4305 | 53116.3478 | 55641.0040 | 53874.1591 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 53163.3115 | 54246.5006 | 54323.1530 | 57974.7094 | **Q1** [None, 8.0] |
+
+#### E. Slice plot
+
+![houses@s43/moe](slice_houses@s43_moe.png)
+
+
+---
+
+## houses@s44  (search X=[8000, 8], holdout n=2000)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 48838.26386** (winner retrained in 0.29s, cv score of winner: 50654.3382)
+- cv best RMSE: 50654.3382, median: 51120.2765, p10: 50847.9634
+- train: median 0.206s/fold, mean 0.181s, p90 0.261s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.667 |
+| `learning_rate` | 0.228 |
+| `min_data_in_leaf` | 0.063 |
+| `max_depth` | 0.026 |
+| `feature_fraction` | 0.008 |
+| `bagging_fraction` | 0.005 |
+| `num_leaves` | 0.002 |
+| `bagging_freq` | 0.001 |
+| `lambda_l1` | 0.000 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 51846.3373 | 2450.6921 | 50654.3382 |
+| True | 30 | 64350.9585 | 3681.9798 | 58652.9668 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 54142.3994 | 51567.6162 | 52081.2127 | 52595.2301 | **Q2** [0.0548, 0.0624] |
+| `num_leaves` | 53888.4843 | 51873.9383 | 52670.7577 | 51910.8426 | **Q2** [96.0, 113.0] |
+| `max_depth` | 54200.7503 | 52468.5722 | — | 52134.2667 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 51943.2776 | 51918.9861 | 52091.0049 | 54292.1137 | **Q2** [12.0, 15.0] |
+| `lambda_l1` | 53980.9400 | 51692.0805 | 52463.0322 | 52250.4058 | **Q2** [0.0138, 0.3111] |
+| `lambda_l2` | 53238.8650 | 52128.8312 | 52314.3403 | 52704.4219 | **Q2** [0.0002, 0.0007] |
+| `feature_fraction` | 53775.7243 | 52081.5784 | 51757.3688 | 52771.7871 | **Q3** [0.7446, 0.7641] |
+| `bagging_fraction` | 52748.7338 | 52226.9187 | 52445.8032 | 52965.0027 | **Q2** [0.8165, 0.8376] |
+
+#### E. Slice plot
+
+![houses@s44/naive-lightgbm](slice_houses@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 47775.32027** (winner retrained in 2.30s, cv score of winner: 50348.6061)
+- cv best RMSE: 50348.6061, median: 51067.4774, p10: 50562.9446
+- train: median 1.472s/fold, mean 1.635s, p90 2.787s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.693 |
+| `extra_trees` | 0.223 |
+| `mixture_expert_dropout_rate` | 0.020 |
+| `num_leaves` | 0.014 |
+| `min_data_in_leaf` | 0.011 |
+| `mixture_gate_type` | 0.007 |
+| `feature_fraction` | 0.005 |
+| `mixture_warmup_iters` | 0.005 |
+| `mixture_e_step_mode` | 0.004 |
+| `bagging_freq` | 0.003 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **expert_choice** | 52859.5617 (n=372) | token_choice | Δ +3198.5537 | p=4.12e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 408 | 52833.8534 | 7092.3304 | 50348.6061 |
+| gbdt | 63 | 54676.3713 | 8222.0732 | 50613.5339 |
+| none | 29 | 63392.1433 | 17061.2321 | 50608.3009 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 372 | 52859.5617 | 6919.7726 | 50348.6061 |
+| token_choice | 128 | 56058.1154 | 11701.5448 | 50431.9257 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 293 | 52865.1352 | 5831.4007 | 50348.6061 |
+| loss_only | 153 | 53238.7388 | 7158.7776 | 50503.6169 |
+| gate_only | 54 | 59336.7427 | 17510.1263 | 50435.4329 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 137 | 52337.2726 | 5577.6317 | 50348.6061 |
+| kmeans_features | 114 | 52881.7566 | 8170.5323 | 50378.3946 |
+| random | 129 | 53692.4163 | 9104.7337 | 50503.6169 |
+| gmm | 32 | 54553.5168 | 8353.9899 | 51073.1369 |
+| tree_hierarchical | 70 | 56268.4030 | 11726.2868 | 50360.3696 |
+| gmm_features | 18 | 57202.5936 | 6881.1089 | 50730.8716 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 117 | 52855.9268 | 3765.1454 | 50503.6169 |
+| markov | 259 | 53154.3453 | 7102.7703 | 50348.6061 |
+| ema | 124 | 55549.0070 | 13014.9506 | 50360.3696 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 192 | 53456.4146 | 7314.2267 | 50378.3946 |
+| False | 308 | 53816.7667 | 9192.4684 | 50348.6061 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 52792.7314 | 7324.3767 | 50348.6061 |
+| True | 31 | 67077.5712 | 12975.9660 | 56323.5633 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 59718.5784 | — | — | 52711.4010 | **Q4** [6.0, ∞) |
+| `mixture_diversity_lambda` | 52596.2334 | 52710.1620 | 54410.6510 | 54996.5195 | **Q1** [None, 0.1392] |
+| `mixture_warmup_iters` | 52903.8325 | 52519.7261 | 53501.4449 | 55565.3661 | **Q2** [6.0, 8.0] |
+| `mixture_balance_factor` | — | 52619.1678 | 55505.3252 | 54072.2816 | **Q2** [2.0, 3.0] |
+| `learning_rate` | 57922.2611 | 51976.9329 | 52322.3763 | 52491.9956 | **Q2** [0.0929, 0.1076] |
+| `num_leaves` | 54825.5820 | 53191.1202 | 52793.2573 | 53834.9690 | **Q3** [76.0, 84.0] |
+| `max_depth` | 59553.7531 | 53142.6459 | — | 52479.1975 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 52530.9065 | 52469.1748 | 52682.2717 | 56666.7004 | **Q2** [13.0, 17.0] |
+
+#### E. Slice plot
+
+![houses@s44/moe](slice_houses@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| houses@s42 | `mixture_routing_mode` | **token_choice** | +6772.1273 | 1.16e-03 |
+| houses@s43 | `mixture_routing_mode` | **expert_choice** | +13124.3606 | 2.72e-03 |
+| houses@s44 | `mixture_routing_mode` | **expert_choice** | +3198.5537 | 4.12e-03 |

--- a/bench_results/wide_v081/ds_houses_summary.json
+++ b/bench_results/wide_v081/ds_houses_summary.json
@@ -1,0 +1,2842 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "houses"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "houses": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 50837.855116826635,
+      "cv_best": 50493.33966908023,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1707
+     },
+     "43": {
+      "holdout_rmse": 50650.09520774331,
+      "cv_best": 50976.408933918356,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3348
+     },
+     "44": {
+      "holdout_rmse": 48838.263864625835,
+      "cv_best": 50654.33815486819,
+      "crash_rate": 0.0,
+      "retrain_s": 0.2895
+     }
+    },
+    "holdout_mean": 50108.738063,
+    "holdout_std": 901.625185,
+    "cv_best_mean": 50708.028919
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 49448.98955554052,
+      "cv_best": 50063.75325289865,
+      "crash_rate": 0.0,
+      "retrain_s": 1.9235
+     },
+     "43": {
+      "holdout_rmse": 48643.46808862054,
+      "cv_best": 50032.18860289062,
+      "crash_rate": 0.0,
+      "retrain_s": 44.2385
+     },
+     "44": {
+      "holdout_rmse": 47775.32026838286,
+      "cv_best": 50348.606126918145,
+      "crash_rate": 0.0,
+      "retrain_s": 2.2995
+     }
+    },
+    "holdout_mean": 48622.592638,
+    "holdout_std": 683.432054,
+    "cv_best_mean": 50148.182661
+   }
+  }
+ },
+ "runs": {
+  "houses@s42": {
+   "dataset": "houses",
+   "seed": 42,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 206067.006875,
+    "std": 114867.76939213117
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50493.33966908023,
+    "rmse_p10": 50883.3159556189,
+    "rmse_median": 51154.24245167453,
+    "train_s_median": 0.19078299459069967,
+    "train_s_mean": 0.19010474365279081,
+    "train_s_p90": 0.23610934358090163,
+    "best_params": {
+     "learning_rate": 0.10253172401475785,
+     "num_leaves": 31,
+     "max_depth": 12,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 7.261140808510807e-06,
+     "lambda_l2": 4.616020113245824e-06,
+     "feature_fraction": 0.7206977796715328,
+     "bagging_fraction": 0.7203896209364717,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6217,
+     "extra_trees": 0.3249,
+     "min_data_in_leaf": 0.0145,
+     "feature_fraction": 0.0127,
+     "max_depth": 0.01,
+     "num_leaves": 0.0092,
+     "bagging_fraction": 0.0047,
+     "bagging_freq": 0.0011,
+     "lambda_l2": 0.0009,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 64290.3048,
+        "std": 8625.1273,
+        "min": 57820.1777
+       },
+       "False": {
+        "n": 468,
+        "mean": 51746.4828,
+        "std": 2793.877,
+        "min": 50493.3397
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12543.822,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0878
+       ],
+       "n": 125,
+       "mean_rmse": 54781.742
+      },
+      "Q2": {
+       "range": [
+        0.0878,
+        0.0995
+       ],
+       "n": 125,
+       "mean_rmse": 51578.322
+      },
+      "Q3": {
+       "range": [
+        0.0995,
+        0.1121
+       ],
+       "n": 125,
+       "mean_rmse": 51574.0783
+      },
+      "Q4": {
+       "range": [
+        0.1121,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52263.0074
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        31.0
+       ],
+       "n": 104,
+       "mean_rmse": 52730.6402
+      },
+      "Q2": {
+       "range": [
+        31.0,
+        35.0
+       ],
+       "n": 119,
+       "mean_rmse": 52014.5142
+      },
+      "Q3": {
+       "range": [
+        35.0,
+        40.0
+       ],
+       "n": 136,
+       "mean_rmse": 51693.7554
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 141,
+       "mean_rmse": 53692.051
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 87,
+       "mean_rmse": 55249.4566
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 146,
+       "mean_rmse": 52409.8563
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 267,
+       "mean_rmse": 51745.7003
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        16.0
+       ],
+       "n": 99,
+       "mean_rmse": 52514.0039
+      },
+      "Q2": {
+       "range": [
+        16.0,
+        20.0
+       ],
+       "n": 143,
+       "mean_rmse": 51974.6581
+      },
+      "Q3": {
+       "range": [
+        20.0,
+        24.0
+       ],
+       "n": 124,
+       "mean_rmse": 52062.3832
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 53639.147
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52689.4904
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0004
+       ],
+       "n": 125,
+       "mean_rmse": 52130.293
+      },
+      "Q3": {
+       "range": [
+        0.0004,
+        0.0791
+       ],
+       "n": 125,
+       "mean_rmse": 52972.4713
+      },
+      "Q4": {
+       "range": [
+        0.0791,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52404.895
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0141
+       ],
+       "n": 125,
+       "mean_rmse": 53832.3713
+      },
+      "Q2": {
+       "range": [
+        0.0141,
+        0.1009
+       ],
+       "n": 125,
+       "mean_rmse": 52038.4769
+      },
+      "Q3": {
+       "range": [
+        0.1009,
+        0.3701
+       ],
+       "n": 125,
+       "mean_rmse": 51838.7513
+      },
+      "Q4": {
+       "range": [
+        0.3701,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52487.5502
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7264
+       ],
+       "n": 125,
+       "mean_rmse": 54015.5799
+      },
+      "Q2": {
+       "range": [
+        0.7264,
+        0.7497
+       ],
+       "n": 125,
+       "mean_rmse": 51563.4755
+      },
+      "Q3": {
+       "range": [
+        0.7497,
+        0.7733
+       ],
+       "n": 125,
+       "mean_rmse": 51891.5653
+      },
+      "Q4": {
+       "range": [
+        0.7733,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52726.529
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6783
+       ],
+       "n": 125,
+       "mean_rmse": 52586.4592
+      },
+      "Q2": {
+       "range": [
+        0.6783,
+        0.7446
+       ],
+       "n": 125,
+       "mean_rmse": 52324.8414
+      },
+      "Q3": {
+       "range": [
+        0.7446,
+        0.9142
+       ],
+       "n": 125,
+       "mean_rmse": 52858.4815
+      },
+      "Q4": {
+       "range": [
+        0.9142,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52427.3677
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 490.4,
+    "holdout": {
+     "holdout_rmse": 50837.855116826635,
+     "retrain_s": 0.1707,
+     "predict_s": 0.0021,
+     "cv_rmse_of_winner": 50493.33966908023
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50063.75325289865,
+    "rmse_p10": 50425.25390642355,
+    "rmse_median": 51081.339127985266,
+    "train_s_median": 1.1839590879157185,
+    "train_s_mean": 1.4154098790071905,
+    "train_s_p90": 2.104063954278827,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.2020293739964649,
+     "num_leaves": 121,
+     "max_depth": 10,
+     "min_data_in_leaf": 16,
+     "lambda_l1": 1.8553554511319095,
+     "lambda_l2": 1.3125691166732901e-06,
+     "feature_fraction": 0.725940675968232,
+     "bagging_fraction": 0.8976338539654822,
+     "bagging_freq": 0,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 6,
+     "mixture_balance_factor": 7,
+     "mixture_diversity_lambda": 0.4826233142294541,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.10730442559752407,
+     "mixture_load_balance_alpha": 0.03920118904232529,
+     "mixture_gate_max_depth": 3,
+     "mixture_gate_num_leaves": 52,
+     "mixture_gate_learning_rate": 0.040263808042205355,
+     "mixture_gate_lambda_l2": 0.013967458901325194,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.10034908920863878,
+     "mixture_gate_temperature_init": 2.5149224396575747,
+     "gate_temp_final_ratio": 0.9996766788176826,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.6425,
+     "extra_trees": 0.1548,
+     "mixture_gate_type": 0.0928,
+     "mixture_init": 0.0282,
+     "bagging_fraction": 0.0126,
+     "bagging_freq": 0.0124,
+     "mixture_diversity_lambda": 0.0095,
+     "min_data_in_leaf": 0.0087,
+     "mixture_e_step_mode": 0.0069,
+     "lambda_l1": 0.0067,
+     "mixture_expert_dropout_rate": 0.0054,
+     "feature_fraction": 0.0047,
+     "mixture_warmup_iters": 0.0044,
+     "num_leaves": 0.002,
+     "mixture_hard_m_step": 0.0019,
+     "mixture_routing_mode": 0.0018,
+     "max_depth": 0.0012,
+     "mixture_refit_leaves": 0.0012,
+     "mixture_load_balance_alpha": 0.0009,
+     "mixture_r_smoothing": 0.0007,
+     "mixture_balance_factor": 0.0005,
+     "lambda_l2": 0.0002,
+     "mixture_num_experts": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 157,
+        "mean": 54854.0059,
+        "std": 13746.7022,
+        "min": 50387.7777
+       },
+       "none": {
+        "n": 22,
+        "mean": 68183.3605,
+        "std": 15483.9601,
+        "min": 51929.4044
+       },
+       "gbdt": {
+        "n": 321,
+        "mean": 53851.6558,
+        "std": 7583.0029,
+        "min": 50063.7533
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 1002.3501,
+       "p_value": 0.396401,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 453,
+        "mean": 54160.4088,
+        "std": 10271.8968,
+        "min": 50063.7533
+       },
+       "expert_choice": {
+        "n": 47,
+        "mean": 60932.5361,
+        "std": 12949.3021,
+        "min": 51533.7082
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 6772.1273,
+       "p_value": 0.001159,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 436,
+        "mean": 53765.2295,
+        "std": 8640.483,
+        "min": 50063.7533
+       },
+       "loss_only": {
+        "n": 39,
+        "mean": 57792.0083,
+        "std": 10857.5253,
+        "min": 51533.7082
+       },
+       "em": {
+        "n": 25,
+        "mean": 68118.6401,
+        "std": 24683.5026,
+        "min": 51089.0199
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 4026.7788,
+       "p_value": 0.031432,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 209,
+        "mean": 53891.4833,
+        "std": 6013.5774,
+        "min": 50063.7533
+       },
+       "gmm": {
+        "n": 17,
+        "mean": 77354.1243,
+        "std": 27073.4725,
+        "min": 51137.9576
+       },
+       "random": {
+        "n": 190,
+        "mean": 53027.1533,
+        "std": 10068.3199,
+        "min": 50387.7777
+       },
+       "gmm_features": {
+        "n": 37,
+        "mean": 54025.7028,
+        "std": 8156.2326,
+        "min": 50729.6527
+       },
+       "kmeans_features": {
+        "n": 34,
+        "mean": 55256.2911,
+        "std": 6831.3861,
+        "min": 51076.9097
+       },
+       "tree_hierarchical": {
+        "n": 13,
+        "mean": 66717.71,
+        "std": 15218.0083,
+        "min": 50559.7076
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 864.33,
+       "p_value": 0.305893,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 70,
+        "mean": 53908.2782,
+        "std": 8869.8399,
+        "min": 50594.2988
+       },
+       "markov": {
+        "n": 65,
+        "mean": 55889.5897,
+        "std": 9954.5724,
+        "min": 50881.7753
+       },
+       "none": {
+        "n": 365,
+        "mean": 54772.8536,
+        "std": 11171.0938,
+        "min": 50063.7533
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 864.5754,
+       "p_value": 0.479177,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 259,
+        "mean": 54330.6249,
+        "std": 12550.7596,
+        "min": 50387.7777
+       },
+       "True": {
+        "n": 241,
+        "mean": 55298.1848,
+        "std": 8328.3174,
+        "min": 50063.7533
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 967.5599,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 74807.4134,
+        "std": 22369.5943,
+        "min": 56293.7129
+       },
+       "False": {
+        "n": 468,
+        "mean": 53428.7546,
+        "std": 7725.0691,
+        "min": 50063.7533
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 21378.6588,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 21,
+       "mean_rmse": 68459.8475
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 479,
+       "mean_rmse": 54197.9908
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1405
+       ],
+       "n": 125,
+       "mean_rmse": 53740.4996
+      },
+      "Q2": {
+       "range": [
+        0.1405,
+        0.2363
+       ],
+       "n": 125,
+       "mean_rmse": 53843.9551
+      },
+      "Q3": {
+       "range": [
+        0.2363,
+        0.4666
+       ],
+       "n": 125,
+       "mean_rmse": 56915.7114
+      },
+      "Q4": {
+       "range": [
+        0.4666,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 54687.7889
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 67,
+       "mean_rmse": 55403.6587
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 177,
+       "mean_rmse": 53403.5448
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 101,
+       "mean_rmse": 56295.8581
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 155,
+       "mean_rmse": 55149.2912
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 102,
+       "mean_rmse": 54573.7064
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 35,
+       "mean_rmse": 53951.4524
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 200,
+       "mean_rmse": 55778.0034
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 163,
+       "mean_rmse": 53914.5693
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1216
+       ],
+       "n": 125,
+       "mean_rmse": 59187.7545
+      },
+      "Q2": {
+       "range": [
+        0.1216,
+        0.1661
+       ],
+       "n": 125,
+       "mean_rmse": 52203.5091
+      },
+      "Q3": {
+       "range": [
+        0.1661,
+        0.2177
+       ],
+       "n": 125,
+       "mean_rmse": 53139.8697
+      },
+      "Q4": {
+       "range": [
+        0.2177,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 54656.8218
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        97.75
+       ],
+       "n": 125,
+       "mean_rmse": 57640.0757
+      },
+      "Q2": {
+       "range": [
+        97.75,
+        118.0
+       ],
+       "n": 117,
+       "mean_rmse": 53551.3946
+      },
+      "Q3": {
+       "range": [
+        118.0,
+        124.0
+       ],
+       "n": 108,
+       "mean_rmse": 54159.7571
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 150,
+       "mean_rmse": 53858.1199
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 57,
+       "mean_rmse": 60222.5688
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 159,
+       "mean_rmse": 54595.0013
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 94,
+       "mean_rmse": 55259.8675
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 190,
+       "mean_rmse": 53109.3432
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        15.0
+       ],
+       "n": 103,
+       "mean_rmse": 54203.4623
+      },
+      "Q2": {
+       "range": [
+        15.0,
+        20.0
+       ],
+       "n": 129,
+       "mean_rmse": 54103.5091
+      },
+      "Q3": {
+       "range": [
+        20.0,
+        26.0
+       ],
+       "n": 122,
+       "mean_rmse": 52816.724
+      },
+      "Q4": {
+       "range": [
+        26.0,
+        null
+       ],
+       "n": 146,
+       "mean_rmse": 57483.1833
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 3596.7,
+    "holdout": {
+     "holdout_rmse": 49448.98955554052,
+     "retrain_s": 1.9235,
+     "predict_s": 0.0151,
+     "cv_rmse_of_winner": 50063.75325289865
+    }
+   }
+  },
+  "houses@s43": {
+   "dataset": "houses",
+   "seed": 43,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 207292.308625,
+    "std": 114725.69189141605
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50976.408933918356,
+    "rmse_p10": 51303.10125000786,
+    "rmse_median": 51629.02692255964,
+    "train_s_median": 0.3555434912443161,
+    "train_s_mean": 0.3382972460925579,
+    "train_s_p90": 0.4485373130068183,
+    "best_params": {
+     "learning_rate": 0.08316351589813638,
+     "num_leaves": 45,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.0064939179678462355,
+     "lambda_l2": 4.806050595452139,
+     "feature_fraction": 0.713849115289837,
+     "bagging_fraction": 0.7847472740733468,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.5852,
+     "learning_rate": 0.3052,
+     "min_data_in_leaf": 0.0628,
+     "feature_fraction": 0.0246,
+     "max_depth": 0.0167,
+     "bagging_fraction": 0.0027,
+     "num_leaves": 0.001,
+     "bagging_freq": 0.0009,
+     "lambda_l2": 0.0004,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 30,
+        "mean": 63746.3169,
+        "std": 5075.717,
+        "min": 57331.5582
+       },
+       "False": {
+        "n": 470,
+        "mean": 52168.2304,
+        "std": 2334.6902,
+        "min": 50976.4089
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 11578.0865,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0588
+       ],
+       "n": 125,
+       "mean_rmse": 53935.3332
+      },
+      "Q2": {
+       "range": [
+        0.0588,
+        0.0668
+       ],
+       "n": 125,
+       "mean_rmse": 52579.071
+      },
+      "Q3": {
+       "range": [
+        0.0668,
+        0.0788
+       ],
+       "n": 125,
+       "mean_rmse": 52023.8399
+      },
+      "Q4": {
+       "range": [
+        0.0788,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52913.4185
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        69.75
+       ],
+       "n": 125,
+       "mean_rmse": 52920.8235
+      },
+      "Q2": {
+       "range": [
+        69.75,
+        101.5
+       ],
+       "n": 125,
+       "mean_rmse": 53441.8723
+      },
+      "Q3": {
+       "range": [
+        101.5,
+        116.0
+       ],
+       "n": 118,
+       "mean_rmse": 52517.0176
+      },
+      "Q4": {
+       "range": [
+        116.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 52569.0361
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 39,
+       "mean_rmse": 55668.9373
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 100,
+       "mean_rmse": 52305.1409
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 194,
+       "mean_rmse": 52743.1669
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 167,
+       "mean_rmse": 52680.7233
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 106,
+       "mean_rmse": 51997.5348
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        14.0
+       ],
+       "n": 127,
+       "mean_rmse": 52801.3171
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        20.0
+       ],
+       "n": 134,
+       "mean_rmse": 52270.6233
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 54208.1829
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 53341.0887
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 52435.9029
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0039
+       ],
+       "n": 125,
+       "mean_rmse": 52987.978
+      },
+      "Q4": {
+       "range": [
+        0.0039,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52686.6929
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0781
+       ],
+       "n": 125,
+       "mean_rmse": 53545.8936
+      },
+      "Q2": {
+       "range": [
+        0.0781,
+        0.5555
+       ],
+       "n": 125,
+       "mean_rmse": 52884.3822
+      },
+      "Q3": {
+       "range": [
+        0.5555,
+        2.3927
+       ],
+       "n": 125,
+       "mean_rmse": 52504.6073
+      },
+      "Q4": {
+       "range": [
+        2.3927,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52516.7794
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.741
+       ],
+       "n": 125,
+       "mean_rmse": 53422.5595
+      },
+      "Q2": {
+       "range": [
+        0.741,
+        0.782
+       ],
+       "n": 125,
+       "mean_rmse": 52289.6307
+      },
+      "Q3": {
+       "range": [
+        0.782,
+        0.8076
+       ],
+       "n": 125,
+       "mean_rmse": 52469.9102
+      },
+      "Q4": {
+       "range": [
+        0.8076,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 53269.562
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.744
+       ],
+       "n": 125,
+       "mean_rmse": 53144.9239
+      },
+      "Q2": {
+       "range": [
+        0.744,
+        0.7877
+       ],
+       "n": 125,
+       "mean_rmse": 52669.6318
+      },
+      "Q3": {
+       "range": [
+        0.7877,
+        0.8594
+       ],
+       "n": 125,
+       "mean_rmse": 52291.9041
+      },
+      "Q4": {
+       "range": [
+        0.8594,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 53345.2027
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 863.0,
+    "holdout": {
+     "holdout_rmse": 50650.09520774331,
+     "retrain_s": 0.3348,
+     "predict_s": 0.0028,
+     "cv_rmse_of_winner": 50976.408933918356
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50032.18860289062,
+    "rmse_p10": 50426.07564427419,
+    "rmse_median": 50957.325914083485,
+    "train_s_median": 4.852867399342358,
+    "train_s_mean": 7.128148925234378,
+    "train_s_p90": 17.69325329557062,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 6,
+     "learning_rate": 0.09533250669396538,
+     "num_leaves": 71,
+     "max_depth": 9,
+     "min_data_in_leaf": 15,
+     "lambda_l1": 2.0360727606436133,
+     "lambda_l2": 0.0322147881117608,
+     "feature_fraction": 0.591486384985502,
+     "bagging_fraction": 0.7740553543141822,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 35,
+     "mixture_balance_factor": 7,
+     "mixture_smoothing_lambda": 0.5514290511911544,
+     "mixture_diversity_lambda": 0.09569905000036626,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.0395678632329794,
+     "mixture_load_balance_alpha": 0.43796722117833725,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 32,
+     "mixture_gate_learning_rate": 0.05183291182312062,
+     "mixture_gate_lambda_l2": 8.897892151908811,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_entropy_lambda": 0.10005780709614848,
+     "mixture_gate_temperature_init": 2.2611847267665293,
+     "gate_temp_final_ratio": 0.7400506504476354,
+     "mixture_expert_capacity_factor": 1.0067372219638537,
+     "mixture_expert_choice_boost": 25.026558596569654,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.45896882094813246,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 4,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "min_data_in_leaf": 0.317,
+     "mixture_diversity_lambda": 0.2259,
+     "lambda_l2": 0.1405,
+     "learning_rate": 0.0969,
+     "bagging_fraction": 0.0757,
+     "mixture_routing_mode": 0.0246,
+     "mixture_warmup_iters": 0.0219,
+     "feature_fraction": 0.0215,
+     "mixture_init": 0.0163,
+     "extra_trees": 0.0133,
+     "mixture_e_step_mode": 0.0091,
+     "mixture_balance_factor": 0.0074,
+     "max_depth": 0.0054,
+     "mixture_num_experts": 0.0032,
+     "num_leaves": 0.0029,
+     "mixture_load_balance_alpha": 0.0028,
+     "bagging_freq": 0.0028,
+     "lambda_l1": 0.0026,
+     "mixture_r_smoothing": 0.0025,
+     "mixture_gate_type": 0.0025,
+     "mixture_expert_dropout_rate": 0.0023,
+     "mixture_refit_leaves": 0.0021,
+     "mixture_hard_m_step": 0.0007
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 223,
+        "mean": 55736.3371,
+        "std": 19329.9573,
+        "min": 50032.1886
+       },
+       "leaf_reuse": {
+        "n": 143,
+        "mean": 54071.6466,
+        "std": 10898.4952,
+        "min": 50286.1129
+       },
+       "none": {
+        "n": 134,
+        "mean": 54650.9092,
+        "std": 9836.951,
+        "min": 50319.592
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "none",
+       "delta_mean": 579.2626,
+       "p_value": 0.643599,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 449,
+        "mean": 53630.6562,
+        "std": 11762.1476,
+        "min": 50032.1886
+       },
+       "token_choice": {
+        "n": 51,
+        "mean": 66755.0168,
+        "std": 29214.5955,
+        "min": 50038.4021
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 13124.3606,
+       "p_value": 0.002724,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 145,
+        "mean": 55336.642,
+        "std": 15836.7701,
+        "min": 50286.1129
+       },
+       "gate_only": {
+        "n": 69,
+        "mean": 54704.369,
+        "std": 8815.5175,
+        "min": 50032.1886
+       },
+       "em": {
+        "n": 286,
+        "mean": 54847.0487,
+        "std": 15842.0633,
+        "min": 50038.4021
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 142.6797,
+       "p_value": 0.920211,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 142,
+        "mean": 56955.0442,
+        "std": 22295.2548,
+        "min": 50195.5568
+       },
+       "tree_hierarchical": {
+        "n": 156,
+        "mean": 52488.3863,
+        "std": 6821.791,
+        "min": 50187.0748
+       },
+       "uniform": {
+        "n": 17,
+        "mean": 62534.3639,
+        "std": 26069.0675,
+        "min": 50808.4965
+       },
+       "kmeans_features": {
+        "n": 68,
+        "mean": 54996.2863,
+        "std": 10949.6795,
+        "min": 50444.1114
+       },
+       "gmm_features": {
+        "n": 14,
+        "mean": 65965.0731,
+        "std": 20606.0131,
+        "min": 50738.5145
+       },
+       "random": {
+        "n": 103,
+        "mean": 53228.3811,
+        "std": 7335.0664,
+        "min": 50032.1886
+       }
+      },
+      "best": {
+       "value": "tree_hierarchical",
+       "runner_up": "random",
+       "delta_mean": 739.9948,
+       "p_value": 0.416942,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 210,
+        "mean": 55297.8656,
+        "std": 17696.1112,
+        "min": 50032.1886
+       },
+       "none": {
+        "n": 22,
+        "mean": 64738.3478,
+        "std": 25209.1516,
+        "min": 50576.5624
+       },
+       "markov": {
+        "n": 268,
+        "mean": 53909.9816,
+        "std": 10818.9119,
+        "min": 50187.0748
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 1387.884,
+       "p_value": 0.319363,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 54335.8159,
+        "std": 14598.3506,
+        "min": 50032.1886
+       },
+       "True": {
+        "n": 32,
+        "mean": 64234.6452,
+        "std": 18425.3868,
+        "min": 51092.1033
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 9898.8293,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 54424.3998,
+        "std": 15231.1019,
+        "min": 50032.1886
+       },
+       "True": {
+        "n": 30,
+        "mean": 63506.7524,
+        "std": 8515.1764,
+        "min": 57253.8543
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 9082.3526,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 90,
+       "mean_rmse": 59377.3346
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 410,
+       "mean_rmse": 54001.7326
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0613
+       ],
+       "n": 125,
+       "mean_rmse": 55180.4023
+      },
+      "Q2": {
+       "range": [
+        0.0613,
+        0.1073
+       ],
+       "n": 125,
+       "mean_rmse": 53362.9569
+      },
+      "Q3": {
+       "range": [
+        0.1073,
+        0.157
+       ],
+       "n": 125,
+       "mean_rmse": 53092.0466
+      },
+      "Q4": {
+       "range": [
+        0.157,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 58241.9581
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        12.75
+       ],
+       "n": 125,
+       "mean_rmse": 55839.6956
+      },
+      "Q2": {
+       "range": [
+        12.75,
+        17.0
+       ],
+       "n": 114,
+       "mean_rmse": 55686.0805
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        24.0
+       ],
+       "n": 119,
+       "mean_rmse": 53201.8775
+      },
+      "Q4": {
+       "range": [
+        24.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 55108.9572
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 63,
+       "mean_rmse": 59404.261
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 173,
+       "mean_rmse": 55584.5889
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 56,
+       "mean_rmse": 52957.5405
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 208,
+       "mean_rmse": 53655.9899
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0805
+       ],
+       "n": 125,
+       "mean_rmse": 59809.8159
+      },
+      "Q2": {
+       "range": [
+        0.0805,
+        0.0946
+       ],
+       "n": 125,
+       "mean_rmse": 54342.53
+      },
+      "Q3": {
+       "range": [
+        0.0946,
+        0.1136
+       ],
+       "n": 125,
+       "mean_rmse": 53438.242
+      },
+      "Q4": {
+       "range": [
+        0.1136,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52286.7758
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        38.0
+       ],
+       "n": 112,
+       "mean_rmse": 54170.7331
+      },
+      "Q2": {
+       "range": [
+        38.0,
+        48.0
+       ],
+       "n": 134,
+       "mean_rmse": 53408.3415
+      },
+      "Q3": {
+       "range": [
+        48.0,
+        60.0
+       ],
+       "n": 127,
+       "mean_rmse": 55795.5767
+      },
+      "Q4": {
+       "range": [
+        60.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 56494.4281
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 61,
+       "mean_rmse": 58813.4305
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 90,
+       "mean_rmse": 53116.3478
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 178,
+       "mean_rmse": 55641.004
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 171,
+       "mean_rmse": 53874.1591
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 114,
+       "mean_rmse": 53163.3115
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 110,
+       "mean_rmse": 54246.5006
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        18.0
+       ],
+       "n": 149,
+       "mean_rmse": 54323.153
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 57974.7094
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 17889.1,
+    "holdout": {
+     "holdout_rmse": 48643.46808862054,
+     "retrain_s": 44.2385,
+     "predict_s": 0.044,
+     "cv_rmse_of_winner": 50032.18860289062
+    }
+   }
+  },
+  "houses@s44": {
+   "dataset": "houses",
+   "seed": 44,
+   "X_search_shape": [
+    8000,
+    8
+   ],
+   "n_holdout": 2000,
+   "y_stats": {
+    "mean": 205256.982,
+    "std": 114405.72363980168
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50654.33815486819,
+    "rmse_p10": 50847.9634242126,
+    "rmse_median": 51120.27654932394,
+    "train_s_median": 0.20575066413730383,
+    "train_s_mean": 0.18109318893924353,
+    "train_s_p90": 0.2606154317781329,
+    "best_params": {
+     "learning_rate": 0.05840789917543454,
+     "num_leaves": 112,
+     "max_depth": 12,
+     "min_data_in_leaf": 12,
+     "lambda_l1": 0.42318194939643616,
+     "lambda_l2": 0.001934497622035067,
+     "feature_fraction": 0.7750954237465744,
+     "bagging_fraction": 0.8158423456565309,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.6673,
+     "learning_rate": 0.2284,
+     "min_data_in_leaf": 0.0629,
+     "max_depth": 0.0261,
+     "feature_fraction": 0.0079,
+     "bagging_fraction": 0.005,
+     "num_leaves": 0.0016,
+     "bagging_freq": 0.0007,
+     "lambda_l1": 0.0001,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 51846.3373,
+        "std": 2450.6921,
+        "min": 50654.3382
+       },
+       "True": {
+        "n": 30,
+        "mean": 64350.9585,
+        "std": 3681.9798,
+        "min": 58652.9668
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 12504.6212,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0548
+       ],
+       "n": 125,
+       "mean_rmse": 54142.3994
+      },
+      "Q2": {
+       "range": [
+        0.0548,
+        0.0624
+       ],
+       "n": 125,
+       "mean_rmse": 51567.6162
+      },
+      "Q3": {
+       "range": [
+        0.0624,
+        0.0742
+       ],
+       "n": 125,
+       "mean_rmse": 52081.2127
+      },
+      "Q4": {
+       "range": [
+        0.0742,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52595.2301
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        96.0
+       ],
+       "n": 124,
+       "mean_rmse": 53888.4843
+      },
+      "Q2": {
+       "range": [
+        96.0,
+        113.0
+       ],
+       "n": 113,
+       "mean_rmse": 51873.9383
+      },
+      "Q3": {
+       "range": [
+        113.0,
+        120.0
+       ],
+       "n": 134,
+       "mean_rmse": 52670.7577
+      },
+      "Q4": {
+       "range": [
+        120.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 51910.8426
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 102,
+       "mean_rmse": 54200.7503
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 61,
+       "mean_rmse": 52468.5722
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 337,
+       "mean_rmse": 52134.2667
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 109,
+       "mean_rmse": 51943.2776
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        15.0
+       ],
+       "n": 113,
+       "mean_rmse": 51918.9861
+      },
+      "Q3": {
+       "range": [
+        15.0,
+        20.0
+       ],
+       "n": 147,
+       "mean_rmse": 52091.0049
+      },
+      "Q4": {
+       "range": [
+        20.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 54292.1137
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0138
+       ],
+       "n": 125,
+       "mean_rmse": 53980.94
+      },
+      "Q2": {
+       "range": [
+        0.0138,
+        0.3111
+       ],
+       "n": 125,
+       "mean_rmse": 51692.0805
+      },
+      "Q3": {
+       "range": [
+        0.3111,
+        0.8567
+       ],
+       "n": 125,
+       "mean_rmse": 52463.0322
+      },
+      "Q4": {
+       "range": [
+        0.8567,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52250.4058
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 125,
+       "mean_rmse": 53238.865
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.0007
+       ],
+       "n": 125,
+       "mean_rmse": 52128.8312
+      },
+      "Q3": {
+       "range": [
+        0.0007,
+        0.0024
+       ],
+       "n": 125,
+       "mean_rmse": 52314.3403
+      },
+      "Q4": {
+       "range": [
+        0.0024,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52704.4219
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7201
+       ],
+       "n": 125,
+       "mean_rmse": 53775.7243
+      },
+      "Q2": {
+       "range": [
+        0.7201,
+        0.7446
+       ],
+       "n": 125,
+       "mean_rmse": 52081.5784
+      },
+      "Q3": {
+       "range": [
+        0.7446,
+        0.7641
+       ],
+       "n": 125,
+       "mean_rmse": 51757.3688
+      },
+      "Q4": {
+       "range": [
+        0.7641,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52771.7871
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8165
+       ],
+       "n": 125,
+       "mean_rmse": 52748.7338
+      },
+      "Q2": {
+       "range": [
+        0.8165,
+        0.8376
+       ],
+       "n": 125,
+       "mean_rmse": 52226.9187
+      },
+      "Q3": {
+       "range": [
+        0.8376,
+        0.8807
+       ],
+       "n": 125,
+       "mean_rmse": 52445.8032
+      },
+      "Q4": {
+       "range": [
+        0.8807,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52965.0027
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 463.4,
+    "holdout": {
+     "holdout_rmse": 48838.263864625835,
+     "retrain_s": 0.2895,
+     "predict_s": 0.0027,
+     "cv_rmse_of_winner": 50654.33815486819
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 50348.606126918145,
+    "rmse_p10": 50562.94464423826,
+    "rmse_median": 51067.47741108843,
+    "train_s_median": 1.4723297756165266,
+    "train_s_mean": 1.6346338571637868,
+    "train_s_p90": 2.78747956559062,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 6,
+     "learning_rate": 0.09752268018678915,
+     "num_leaves": 80,
+     "max_depth": 12,
+     "min_data_in_leaf": 17,
+     "lambda_l1": 0.020803313130906075,
+     "lambda_l2": 5.351377705402213e-06,
+     "feature_fraction": 0.7729336598997042,
+     "bagging_fraction": 0.9752016969941822,
+     "bagging_freq": 0,
+     "extra_trees": false,
+     "mixture_init": "uniform",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 5,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.32577382423122836,
+     "mixture_diversity_lambda": 0.17161364246640243,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.065530290547334,
+     "mixture_load_balance_alpha": 0.4915597028932099,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 57,
+     "mixture_gate_learning_rate": 0.16314319539547728,
+     "mixture_gate_lambda_l2": 0.015058272546070084,
+     "mixture_gate_iters_per_round": 1,
+     "mixture_gate_entropy_lambda": 0.26232378895875497,
+     "mixture_gate_temperature_init": 0.6017165598871621,
+     "gate_temp_final_ratio": 0.4615975698227594,
+     "mixture_gate_retrain_interval": 5,
+     "mixture_expert_capacity_factor": 1.3870429229554626,
+     "mixture_expert_choice_boost": 7.071652977170541,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "every_n",
+     "mixture_refit_decay_rate": 0.4080206436846957,
+     "mixture_refit_every_n": 28,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6929,
+     "extra_trees": 0.2233,
+     "mixture_expert_dropout_rate": 0.02,
+     "num_leaves": 0.0142,
+     "min_data_in_leaf": 0.0107,
+     "mixture_gate_type": 0.0073,
+     "feature_fraction": 0.0055,
+     "mixture_warmup_iters": 0.005,
+     "mixture_e_step_mode": 0.0035,
+     "bagging_freq": 0.0027,
+     "bagging_fraction": 0.0026,
+     "max_depth": 0.0025,
+     "mixture_init": 0.0021,
+     "mixture_diversity_lambda": 0.0016,
+     "mixture_load_balance_alpha": 0.0014,
+     "mixture_hard_m_step": 0.0014,
+     "lambda_l1": 0.0012,
+     "mixture_routing_mode": 0.0009,
+     "mixture_balance_factor": 0.0005,
+     "mixture_r_smoothing": 0.0004,
+     "mixture_num_experts": 0.0002,
+     "mixture_refit_leaves": 0.0001,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 63,
+        "mean": 54676.3713,
+        "std": 8222.0732,
+        "min": 50613.5339
+       },
+       "none": {
+        "n": 29,
+        "mean": 63392.1433,
+        "std": 17061.2321,
+        "min": 50608.3009
+       },
+       "leaf_reuse": {
+        "n": 408,
+        "mean": 52833.8534,
+        "std": 7092.3304,
+        "min": 50348.6061
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 1842.5179,
+       "p_value": 0.098542,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 128,
+        "mean": 56058.1154,
+        "std": 11701.5448,
+        "min": 50431.9257
+       },
+       "expert_choice": {
+        "n": 372,
+        "mean": 52859.5617,
+        "std": 6919.7726,
+        "min": 50348.6061
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 3198.5537,
+       "p_value": 0.004121,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 293,
+        "mean": 52865.1352,
+        "std": 5831.4007,
+        "min": 50348.6061
+       },
+       "gate_only": {
+        "n": 54,
+        "mean": 59336.7427,
+        "std": 17510.1263,
+        "min": 50435.4329
+       },
+       "loss_only": {
+        "n": 153,
+        "mean": 53238.7388,
+        "std": 7158.7776,
+        "min": 50503.6169
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 373.6036,
+       "p_value": 0.57957,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 114,
+        "mean": 52881.7566,
+        "std": 8170.5323,
+        "min": 50378.3946
+       },
+       "tree_hierarchical": {
+        "n": 70,
+        "mean": 56268.403,
+        "std": 11726.2868,
+        "min": 50360.3696
+       },
+       "random": {
+        "n": 129,
+        "mean": 53692.4163,
+        "std": 9104.7337,
+        "min": 50503.6169
+       },
+       "gmm": {
+        "n": 32,
+        "mean": 54553.5168,
+        "std": 8353.9899,
+        "min": 51073.1369
+       },
+       "gmm_features": {
+        "n": 18,
+        "mean": 57202.5936,
+        "std": 6881.1089,
+        "min": 50730.8716
+       },
+       "uniform": {
+        "n": 137,
+        "mean": 52337.2726,
+        "std": 5577.6317,
+        "min": 50348.6061
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "kmeans_features",
+       "delta_mean": 544.484,
+       "p_value": 0.548241,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 117,
+        "mean": 52855.9268,
+        "std": 3765.1454,
+        "min": 50503.6169
+       },
+       "ema": {
+        "n": 124,
+        "mean": 55549.007,
+        "std": 13014.9506,
+        "min": 50360.3696
+       },
+       "markov": {
+        "n": 259,
+        "mean": 53154.3453,
+        "std": 7102.7703,
+        "min": 50348.6061
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 298.4185,
+       "p_value": 0.596851,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 308,
+        "mean": 53816.7667,
+        "std": 9192.4684,
+        "min": 50348.6061
+       },
+       "True": {
+        "n": 192,
+        "mean": 53456.4146,
+        "std": 7314.2267,
+        "min": 50378.3946
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 360.3521,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 67077.5712,
+        "std": 12975.966,
+        "min": 56323.5633
+       },
+       "False": {
+        "n": 469,
+        "mean": 52792.7314,
+        "std": 7324.3767,
+        "min": 50348.6061
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 14284.8398,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 69,
+       "mean_rmse": 59718.5784
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 431,
+       "mean_rmse": 52711.401
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.1392
+       ],
+       "n": 125,
+       "mean_rmse": 52596.2334
+      },
+      "Q2": {
+       "range": [
+        0.1392,
+        0.1779
+       ],
+       "n": 125,
+       "mean_rmse": 52710.162
+      },
+      "Q3": {
+       "range": [
+        0.1779,
+        0.3446
+       ],
+       "n": 125,
+       "mean_rmse": 54410.651
+      },
+      "Q4": {
+       "range": [
+        0.3446,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 54996.5195
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 92,
+       "mean_rmse": 52903.8325
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 144,
+       "mean_rmse": 52519.7261
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 126,
+       "mean_rmse": 53501.4449
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 138,
+       "mean_rmse": 55565.3661
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 245,
+       "mean_rmse": 52619.1678
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        8.0
+       ],
+       "n": 111,
+       "mean_rmse": 55505.3252
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 144,
+       "mean_rmse": 54072.2816
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0929
+       ],
+       "n": 125,
+       "mean_rmse": 57922.2611
+      },
+      "Q2": {
+       "range": [
+        0.0929,
+        0.1076
+       ],
+       "n": 125,
+       "mean_rmse": 51976.9329
+      },
+      "Q3": {
+       "range": [
+        0.1076,
+        0.1279
+       ],
+       "n": 125,
+       "mean_rmse": 52322.3763
+      },
+      "Q4": {
+       "range": [
+        0.1279,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 52491.9956
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        65.75
+       ],
+       "n": 125,
+       "mean_rmse": 54825.582
+      },
+      "Q2": {
+       "range": [
+        65.75,
+        76.0
+       ],
+       "n": 123,
+       "mean_rmse": 53191.1202
+      },
+      "Q3": {
+       "range": [
+        76.0,
+        84.0
+       ],
+       "n": 118,
+       "mean_rmse": 52793.2573
+      },
+      "Q4": {
+       "range": [
+        84.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 53834.969
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 72,
+       "mean_rmse": 59553.7531
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 136,
+       "mean_rmse": 53142.6459
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 292,
+       "mean_rmse": 52479.1975
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 121,
+       "mean_rmse": 52530.9065
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        17.0
+       ],
+       "n": 101,
+       "mean_rmse": 52469.1748
+      },
+      "Q3": {
+       "range": [
+        17.0,
+        22.0
+       ],
+       "n": 143,
+       "mean_rmse": 52682.2717
+      },
+      "Q4": {
+       "range": [
+        22.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 56666.7004
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 4169.3,
+    "holdout": {
+     "holdout_rmse": 47775.32026838286,
+     "retrain_s": 2.2995,
+     "predict_s": 0.04,
+     "cv_rmse_of_winner": 50348.606126918145
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_synthetic_ensemble_report.md
+++ b/bench_results/wide_v081/ds_synthetic_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['synthetic'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| synthetic | naive-ensemble | **4.72332** ± 0.32678 | 5.42496 | 0.0% | 0.43 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| synthetic@s42 | naive-ensemble | 5.3159 | 5.6074 | 0.173 | 437 |
+| synthetic@s43 | naive-ensemble | 5.4566 | 5.7179 | 0.429 | 980 |
+| synthetic@s44 | naive-ensemble | 5.5024 | 5.7684 | 0.280 | 672 |
+
+
+
+---
+
+## synthetic@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 4.97808** (winner retrained in 0.17s, cv score of winner: 5.3159)
+- cv best RMSE: 5.3159, median: 5.6074, p10: 5.4192
+- train: median 0.173s/fold, mean 0.172s, p90 0.254s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.696 |
+| `learning_rate` | 0.253 |
+| `bagging_fraction` | 0.017 |
+| `bagging_freq` | 0.014 |
+| `feature_fraction` | 0.010 |
+| `num_leaves` | 0.007 |
+| `max_depth` | 0.002 |
+| `lambda_l1` | 0.001 |
+| `extra_trees` | 0.001 |
+| `n_models` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 437 | 5.8014 | 0.6251 | 5.3159 |
+| False | 63 | 6.0527 | 0.5984 | 5.3736 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.1770 | 5.6431 | 5.6511 | 5.8612 | **Q2** [0.1028, 0.118] |
+| `num_leaves` | 5.7659 | 5.6967 | 5.8270 | 6.0304 | **Q2** [27.0, 32.0] |
+| `max_depth` | 6.1574 | 5.8847 | 5.6745 | 5.9240 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | — | 5.5233 | 5.6605 | 6.4879 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 5.9329 | 5.9424 | 5.7070 | 5.7500 | **Q3** [0.0083, 0.0226] |
+| `lambda_l2` | 5.8499 | 5.6781 | 5.7458 | 6.0584 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.0968 | 5.8607 | 5.7405 | 5.6343 | **Q4** [0.9811, ∞) |
+| `bagging_fraction` | 6.0281 | 5.6927 | 5.6123 | 5.9992 | **Q3** [0.7759, 0.7967] |
+
+#### E. Slice plot
+
+![synthetic@s42/naive-ensemble](slice_synthetic@s42_naive-ensemble.png)
+
+
+---
+
+## synthetic@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 4.26202** (winner retrained in 0.53s, cv score of winner: 5.4566)
+- cv best RMSE: 5.4566, median: 5.7179, p10: 5.5596
+- train: median 0.429s/fold, mean 0.389s, p90 0.553s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.833 |
+| `feature_fraction` | 0.055 |
+| `learning_rate` | 0.029 |
+| `bagging_fraction` | 0.027 |
+| `num_leaves` | 0.021 |
+| `max_depth` | 0.016 |
+| `bagging_freq` | 0.015 |
+| `extra_trees` | 0.004 |
+| `n_models` | 0.001 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 5.8785 | 0.4542 | 5.4566 |
+| True | 32 | 6.5740 | 0.9689 | 5.6650 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.0646 | 5.8554 | 5.8343 | 5.9378 | **Q3** [0.0442, 0.0551] |
+| `num_leaves` | 5.9562 | 5.7972 | 5.8913 | 6.0475 | **Q2** [46.0, 53.0] |
+| `max_depth` | 6.5456 | 5.9124 | 5.8932 | 5.8209 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | — | 5.7131 | 5.7993 | 6.3985 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 5.9598 | 5.8026 | 5.9442 | 5.9855 | **Q2** [0.0014, 0.0047] |
+| `lambda_l2` | 5.9276 | 5.8550 | 5.8819 | 6.0276 | **Q2** [0.0, 0.0002] |
+| `feature_fraction` | 6.2281 | 5.7835 | 5.7656 | 5.9150 | **Q3** [0.9281, 0.9523] |
+| `bagging_fraction` | 6.0150 | 5.8623 | 5.8120 | 6.0029 | **Q3** [0.8396, 0.8803] |
+
+#### E. Slice plot
+
+![synthetic@s43/naive-ensemble](slice_synthetic@s43_naive-ensemble.png)
+
+
+---
+
+## synthetic@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 4.92985** (winner retrained in 0.59s, cv score of winner: 5.5024)
+- cv best RMSE: 5.5024, median: 5.7684, p10: 5.5967
+- train: median 0.280s/fold, mean 0.266s, p90 0.397s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.626 |
+| `learning_rate` | 0.206 |
+| `feature_fraction` | 0.088 |
+| `n_models` | 0.027 |
+| `bagging_fraction` | 0.016 |
+| `max_depth` | 0.015 |
+| `num_leaves` | 0.012 |
+| `extra_trees` | 0.005 |
+| `bagging_freq` | 0.002 |
+| `lambda_l2` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 413 | 5.8941 | 0.4930 | 5.5024 |
+| True | 87 | 6.4892 | 0.6728 | 5.8148 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.0287 | 5.9279 | 5.9387 | 6.0953 | **Q2** [0.041, 0.0703] |
+| `num_leaves` | 6.3999 | 5.9567 | 5.8209 | 5.8324 | **Q3** [105.0, 117.0] |
+| `max_depth` | 6.5329 | 5.8996 | 5.9648 | 5.9191 | **Q2** [8.0, 9.0] |
+| `min_data_in_leaf` | — | 5.7539 | 5.8150 | 6.5983 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 6.1981 | 5.9757 | 5.9435 | 5.8734 | **Q4** [0.7269, ∞) |
+| `lambda_l2` | 5.9886 | 5.8508 | 5.9147 | 6.2366 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 6.4315 | 5.7970 | 5.8457 | 5.9164 | **Q2** [0.9078, 0.9304] |
+| `bagging_fraction` | 5.9992 | 6.0241 | 5.9536 | 6.0137 | **Q3** [0.8284, 0.8945] |
+
+#### E. Slice plot
+
+![synthetic@s44/naive-ensemble](slice_synthetic@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_synthetic_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_synthetic_ensemble_summary.json
@@ -1,0 +1,1169 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "synthetic"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "synthetic": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 4.9780791307098475,
+      "cv_best": 5.3159050922239715,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1688
+     },
+     "43": {
+      "holdout_rmse": 4.262024823029801,
+      "cv_best": 5.456578431551898,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5278
+     },
+     "44": {
+      "holdout_rmse": 4.929851990923527,
+      "cv_best": 5.502397346043145,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5852
+     }
+    },
+    "holdout_mean": 4.723319,
+    "holdout_std": 0.326778,
+    "cv_best_mean": 5.42496
+   }
+  }
+ },
+ "runs": {
+  "synthetic@s42": {
+   "dataset": "synthetic",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -1.1238261010719193,
+    "std": 12.024415840059472
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.3159050922239715,
+    "rmse_p10": 5.419177140065674,
+    "rmse_median": 5.607416022415975,
+    "train_s_median": 0.17305779550224543,
+    "train_s_mean": 0.17153983008116483,
+    "train_s_p90": 0.25371948029845953,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.1040431220226422,
+     "num_leaves": 23,
+     "max_depth": 9,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.016835861061216716,
+     "lambda_l2": 3.005023111987688e-06,
+     "feature_fraction": 0.9685745467617922,
+     "bagging_fraction": 0.8044340706917712,
+     "bagging_freq": 0,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6957,
+     "learning_rate": 0.2528,
+     "bagging_fraction": 0.0169,
+     "bagging_freq": 0.0137,
+     "feature_fraction": 0.0096,
+     "num_leaves": 0.0075,
+     "max_depth": 0.0021,
+     "lambda_l1": 0.0008,
+     "extra_trees": 0.0005,
+     "n_models": 0.0002,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 63,
+        "mean": 6.0527,
+        "std": 0.5984,
+        "min": 5.3736
+       },
+       "True": {
+        "n": 437,
+        "mean": 5.8014,
+        "std": 0.6251,
+        "min": 5.3159
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.2513,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1028
+       ],
+       "n": 125,
+       "mean_rmse": 6.177
+      },
+      "Q2": {
+       "range": [
+        0.1028,
+        0.118
+       ],
+       "n": 125,
+       "mean_rmse": 5.6431
+      },
+      "Q3": {
+       "range": [
+        0.118,
+        0.1398
+       ],
+       "n": 125,
+       "mean_rmse": 5.6511
+      },
+      "Q4": {
+       "range": [
+        0.1398,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.8612
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        27.0
+       ],
+       "n": 117,
+       "mean_rmse": 5.7659
+      },
+      "Q2": {
+       "range": [
+        27.0,
+        32.0
+       ],
+       "n": 117,
+       "mean_rmse": 5.6967
+      },
+      "Q3": {
+       "range": [
+        32.0,
+        73.25
+       ],
+       "n": 141,
+       "mean_rmse": 5.827
+      },
+      "Q4": {
+       "range": [
+        73.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.0304
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 75,
+       "mean_rmse": 6.1574
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 53,
+       "mean_rmse": 5.8847
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 244,
+       "mean_rmse": 5.6745
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 5.924
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 161,
+       "mean_rmse": 5.5233
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 208,
+       "mean_rmse": 5.6605
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 6.4879
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.9329
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0083
+       ],
+       "n": 125,
+       "mean_rmse": 5.9424
+      },
+      "Q3": {
+       "range": [
+        0.0083,
+        0.0226
+       ],
+       "n": 125,
+       "mean_rmse": 5.707
+      },
+      "Q4": {
+       "range": [
+        0.0226,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.75
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.8499
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.6781
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.7458
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.0584
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9152
+       ],
+       "n": 125,
+       "mean_rmse": 6.0968
+      },
+      "Q2": {
+       "range": [
+        0.9152,
+        0.961
+       ],
+       "n": 125,
+       "mean_rmse": 5.8607
+      },
+      "Q3": {
+       "range": [
+        0.961,
+        0.9811
+       ],
+       "n": 125,
+       "mean_rmse": 5.7405
+      },
+      "Q4": {
+       "range": [
+        0.9811,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.6343
+      },
+      "best_quartile": "Q4"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7425
+       ],
+       "n": 125,
+       "mean_rmse": 6.0281
+      },
+      "Q2": {
+       "range": [
+        0.7425,
+        0.7759
+       ],
+       "n": 125,
+       "mean_rmse": 5.6927
+      },
+      "Q3": {
+       "range": [
+        0.7759,
+        0.7967
+       ],
+       "n": 125,
+       "mean_rmse": 5.6123
+      },
+      "Q4": {
+       "range": [
+        0.7967,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9992
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 437.2,
+    "holdout": {
+     "holdout_rmse": 4.9780791307098475,
+     "retrain_s": 0.1688,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 5.3159050922239715
+    }
+   }
+  },
+  "synthetic@s43": {
+   "dataset": "synthetic",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.875910802699441,
+    "std": 11.885024346049207
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.456578431551898,
+    "rmse_p10": 5.559576652550493,
+    "rmse_median": 5.717876128749566,
+    "train_s_median": 0.42926231808960436,
+    "train_s_mean": 0.38895289827734236,
+    "train_s_p90": 0.552712208405137,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.052038859824489705,
+     "num_leaves": 44,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.0019297510957203533,
+     "lambda_l2": 0.012989667264938628,
+     "feature_fraction": 0.9626076432452468,
+     "bagging_fraction": 0.8074091241243285,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.833,
+     "feature_fraction": 0.0547,
+     "learning_rate": 0.0289,
+     "bagging_fraction": 0.0266,
+     "num_leaves": 0.0206,
+     "max_depth": 0.0157,
+     "bagging_freq": 0.0147,
+     "extra_trees": 0.0037,
+     "n_models": 0.0011,
+     "lambda_l1": 0.0008,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 5.8785,
+        "std": 0.4542,
+        "min": 5.4566
+       },
+       "True": {
+        "n": 32,
+        "mean": 6.574,
+        "std": 0.9689,
+        "min": 5.665
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.6955,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0358
+       ],
+       "n": 125,
+       "mean_rmse": 6.0646
+      },
+      "Q2": {
+       "range": [
+        0.0358,
+        0.0442
+       ],
+       "n": 125,
+       "mean_rmse": 5.8554
+      },
+      "Q3": {
+       "range": [
+        0.0442,
+        0.0551
+       ],
+       "n": 125,
+       "mean_rmse": 5.8343
+      },
+      "Q4": {
+       "range": [
+        0.0551,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9378
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        46.0
+       ],
+       "n": 113,
+       "mean_rmse": 5.9562
+      },
+      "Q2": {
+       "range": [
+        46.0,
+        53.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.7972
+      },
+      "Q3": {
+       "range": [
+        53.0,
+        62.0
+       ],
+       "n": 132,
+       "mean_rmse": 5.8913
+      },
+      "Q4": {
+       "range": [
+        62.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 6.0475
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 34,
+       "mean_rmse": 6.5456
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 194,
+       "mean_rmse": 5.9124
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 120,
+       "mean_rmse": 5.8932
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 152,
+       "mean_rmse": 5.8209
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 165,
+       "mean_rmse": 5.7131
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 208,
+       "mean_rmse": 5.7993
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 6.3985
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0014
+       ],
+       "n": 125,
+       "mean_rmse": 5.9598
+      },
+      "Q2": {
+       "range": [
+        0.0014,
+        0.0047
+       ],
+       "n": 125,
+       "mean_rmse": 5.8026
+      },
+      "Q3": {
+       "range": [
+        0.0047,
+        0.0931
+       ],
+       "n": 125,
+       "mean_rmse": 5.9442
+      },
+      "Q4": {
+       "range": [
+        0.0931,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9855
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.9276
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0002
+       ],
+       "n": 125,
+       "mean_rmse": 5.855
+      },
+      "Q3": {
+       "range": [
+        0.0002,
+        0.0187
+       ],
+       "n": 125,
+       "mean_rmse": 5.8819
+      },
+      "Q4": {
+       "range": [
+        0.0187,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.0276
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9066
+       ],
+       "n": 125,
+       "mean_rmse": 6.2281
+      },
+      "Q2": {
+       "range": [
+        0.9066,
+        0.9281
+       ],
+       "n": 125,
+       "mean_rmse": 5.7835
+      },
+      "Q3": {
+       "range": [
+        0.9281,
+        0.9523
+       ],
+       "n": 125,
+       "mean_rmse": 5.7656
+      },
+      "Q4": {
+       "range": [
+        0.9523,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.915
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7993
+       ],
+       "n": 125,
+       "mean_rmse": 6.015
+      },
+      "Q2": {
+       "range": [
+        0.7993,
+        0.8396
+       ],
+       "n": 125,
+       "mean_rmse": 5.8623
+      },
+      "Q3": {
+       "range": [
+        0.8396,
+        0.8803
+       ],
+       "n": 125,
+       "mean_rmse": 5.812
+      },
+      "Q4": {
+       "range": [
+        0.8803,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.0029
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 979.8,
+    "holdout": {
+     "holdout_rmse": 4.262024823029801,
+     "retrain_s": 0.5278,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 5.456578431551898
+    }
+   }
+  },
+  "synthetic@s44": {
+   "dataset": "synthetic",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.8513872282377526,
+    "std": 12.522023281908787
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.502397346043145,
+    "rmse_p10": 5.596693862061823,
+    "rmse_median": 5.768439643468171,
+    "train_s_median": 0.2796251457184553,
+    "train_s_mean": 0.2661917904168367,
+    "train_s_p90": 0.39683736305683853,
+    "best_params": {
+     "n_models": 3,
+     "learning_rate": 0.04686169377325493,
+     "num_leaves": 102,
+     "max_depth": 8,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.8010137684352713,
+     "lambda_l2": 4.38440737052549e-08,
+     "feature_fraction": 0.9175311332829224,
+     "bagging_fraction": 0.7466480010756662,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6261,
+     "learning_rate": 0.2061,
+     "feature_fraction": 0.0877,
+     "n_models": 0.0268,
+     "bagging_fraction": 0.0158,
+     "max_depth": 0.0151,
+     "num_leaves": 0.0121,
+     "extra_trees": 0.0055,
+     "bagging_freq": 0.0024,
+     "lambda_l2": 0.002,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 87,
+        "mean": 6.4892,
+        "std": 0.6728,
+        "min": 5.8148
+       },
+       "False": {
+        "n": 413,
+        "mean": 5.8941,
+        "std": 0.493,
+        "min": 5.5024
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5951,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.041
+       ],
+       "n": 125,
+       "mean_rmse": 6.0287
+      },
+      "Q2": {
+       "range": [
+        0.041,
+        0.0703
+       ],
+       "n": 125,
+       "mean_rmse": 5.9279
+      },
+      "Q3": {
+       "range": [
+        0.0703,
+        0.1239
+       ],
+       "n": 125,
+       "mean_rmse": 5.9387
+      },
+      "Q4": {
+       "range": [
+        0.1239,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.0953
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        91.0
+       ],
+       "n": 124,
+       "mean_rmse": 6.3999
+      },
+      "Q2": {
+       "range": [
+        91.0,
+        105.0
+       ],
+       "n": 111,
+       "mean_rmse": 5.9567
+      },
+      "Q3": {
+       "range": [
+        105.0,
+        117.0
+       ],
+       "n": 134,
+       "mean_rmse": 5.8209
+      },
+      "Q4": {
+       "range": [
+        117.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 5.8324
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 59,
+       "mean_rmse": 6.5329
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 147,
+       "mean_rmse": 5.8996
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        11.0
+       ],
+       "n": 130,
+       "mean_rmse": 5.9648
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 164,
+       "mean_rmse": 5.9191
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 159,
+       "mean_rmse": 5.7539
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 212,
+       "mean_rmse": 5.815
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 6.5983
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 6.1981
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0064
+       ],
+       "n": 125,
+       "mean_rmse": 5.9757
+      },
+      "Q3": {
+       "range": [
+        0.0064,
+        0.7269
+       ],
+       "n": 125,
+       "mean_rmse": 5.9435
+      },
+      "Q4": {
+       "range": [
+        0.7269,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.8734
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.9886
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.8508
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.9147
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.2366
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9078
+       ],
+       "n": 125,
+       "mean_rmse": 6.4315
+      },
+      "Q2": {
+       "range": [
+        0.9078,
+        0.9304
+       ],
+       "n": 125,
+       "mean_rmse": 5.797
+      },
+      "Q3": {
+       "range": [
+        0.9304,
+        0.954
+       ],
+       "n": 125,
+       "mean_rmse": 5.8457
+      },
+      "Q4": {
+       "range": [
+        0.954,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9164
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7421
+       ],
+       "n": 125,
+       "mean_rmse": 5.9992
+      },
+      "Q2": {
+       "range": [
+        0.7421,
+        0.8284
+       ],
+       "n": 125,
+       "mean_rmse": 6.0241
+      },
+      "Q3": {
+       "range": [
+        0.8284,
+        0.8945
+       ],
+       "n": 125,
+       "mean_rmse": 5.9536
+      },
+      "Q4": {
+       "range": [
+        0.8945,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.0137
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 672.3,
+    "holdout": {
+     "holdout_rmse": 4.929851990923527,
+     "retrain_s": 0.5852,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 5.502397346043145
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_synthetic_report.md
+++ b/bench_results/wide_v081/ds_synthetic_report.md
@@ -1,0 +1,537 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['synthetic'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| synthetic | naive-lightgbm | **4.83980** ± 0.31113 | 5.48121 | 0.0% | 0.23 |
+| synthetic | moe | **3.79177** ± 0.24946 | 4.27509 | 0.0% | 1.76 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| synthetic@s42 | naive-lightgbm | 5.3096 | 5.5469 | 0.150 | 377 |
+| synthetic@s42 | moe | 5.1618 | 5.4889 | 2.923 | 6756 |
+| synthetic@s43 | naive-lightgbm | 5.5192 | 5.8184 | 0.099 | 249 |
+| synthetic@s43 | moe | 4.1840 | 4.7100 | 0.388 | 1814 |
+| synthetic@s44 | naive-lightgbm | 5.6149 | 6.0510 | 0.123 | 307 |
+| synthetic@s44 | moe | 3.4794 | 4.5422 | 0.228 | 711 |
+
+
+
+---
+
+## synthetic@s42  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 4.40130** (winner retrained in 0.36s, cv score of winner: 5.3096)
+- cv best RMSE: 5.3096, median: 5.5469, p10: 5.4101
+- train: median 0.150s/fold, mean 0.146s, p90 0.209s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.671 |
+| `learning_rate` | 0.260 |
+| `feature_fraction` | 0.032 |
+| `bagging_fraction` | 0.022 |
+| `num_leaves` | 0.008 |
+| `extra_trees` | 0.003 |
+| `max_depth` | 0.001 |
+| `bagging_freq` | 0.001 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 5.7104 | 0.4933 | 5.3096 |
+| True | 32 | 6.8388 | 1.3862 | 5.6091 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.0027 | 5.6405 | 5.6945 | 5.7926 | **Q2** [0.0461, 0.0568] |
+| `num_leaves` | 5.6610 | 5.6656 | 5.9632 | 5.8424 | **Q1** [None, 30.0] |
+| `max_depth` | 6.1194 | 5.6517 | — | 5.7335 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 5.5496 | 5.5381 | 5.6075 | 6.4120 | **Q2** [7.0, 8.0] |
+| `lambda_l1` | 5.9018 | 5.8799 | 5.6872 | 5.6616 | **Q4** [0.9322, ∞) |
+| `lambda_l2` | 5.6751 | 5.8891 | 5.8415 | 5.7247 | **Q1** [None, 0.0] |
+| `feature_fraction` | 6.1383 | 5.7015 | 5.6382 | 5.6524 | **Q3** [0.9547, 0.9788] |
+| `bagging_fraction` | 5.7691 | 5.7066 | 5.6783 | 5.9765 | **Q3** [0.6881, 0.7753] |
+
+#### E. Slice plot
+
+![synthetic@s42/naive-lightgbm](slice_synthetic@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 4.11088** (winner retrained in 4.59s, cv score of winner: 5.1618)
+- cv best RMSE: 5.1618, median: 5.4889, p10: 5.2769
+- train: median 2.923s/fold, mean 2.685s, p90 4.444s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.606 |
+| `mixture_gate_type` | 0.107 |
+| `min_data_in_leaf` | 0.081 |
+| `num_leaves` | 0.049 |
+| `feature_fraction` | 0.039 |
+| `mixture_init` | 0.021 |
+| `mixture_expert_dropout_rate` | 0.019 |
+| `mixture_warmup_iters` | 0.013 |
+| `mixture_diversity_lambda` | 0.007 |
+| `extra_trees` | 0.007 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 5.6612 (n=396) | gbdt | Δ +0.5435 | p=0.00e+00 |
+| `mixture_routing_mode` | **token_choice** | 5.7144 (n=420) | expert_choice | Δ +0.7103 | p=0.00e+00 |
+| `mixture_e_step_mode` | **gate_only** | 5.7048 (n=432) | loss_only | Δ +0.8237 | p=3.78e-04 |
+| `mixture_r_smoothing` | **none** | 5.6960 (n=389) | markov | Δ +0.5051 | p=4.81e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 396 | 5.6612 | 0.7024 | 5.1618 |
+| gbdt | 61 | 6.2047 | 0.6100 | 5.4905 |
+| none | 43 | 6.8299 | 1.0100 | 5.8592 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 420 | 5.7144 | 0.7522 | 5.1618 |
+| expert_choice | 80 | 6.4247 | 0.8154 | 5.5558 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 432 | 5.7048 | 0.6749 | 5.1618 |
+| loss_only | 27 | 6.5285 | 1.0233 | 5.5642 |
+| em | 41 | 6.6656 | 1.1169 | 5.5815 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 325 | 5.7071 | 0.8208 | 5.1618 |
+| tree_hierarchical | 49 | 5.8407 | 0.5617 | 5.3535 |
+| kmeans_features | 38 | 5.9068 | 0.7556 | 5.3458 |
+| gmm_features | 17 | 6.0124 | 0.6026 | 5.4191 |
+| random | 44 | 6.2409 | 0.8644 | 5.2556 |
+| uniform | 27 | 6.3615 | 0.5714 | 5.4839 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 389 | 5.6960 | 0.7104 | 5.1618 |
+| markov | 47 | 6.2011 | 1.1351 | 5.2259 |
+| ema | 64 | 6.3566 | 0.7568 | 5.3113 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 5.7960 | 0.7793 | 5.1618 |
+| True | 32 | 6.2967 | 1.0158 | 5.3865 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 467 | 5.7636 | 0.6904 | 5.1618 |
+| True | 33 | 6.7402 | 1.4850 | 5.3635 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 6.5055 | 5.9987 | — | 5.6677 | **Q4** [6.0, ∞) |
+| `mixture_diversity_lambda` | 6.0308 | 5.7026 | 5.8039 | 5.7748 | **Q2** [0.3259, 0.365] |
+| `mixture_warmup_iters` | 5.8027 | 5.6146 | 5.7452 | 6.1165 | **Q2** [9.0, 13.0] |
+| `mixture_balance_factor` | 5.8329 | — | — | 5.8270 | **Q4** [4.0, ∞) |
+| `learning_rate` | 6.1627 | 5.6217 | 5.7668 | 5.7610 | **Q2** [0.1049, 0.142] |
+| `num_leaves` | 6.2358 | 5.6597 | 5.7198 | 5.6958 | **Q2** [96.75, 108.0] |
+| `max_depth` | 6.3327 | 5.7969 | 5.7470 | 5.6335 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 5.6772 | 5.6763 | 5.5703 | 6.2672 | **Q3** [8.0, 11.0] |
+
+#### E. Slice plot
+
+![synthetic@s42/moe](slice_synthetic@s42_moe.png)
+
+
+---
+
+## synthetic@s43  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 5.09057** (winner retrained in 0.18s, cv score of winner: 5.5192)
+- cv best RMSE: 5.5192, median: 5.8184, p10: 5.6691
+- train: median 0.099s/fold, mean 0.095s, p90 0.137s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.771 |
+| `learning_rate` | 0.136 |
+| `bagging_fraction` | 0.042 |
+| `feature_fraction` | 0.027 |
+| `bagging_freq` | 0.007 |
+| `max_depth` | 0.005 |
+| `lambda_l1` | 0.005 |
+| `lambda_l2` | 0.004 |
+| `extra_trees` | 0.002 |
+| `num_leaves` | 0.002 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 446 | 5.9559 | 0.4653 | 5.5192 |
+| False | 54 | 6.3077 | 0.6867 | 5.7045 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.2452 | 5.8588 | 5.9002 | 5.9714 | **Q2** [0.104, 0.12] |
+| `num_leaves` | 6.1871 | 5.9433 | 5.9227 | 5.9358 | **Q3** [118.0, 123.0] |
+| `max_depth` | 6.3585 | 5.9511 | — | 5.9551 | **Q2** [8.0, 9.0] |
+| `min_data_in_leaf` | — | 5.7701 | 5.8555 | 6.4802 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 6.0938 | 5.9732 | 5.9434 | 5.9653 | **Q3** [0.0017, 0.0067] |
+| `lambda_l2` | 6.0009 | 5.9181 | 5.8718 | 6.1849 | **Q3** [0.0, 0.0] |
+| `feature_fraction` | 6.2526 | 5.9369 | 5.8896 | 5.8966 | **Q3** [0.9539, 0.9731] |
+| `bagging_fraction` | 6.0995 | 5.9145 | 5.9622 | 5.9995 | **Q2** [0.8768, 0.9024] |
+
+#### E. Slice plot
+
+![synthetic@s43/naive-lightgbm](slice_synthetic@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 3.76251** (winner retrained in 0.37s, cv score of winner: 4.1840)
+- cv best RMSE: 4.1840, median: 4.7100, p10: 4.3729
+- train: median 0.388s/fold, mean 0.713s, p90 2.584s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.767 |
+| `mixture_init` | 0.062 |
+| `min_data_in_leaf` | 0.033 |
+| `learning_rate` | 0.026 |
+| `mixture_balance_factor` | 0.021 |
+| `feature_fraction` | 0.021 |
+| `mixture_warmup_iters` | 0.012 |
+| `bagging_fraction` | 0.011 |
+| `mixture_hard_m_step` | 0.009 |
+| `num_leaves` | 0.006 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 5.0671 (n=449) | leaf_reuse | Δ +2.9488 | p=0.00e+00 |
+| `mixture_routing_mode` | **token_choice** | 5.2059 (n=348) | expert_choice | Δ +0.8183 | p=0.00e+00 |
+| `mixture_init` | **gmm** | 5.1270 (n=298) | tree_hierarchical | Δ +0.4784 | p=3.32e-03 |
+| `mixture_r_smoothing` | **none** | 5.2139 (n=304) | markov | Δ +0.4392 | p=1.59e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 449 | 5.0671 | 0.8647 | 4.1840 |
+| leaf_reuse | 27 | 8.0159 | 1.2111 | 5.8063 |
+| none | 24 | 9.8238 | 1.4500 | 6.3409 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 348 | 5.2059 | 1.3990 | 4.1840 |
+| expert_choice | 152 | 6.0242 | 1.5738 | 4.4635 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 266 | 5.3008 | 1.4940 | 4.2535 |
+| em | 170 | 5.3511 | 1.5034 | 4.1840 |
+| gate_only | 64 | 6.3690 | 1.1788 | 5.0206 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 298 | 5.1270 | 1.4588 | 4.1840 |
+| tree_hierarchical | 124 | 5.6054 | 1.5213 | 4.4607 |
+| uniform | 18 | 6.2991 | 1.0230 | 5.5203 |
+| kmeans_features | 16 | 6.3576 | 1.0954 | 5.2180 |
+| random | 27 | 6.5719 | 0.9512 | 5.5542 |
+| gmm_features | 17 | 6.5813 | 1.3023 | 5.2055 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 304 | 5.2139 | 1.4631 | 4.1840 |
+| markov | 169 | 5.6531 | 1.4191 | 4.4453 |
+| ema | 27 | 6.9227 | 1.4267 | 4.8742 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 296 | 5.3824 | 1.4486 | 4.1840 |
+| True | 204 | 5.5595 | 1.5711 | 4.3306 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 453 | 5.3403 | 1.4776 | 4.1840 |
+| False | 47 | 6.5569 | 1.2753 | 4.9661 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 5.4547 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 6.1246 | 5.3212 | 5.0842 | 5.2886 | **Q3** [0.34, 0.4317] |
+| `mixture_warmup_iters` | 5.8503 | 5.4095 | 5.1507 | 5.3832 | **Q3** [38.0, 43.0] |
+| `mixture_balance_factor` | 6.3315 | 5.4097 | — | 5.3515 | **Q4** [5.0, ∞) |
+| `learning_rate` | 6.2409 | 5.1666 | 5.0114 | 5.3997 | **Q3** [0.1493, 0.1846] |
+| `num_leaves` | 5.2485 | 5.3322 | 5.4161 | 5.8151 | **Q1** [None, 31.0] |
+| `max_depth` | 5.7956 | 5.1868 | 5.2300 | 5.6351 | **Q2** [8.0, 9.0] |
+| `min_data_in_leaf` | 5.2213 | 5.0892 | 5.3073 | 6.2278 | **Q2** [7.0, 11.0] |
+
+#### E. Slice plot
+
+![synthetic@s43/moe](slice_synthetic@s43_moe.png)
+
+
+---
+
+## synthetic@s44  (search X=[1600, 5], holdout n=400)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 5.02751** (winner retrained in 0.15s, cv score of winner: 5.6149)
+- cv best RMSE: 5.6149, median: 6.0510, p10: 5.7619
+- train: median 0.123s/fold, mean 0.119s, p90 0.179s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.811 |
+| `feature_fraction` | 0.052 |
+| `extra_trees` | 0.042 |
+| `bagging_fraction` | 0.036 |
+| `learning_rate` | 0.027 |
+| `max_depth` | 0.010 |
+| `num_leaves` | 0.009 |
+| `lambda_l2` | 0.006 |
+| `bagging_freq` | 0.003 |
+| `lambda_l1` | 0.003 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 6.1813 | 0.5132 | 5.6149 |
+| True | 30 | 7.0463 | 0.8441 | 6.0670 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 6.3728 | 6.0274 | 6.1293 | 6.4032 | **Q2** [0.0365, 0.0421] |
+| `num_leaves` | 6.2477 | 6.2705 | 6.1595 | 6.2592 | **Q3** [84.0, 109.0] |
+| `max_depth` | 6.3497 | 6.0993 | 6.2599 | 6.2055 | **Q2** [9.0, 10.0] |
+| `min_data_in_leaf` | 5.9990 | 6.0231 | 6.1054 | 6.7147 | **Q1** [None, 6.0] |
+| `lambda_l1` | 6.6018 | 6.0186 | 6.1360 | 6.1764 | **Q2** [0.0588, 0.3447] |
+| `lambda_l2` | 6.2222 | 6.5009 | 6.0797 | 6.1300 | **Q3** [0.0021, 0.2991] |
+| `feature_fraction` | 6.6824 | 6.0070 | 6.1069 | 6.1366 | **Q2** [0.9027, 0.9382] |
+| `bagging_fraction` | 6.3217 | 6.3795 | 6.2683 | 5.9634 | **Q4** [0.9424, ∞) |
+
+#### E. Slice plot
+
+![synthetic@s44/naive-lightgbm](slice_synthetic@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 3.50192** (winner retrained in 0.31s, cv score of winner: 3.4794)
+- cv best RMSE: 3.4794, median: 4.5422, p10: 3.8170
+- train: median 0.228s/fold, mean 0.272s, p90 0.364s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_gate_type` | 0.727 |
+| `mixture_init` | 0.092 |
+| `min_data_in_leaf` | 0.059 |
+| `learning_rate` | 0.033 |
+| `mixture_hard_m_step` | 0.022 |
+| `bagging_freq` | 0.013 |
+| `mixture_load_balance_alpha` | 0.009 |
+| `mixture_expert_dropout_rate` | 0.007 |
+| `mixture_refit_leaves` | 0.005 |
+| `mixture_num_experts` | 0.005 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **gbdt** | 4.7813 (n=446) | leaf_reuse | Δ +3.2045 | p=0.00e+00 |
+| `mixture_routing_mode` | **expert_choice** | 5.1057 (n=440) | token_choice | Δ +1.3804 | p=1.00e-06 |
+| `mixture_init` | **gmm** | 4.9002 (n=382) | tree_hierarchical | Δ +1.0038 | p=5.62e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 446 | 4.7813 | 1.1260 | 3.4794 |
+| leaf_reuse | 25 | 7.9858 | 1.0044 | 6.2720 |
+| none | 29 | 10.4687 | 1.9232 | 6.3885 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 440 | 5.1057 | 1.8254 | 3.4794 |
+| token_choice | 60 | 6.4861 | 1.8522 | 3.7297 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 395 | 5.1302 | 1.8390 | 3.4794 |
+| em | 75 | 5.7473 | 1.9437 | 3.6513 |
+| loss_only | 30 | 5.9406 | 1.9588 | 3.8284 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gmm | 382 | 4.9002 | 1.8680 | 3.4794 |
+| tree_hierarchical | 33 | 5.9040 | 1.8558 | 3.8861 |
+| uniform | 18 | 6.2323 | 0.6778 | 5.3635 |
+| gmm_features | 26 | 6.6015 | 0.8693 | 5.0048 |
+| random | 19 | 6.9308 | 1.2982 | 5.9999 |
+| kmeans_features | 22 | 6.9760 | 0.9869 | 5.8698 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 275 | 5.0895 | 1.8767 | 3.4794 |
+| none | 198 | 5.2939 | 1.7886 | 3.7299 |
+| ema | 27 | 6.9582 | 1.7699 | 4.4371 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 453 | 5.1166 | 1.8324 | 3.4794 |
+| False | 47 | 6.7630 | 1.7023 | 3.8285 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 465 | 5.1733 | 1.8546 | 3.4794 |
+| False | 35 | 6.5750 | 1.7663 | 4.6399 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | — | — | 5.2714 | **Q4** [2.0, ∞) |
+| `mixture_diversity_lambda` | 5.6791 | 5.1389 | 5.0730 | 5.1946 | **Q3** [0.418, 0.4508] |
+| `mixture_warmup_iters` | 5.3580 | 4.9184 | 5.2650 | 5.5947 | **Q2** [18.0, 21.0] |
+| `mixture_balance_factor` | — | — | 5.2464 | 5.3389 | **Q3** [2.0, 8.0] |
+| `learning_rate` | 6.0869 | 5.0747 | 4.9892 | 4.9348 | **Q4** [0.2714, ∞) |
+| `num_leaves` | 5.6035 | 5.1656 | 4.9372 | 5.4045 | **Q3** [72.0, 99.25] |
+| `max_depth` | — | — | 5.1988 | 5.4845 | **Q3** [3.0, 8.0] |
+| `min_data_in_leaf` | 4.8853 | 4.9747 | 4.9725 | 6.1816 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![synthetic@s44/moe](slice_synthetic@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| synthetic@s42 | `mixture_gate_type` | **leaf_reuse** | +0.5435 | 0.00e+00 |
+| synthetic@s42 | `mixture_routing_mode` | **token_choice** | +0.7103 | 0.00e+00 |
+| synthetic@s42 | `mixture_e_step_mode` | **gate_only** | +0.8237 | 3.78e-04 |
+| synthetic@s42 | `mixture_r_smoothing` | **none** | +0.5051 | 4.81e-03 |
+| synthetic@s43 | `mixture_gate_type` | **gbdt** | +2.9488 | 0.00e+00 |
+| synthetic@s43 | `mixture_routing_mode` | **token_choice** | +0.8183 | 0.00e+00 |
+| synthetic@s43 | `mixture_init` | **gmm** | +0.4784 | 3.32e-03 |
+| synthetic@s43 | `mixture_r_smoothing` | **none** | +0.4392 | 1.59e-03 |
+| synthetic@s44 | `mixture_gate_type` | **gbdt** | +3.2045 | 0.00e+00 |
+| synthetic@s44 | `mixture_routing_mode` | **expert_choice** | +1.3804 | 1.00e-06 |
+| synthetic@s44 | `mixture_init` | **gmm** | +1.0038 | 5.62e-03 |

--- a/bench_results/wide_v081/ds_synthetic_summary.json
+++ b/bench_results/wide_v081/ds_synthetic_summary.json
@@ -1,0 +1,2776 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "synthetic"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "synthetic": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 4.401304318166623,
+      "cv_best": 5.309552357292034,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3628
+     },
+     "43": {
+      "holdout_rmse": 5.090569514383884,
+      "cv_best": 5.51921093498564,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1794
+     },
+     "44": {
+      "holdout_rmse": 5.027514507549071,
+      "cv_best": 5.614859466168736,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1464
+     }
+    },
+    "holdout_mean": 4.839796,
+    "holdout_std": 0.311127,
+    "cv_best_mean": 5.481208
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 4.1108789854922225,
+      "cv_best": 5.1618421198350655,
+      "crash_rate": 0.0,
+      "retrain_s": 4.5861
+     },
+     "43": {
+      "holdout_rmse": 3.7625111033364935,
+      "cv_best": 4.184020861828467,
+      "crash_rate": 0.0,
+      "retrain_s": 0.3734
+     },
+     "44": {
+      "holdout_rmse": 3.5019220934340702,
+      "cv_best": 3.4794165911371335,
+      "crash_rate": 0.0,
+      "retrain_s": 0.313
+     }
+    },
+    "holdout_mean": 3.791771,
+    "holdout_std": 0.249465,
+    "cv_best_mean": 4.275093
+   }
+  }
+ },
+ "runs": {
+  "synthetic@s42": {
+   "dataset": "synthetic",
+   "seed": 42,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -1.1238261010719193,
+    "std": 12.024415840059472
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.309552357292034,
+    "rmse_p10": 5.410067423410064,
+    "rmse_median": 5.546873572479786,
+    "train_s_median": 0.1500760016962886,
+    "train_s_mean": 0.14593181077241896,
+    "train_s_p90": 0.20947578363120556,
+    "best_params": {
+     "learning_rate": 0.06927988956598645,
+     "num_leaves": 105,
+     "max_depth": 11,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.00032732966599495624,
+     "lambda_l2": 0.0039429503996035635,
+     "feature_fraction": 0.9130092669152661,
+     "bagging_fraction": 0.6560222043761444,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.6706,
+     "learning_rate": 0.2604,
+     "feature_fraction": 0.0319,
+     "bagging_fraction": 0.0225,
+     "num_leaves": 0.0084,
+     "extra_trees": 0.0031,
+     "max_depth": 0.0013,
+     "bagging_freq": 0.001,
+     "lambda_l1": 0.0009,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 6.8388,
+        "std": 1.3862,
+        "min": 5.6091
+       },
+       "False": {
+        "n": 468,
+        "mean": 5.7104,
+        "std": 0.4933,
+        "min": 5.3096
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.1284,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0461
+       ],
+       "n": 125,
+       "mean_rmse": 6.0027
+      },
+      "Q2": {
+       "range": [
+        0.0461,
+        0.0568
+       ],
+       "n": 125,
+       "mean_rmse": 5.6405
+      },
+      "Q3": {
+       "range": [
+        0.0568,
+        0.0673
+       ],
+       "n": 125,
+       "mean_rmse": 5.6945
+      },
+      "Q4": {
+       "range": [
+        0.0673,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.7926
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        30.0
+       ],
+       "n": 120,
+       "mean_rmse": 5.661
+      },
+      "Q2": {
+       "range": [
+        30.0,
+        40.5
+       ],
+       "n": 130,
+       "mean_rmse": 5.6656
+      },
+      "Q3": {
+       "range": [
+        40.5,
+        88.0
+       ],
+       "n": 123,
+       "mean_rmse": 5.9632
+      },
+      "Q4": {
+       "range": [
+        88.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 5.8424
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 95,
+       "mean_rmse": 6.1194
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 148,
+       "mean_rmse": 5.6517
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 257,
+       "mean_rmse": 5.7335
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 114,
+       "mean_rmse": 5.5496
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 104,
+       "mean_rmse": 5.5381
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 156,
+       "mean_rmse": 5.6075
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 6.412
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 5.9018
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.1025
+       ],
+       "n": 125,
+       "mean_rmse": 5.8799
+      },
+      "Q3": {
+       "range": [
+        0.1025,
+        0.9322
+       ],
+       "n": 125,
+       "mean_rmse": 5.6872
+      },
+      "Q4": {
+       "range": [
+        0.9322,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.6616
+      },
+      "best_quartile": "Q4"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.6751
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 5.8891
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0013
+       ],
+       "n": 125,
+       "mean_rmse": 5.8415
+      },
+      "Q4": {
+       "range": [
+        0.0013,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.7247
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9269
+       ],
+       "n": 125,
+       "mean_rmse": 6.1383
+      },
+      "Q2": {
+       "range": [
+        0.9269,
+        0.9547
+       ],
+       "n": 125,
+       "mean_rmse": 5.7015
+      },
+      "Q3": {
+       "range": [
+        0.9547,
+        0.9788
+       ],
+       "n": 125,
+       "mean_rmse": 5.6382
+      },
+      "Q4": {
+       "range": [
+        0.9788,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.6524
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6516
+       ],
+       "n": 125,
+       "mean_rmse": 5.7691
+      },
+      "Q2": {
+       "range": [
+        0.6516,
+        0.6881
+       ],
+       "n": 125,
+       "mean_rmse": 5.7066
+      },
+      "Q3": {
+       "range": [
+        0.6881,
+        0.7753
+       ],
+       "n": 125,
+       "mean_rmse": 5.6783
+      },
+      "Q4": {
+       "range": [
+        0.7753,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9765
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 376.8,
+    "holdout": {
+     "holdout_rmse": 4.401304318166623,
+     "retrain_s": 0.3628,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 5.309552357292034
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.1618421198350655,
+    "rmse_p10": 5.276875984457247,
+    "rmse_median": 5.4888528465275,
+    "train_s_median": 2.923366782814264,
+    "train_s_mean": 2.6849193766631188,
+    "train_s_p90": 4.4439362308382995,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 6,
+     "learning_rate": 0.180137272397942,
+     "num_leaves": 118,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.590235321672729e-08,
+     "lambda_l2": 0.13208108155898537,
+     "feature_fraction": 0.9993659338258666,
+     "bagging_fraction": 0.7101369902122919,
+     "bagging_freq": 3,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 7,
+     "mixture_balance_factor": 4,
+     "mixture_diversity_lambda": 0.3886489220775435,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.19909871212120042,
+     "mixture_load_balance_alpha": 0.2601334056101819,
+     "mixture_gate_max_depth": 10,
+     "mixture_gate_num_leaves": 63,
+     "mixture_gate_learning_rate": 0.016607834507348054,
+     "mixture_gate_lambda_l2": 0.05718487080908888,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.24253583961793374,
+     "mixture_gate_temperature_init": 0.6556696879531205,
+     "gate_temp_final_ratio": 0.20128067351778942,
+     "mixture_gate_retrain_interval": 19,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.33618995641978366,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6063,
+     "mixture_gate_type": 0.107,
+     "min_data_in_leaf": 0.0809,
+     "num_leaves": 0.0487,
+     "feature_fraction": 0.0393,
+     "mixture_init": 0.0215,
+     "mixture_expert_dropout_rate": 0.0189,
+     "mixture_warmup_iters": 0.0131,
+     "mixture_diversity_lambda": 0.0073,
+     "extra_trees": 0.0067,
+     "mixture_e_step_mode": 0.0064,
+     "max_depth": 0.0063,
+     "mixture_hard_m_step": 0.0063,
+     "mixture_num_experts": 0.0061,
+     "bagging_fraction": 0.0054,
+     "mixture_r_smoothing": 0.0045,
+     "mixture_balance_factor": 0.0039,
+     "mixture_load_balance_alpha": 0.003,
+     "bagging_freq": 0.0027,
+     "mixture_refit_leaves": 0.0026,
+     "lambda_l1": 0.0024,
+     "lambda_l2": 0.0006,
+     "mixture_routing_mode": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 396,
+        "mean": 5.6612,
+        "std": 0.7024,
+        "min": 5.1618
+       },
+       "none": {
+        "n": 43,
+        "mean": 6.8299,
+        "std": 1.01,
+        "min": 5.8592
+       },
+       "gbdt": {
+        "n": 61,
+        "mean": 6.2047,
+        "std": 0.61,
+        "min": 5.4905
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.5435,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 420,
+        "mean": 5.7144,
+        "std": 0.7522,
+        "min": 5.1618
+       },
+       "expert_choice": {
+        "n": 80,
+        "mean": 6.4247,
+        "std": 0.8154,
+        "min": 5.5558
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.7103,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 432,
+        "mean": 5.7048,
+        "std": 0.6749,
+        "min": 5.1618
+       },
+       "loss_only": {
+        "n": 27,
+        "mean": 6.5285,
+        "std": 1.0233,
+        "min": 5.5642
+       },
+       "em": {
+        "n": 41,
+        "mean": 6.6656,
+        "std": 1.1169,
+        "min": 5.5815
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "loss_only",
+       "delta_mean": 0.8237,
+       "p_value": 0.000378,
+       "significant": "True"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 27,
+        "mean": 6.3615,
+        "std": 0.5714,
+        "min": 5.4839
+       },
+       "gmm": {
+        "n": 325,
+        "mean": 5.7071,
+        "std": 0.8208,
+        "min": 5.1618
+       },
+       "random": {
+        "n": 44,
+        "mean": 6.2409,
+        "std": 0.8644,
+        "min": 5.2556
+       },
+       "gmm_features": {
+        "n": 17,
+        "mean": 6.0124,
+        "std": 0.6026,
+        "min": 5.4191
+       },
+       "kmeans_features": {
+        "n": 38,
+        "mean": 5.9068,
+        "std": 0.7556,
+        "min": 5.3458
+       },
+       "tree_hierarchical": {
+        "n": 49,
+        "mean": 5.8407,
+        "std": 0.5617,
+        "min": 5.3535
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.1336,
+       "p_value": 0.154694,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 64,
+        "mean": 6.3566,
+        "std": 0.7568,
+        "min": 5.3113
+       },
+       "markov": {
+        "n": 47,
+        "mean": 6.2011,
+        "std": 1.1351,
+        "min": 5.2259
+       },
+       "none": {
+        "n": 389,
+        "mean": 5.696,
+        "std": 0.7104,
+        "min": 5.1618
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.5051,
+       "p_value": 0.004811,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 5.796,
+        "std": 0.7793,
+        "min": 5.1618
+       },
+       "True": {
+        "n": 32,
+        "mean": 6.2967,
+        "std": 1.0158,
+        "min": 5.3865
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5007,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 33,
+        "mean": 6.7402,
+        "std": 1.485,
+        "min": 5.3635
+       },
+       "False": {
+        "n": 467,
+        "mean": 5.7636,
+        "std": 0.6904,
+        "min": 5.1618
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.9766,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 70,
+       "mean_rmse": 6.5055
+      },
+      "Q2": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 65,
+       "mean_rmse": 5.9987
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 365,
+       "mean_rmse": 5.6677
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.3259
+       ],
+       "n": 125,
+       "mean_rmse": 6.0308
+      },
+      "Q2": {
+       "range": [
+        0.3259,
+        0.365
+       ],
+       "n": 125,
+       "mean_rmse": 5.7026
+      },
+      "Q3": {
+       "range": [
+        0.365,
+        0.4427
+       ],
+       "n": 125,
+       "mean_rmse": 5.8039
+      },
+      "Q4": {
+       "range": [
+        0.4427,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.7748
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 119,
+       "mean_rmse": 5.8027
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 119,
+       "mean_rmse": 5.6146
+      },
+      "Q3": {
+       "range": [
+        13.0,
+        22.0
+       ],
+       "n": 127,
+       "mean_rmse": 5.7452
+      },
+      "Q4": {
+       "range": [
+        22.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 6.1165
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 87,
+       "mean_rmse": 5.8329
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 413,
+       "mean_rmse": 5.827
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1049
+       ],
+       "n": 125,
+       "mean_rmse": 6.1627
+      },
+      "Q2": {
+       "range": [
+        0.1049,
+        0.142
+       ],
+       "n": 125,
+       "mean_rmse": 5.6217
+      },
+      "Q3": {
+       "range": [
+        0.142,
+        0.1716
+       ],
+       "n": 125,
+       "mean_rmse": 5.7668
+      },
+      "Q4": {
+       "range": [
+        0.1716,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.761
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        96.75
+       ],
+       "n": 125,
+       "mean_rmse": 6.2358
+      },
+      "Q2": {
+       "range": [
+        96.75,
+        108.0
+       ],
+       "n": 119,
+       "mean_rmse": 5.6597
+      },
+      "Q3": {
+       "range": [
+        108.0,
+        118.0
+       ],
+       "n": 122,
+       "mean_rmse": 5.7198
+      },
+      "Q4": {
+       "range": [
+        118.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 5.6958
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 102,
+       "mean_rmse": 6.3327
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 65,
+       "mean_rmse": 5.7969
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 135,
+       "mean_rmse": 5.747
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 198,
+       "mean_rmse": 5.6335
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        5.75
+       ],
+       "n": 125,
+       "mean_rmse": 5.6772
+      },
+      "Q2": {
+       "range": [
+        5.75,
+        8.0
+       ],
+       "n": 110,
+       "mean_rmse": 5.6763
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 116,
+       "mean_rmse": 5.5703
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 149,
+       "mean_rmse": 6.2672
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 6755.8,
+    "holdout": {
+     "holdout_rmse": 4.1108789854922225,
+     "retrain_s": 4.5861,
+     "predict_s": 0.0083,
+     "cv_rmse_of_winner": 5.1618421198350655
+    }
+   }
+  },
+  "synthetic@s43": {
+   "dataset": "synthetic",
+   "seed": 43,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.875910802699441,
+    "std": 11.885024346049207
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.51921093498564,
+    "rmse_p10": 5.669064619191913,
+    "rmse_median": 5.8184283834466655,
+    "train_s_median": 0.09945276714861392,
+    "train_s_mean": 0.09505977418199181,
+    "train_s_p90": 0.13666020516306163,
+    "best_params": {
+     "learning_rate": 0.11488635262702641,
+     "num_leaves": 123,
+     "max_depth": 8,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.010975183466182085,
+     "lambda_l2": 2.7434191756154796e-08,
+     "feature_fraction": 0.9690943432323873,
+     "bagging_fraction": 0.9222575754741357,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "min_data_in_leaf": 0.7708,
+     "learning_rate": 0.1356,
+     "bagging_fraction": 0.0422,
+     "feature_fraction": 0.0272,
+     "bagging_freq": 0.0071,
+     "max_depth": 0.0049,
+     "lambda_l1": 0.0048,
+     "lambda_l2": 0.0037,
+     "extra_trees": 0.002,
+     "num_leaves": 0.0017
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 446,
+        "mean": 5.9559,
+        "std": 0.4653,
+        "min": 5.5192
+       },
+       "False": {
+        "n": 54,
+        "mean": 6.3077,
+        "std": 0.6867,
+        "min": 5.7045
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.3518,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.104
+       ],
+       "n": 125,
+       "mean_rmse": 6.2452
+      },
+      "Q2": {
+       "range": [
+        0.104,
+        0.12
+       ],
+       "n": 125,
+       "mean_rmse": 5.8588
+      },
+      "Q3": {
+       "range": [
+        0.12,
+        0.1392
+       ],
+       "n": 125,
+       "mean_rmse": 5.9002
+      },
+      "Q4": {
+       "range": [
+        0.1392,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9714
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        109.0
+       ],
+       "n": 119,
+       "mean_rmse": 6.1871
+      },
+      "Q2": {
+       "range": [
+        109.0,
+        118.0
+       ],
+       "n": 118,
+       "mean_rmse": 5.9433
+      },
+      "Q3": {
+       "range": [
+        118.0,
+        123.0
+       ],
+       "n": 132,
+       "mean_rmse": 5.9227
+      },
+      "Q4": {
+       "range": [
+        123.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 5.9358
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 49,
+       "mean_rmse": 6.3585
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 91,
+       "mean_rmse": 5.9511
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 360,
+       "mean_rmse": 5.9551
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 155,
+       "mean_rmse": 5.7701
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 213,
+       "mean_rmse": 5.8555
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 6.4802
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0002
+       ],
+       "n": 125,
+       "mean_rmse": 6.0938
+      },
+      "Q2": {
+       "range": [
+        0.0002,
+        0.0017
+       ],
+       "n": 125,
+       "mean_rmse": 5.9732
+      },
+      "Q3": {
+       "range": [
+        0.0017,
+        0.0067
+       ],
+       "n": 125,
+       "mean_rmse": 5.9434
+      },
+      "Q4": {
+       "range": [
+        0.0067,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9653
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 6.0009
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.9181
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 5.8718
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.1849
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9257
+       ],
+       "n": 125,
+       "mean_rmse": 6.2526
+      },
+      "Q2": {
+       "range": [
+        0.9257,
+        0.9539
+       ],
+       "n": 125,
+       "mean_rmse": 5.9369
+      },
+      "Q3": {
+       "range": [
+        0.9539,
+        0.9731
+       ],
+       "n": 125,
+       "mean_rmse": 5.8896
+      },
+      "Q4": {
+       "range": [
+        0.9731,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.8966
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8768
+       ],
+       "n": 125,
+       "mean_rmse": 6.0995
+      },
+      "Q2": {
+       "range": [
+        0.8768,
+        0.9024
+       ],
+       "n": 125,
+       "mean_rmse": 5.9145
+      },
+      "Q3": {
+       "range": [
+        0.9024,
+        0.9325
+       ],
+       "n": 125,
+       "mean_rmse": 5.9622
+      },
+      "Q4": {
+       "range": [
+        0.9325,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9995
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 248.6,
+    "holdout": {
+     "holdout_rmse": 5.090569514383884,
+     "retrain_s": 0.1794,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 5.51921093498564
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 4.184020861828467,
+    "rmse_p10": 4.372860454126734,
+    "rmse_median": 4.709956107387953,
+    "train_s_median": 0.38814701698720455,
+    "train_s_mean": 0.7133793352290988,
+    "train_s_p90": 2.584376137554646,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.14443336049747557,
+     "num_leaves": 27,
+     "max_depth": 12,
+     "min_data_in_leaf": 15,
+     "lambda_l1": 0.46606391769490124,
+     "lambda_l2": 1.637472686357386e-05,
+     "feature_fraction": 0.9271109679078051,
+     "bagging_fraction": 0.9515936225478591,
+     "bagging_freq": 1,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 27,
+     "mixture_balance_factor": 4,
+     "mixture_diversity_lambda": 0.2550264484012105,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.14929708583988954,
+     "mixture_load_balance_alpha": 0.21819996638100364,
+     "mixture_gate_max_depth": 8,
+     "mixture_gate_num_leaves": 44,
+     "mixture_gate_learning_rate": 0.06788374660712332,
+     "mixture_gate_lambda_l2": 0.7360418401959758,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.012367290840769355,
+     "mixture_gate_temperature_init": 1.0754149588832762,
+     "gate_temp_final_ratio": 0.28626521822401485,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.7672,
+     "mixture_init": 0.0622,
+     "min_data_in_leaf": 0.0327,
+     "learning_rate": 0.0262,
+     "mixture_balance_factor": 0.0213,
+     "feature_fraction": 0.0207,
+     "mixture_warmup_iters": 0.0119,
+     "bagging_fraction": 0.0111,
+     "mixture_hard_m_step": 0.009,
+     "num_leaves": 0.0064,
+     "mixture_e_step_mode": 0.006,
+     "mixture_expert_dropout_rate": 0.0057,
+     "bagging_freq": 0.0044,
+     "mixture_load_balance_alpha": 0.0043,
+     "mixture_r_smoothing": 0.0024,
+     "mixture_diversity_lambda": 0.0024,
+     "mixture_num_experts": 0.0015,
+     "mixture_refit_leaves": 0.0012,
+     "mixture_routing_mode": 0.0011,
+     "max_depth": 0.0011,
+     "lambda_l1": 0.0007,
+     "lambda_l2": 0.0003,
+     "extra_trees": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 449,
+        "mean": 5.0671,
+        "std": 0.8647,
+        "min": 4.184
+       },
+       "leaf_reuse": {
+        "n": 27,
+        "mean": 8.0159,
+        "std": 1.2111,
+        "min": 5.8063
+       },
+       "none": {
+        "n": 24,
+        "mean": 9.8238,
+        "std": 1.45,
+        "min": 6.3409
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 2.9488,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 152,
+        "mean": 6.0242,
+        "std": 1.5738,
+        "min": 4.4635
+       },
+       "token_choice": {
+        "n": 348,
+        "mean": 5.2059,
+        "std": 1.399,
+        "min": 4.184
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.8183,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 266,
+        "mean": 5.3008,
+        "std": 1.494,
+        "min": 4.2535
+       },
+       "gate_only": {
+        "n": 64,
+        "mean": 6.369,
+        "std": 1.1788,
+        "min": 5.0206
+       },
+       "em": {
+        "n": 170,
+        "mean": 5.3511,
+        "std": 1.5034,
+        "min": 4.184
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "em",
+       "delta_mean": 0.0503,
+       "p_value": 0.733481,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 298,
+        "mean": 5.127,
+        "std": 1.4588,
+        "min": 4.184
+       },
+       "tree_hierarchical": {
+        "n": 124,
+        "mean": 5.6054,
+        "std": 1.5213,
+        "min": 4.4607
+       },
+       "uniform": {
+        "n": 18,
+        "mean": 6.2991,
+        "std": 1.023,
+        "min": 5.5203
+       },
+       "kmeans_features": {
+        "n": 16,
+        "mean": 6.3576,
+        "std": 1.0954,
+        "min": 5.218
+       },
+       "gmm_features": {
+        "n": 17,
+        "mean": 6.5813,
+        "std": 1.3023,
+        "min": 5.2055
+       },
+       "random": {
+        "n": 27,
+        "mean": 6.5719,
+        "std": 0.9512,
+        "min": 5.5542
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 0.4784,
+       "p_value": 0.003325,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 27,
+        "mean": 6.9227,
+        "std": 1.4267,
+        "min": 4.8742
+       },
+       "none": {
+        "n": 304,
+        "mean": 5.2139,
+        "std": 1.4631,
+        "min": 4.184
+       },
+       "markov": {
+        "n": 169,
+        "mean": 5.6531,
+        "std": 1.4191,
+        "min": 4.4453
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "markov",
+       "delta_mean": 0.4392,
+       "p_value": 0.001591,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 296,
+        "mean": 5.3824,
+        "std": 1.4486,
+        "min": 4.184
+       },
+       "True": {
+        "n": 204,
+        "mean": 5.5595,
+        "std": 1.5711,
+        "min": 4.3306
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.1771,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 47,
+        "mean": 6.5569,
+        "std": 1.2753,
+        "min": 4.9661
+       },
+       "True": {
+        "n": 453,
+        "mean": 5.3403,
+        "std": 1.4776,
+        "min": 4.184
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 1.2166,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 500,
+       "mean_rmse": 5.4547
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2413
+       ],
+       "n": 125,
+       "mean_rmse": 6.1246
+      },
+      "Q2": {
+       "range": [
+        0.2413,
+        0.34
+       ],
+       "n": 125,
+       "mean_rmse": 5.3212
+      },
+      "Q3": {
+       "range": [
+        0.34,
+        0.4317
+       ],
+       "n": 125,
+       "mean_rmse": 5.0842
+      },
+      "Q4": {
+       "range": [
+        0.4317,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.2886
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        30.0
+       ],
+       "n": 124,
+       "mean_rmse": 5.8503
+      },
+      "Q2": {
+       "range": [
+        30.0,
+        38.0
+       ],
+       "n": 111,
+       "mean_rmse": 5.4095
+      },
+      "Q3": {
+       "range": [
+        38.0,
+        43.0
+       ],
+       "n": 108,
+       "mean_rmse": 5.1507
+      },
+      "Q4": {
+       "range": [
+        43.0,
+        null
+       ],
+       "n": 157,
+       "mean_rmse": 5.3832
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 43,
+       "mean_rmse": 6.3315
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 162,
+       "mean_rmse": 5.4097
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 295,
+       "mean_rmse": 5.3515
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1241
+       ],
+       "n": 125,
+       "mean_rmse": 6.2409
+      },
+      "Q2": {
+       "range": [
+        0.1241,
+        0.1493
+       ],
+       "n": 125,
+       "mean_rmse": 5.1666
+      },
+      "Q3": {
+       "range": [
+        0.1493,
+        0.1846
+       ],
+       "n": 125,
+       "mean_rmse": 5.0114
+      },
+      "Q4": {
+       "range": [
+        0.1846,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.3997
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        31.0
+       ],
+       "n": 119,
+       "mean_rmse": 5.2485
+      },
+      "Q2": {
+       "range": [
+        31.0,
+        44.0
+       ],
+       "n": 127,
+       "mean_rmse": 5.3322
+      },
+      "Q3": {
+       "range": [
+        44.0,
+        95.25
+       ],
+       "n": 129,
+       "mean_rmse": 5.4161
+      },
+      "Q4": {
+       "range": [
+        95.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.8151
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 90,
+       "mean_rmse": 5.7956
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 50,
+       "mean_rmse": 5.1868
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 203,
+       "mean_rmse": 5.23
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 157,
+       "mean_rmse": 5.6351
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 76,
+       "mean_rmse": 5.2213
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 164,
+       "mean_rmse": 5.0892
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        18.0
+       ],
+       "n": 134,
+       "mean_rmse": 5.3073
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 6.2278
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 1814.4,
+    "holdout": {
+     "holdout_rmse": 3.7625111033364935,
+     "retrain_s": 0.3734,
+     "predict_s": 0.0025,
+     "cv_rmse_of_winner": 4.184020861828467
+    }
+   }
+  },
+  "synthetic@s44": {
+   "dataset": "synthetic",
+   "seed": 44,
+   "X_search_shape": [
+    1600,
+    5
+   ],
+   "n_holdout": 400,
+   "y_stats": {
+    "mean": -0.8513872282377526,
+    "std": 12.522023281908787
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 5.614859466168736,
+    "rmse_p10": 5.761894656227276,
+    "rmse_median": 6.051022123058571,
+    "train_s_median": 0.12331081219017506,
+    "train_s_mean": 0.11853452111706138,
+    "train_s_p90": 0.17880066763609648,
+    "best_params": {
+     "learning_rate": 0.044641229646923034,
+     "num_leaves": 27,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.46182314286549314,
+     "lambda_l2": 0.0024878356459554713,
+     "feature_fraction": 0.9030172132880738,
+     "bagging_fraction": 0.9339570694022165,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.8109,
+     "feature_fraction": 0.0524,
+     "extra_trees": 0.0415,
+     "bagging_fraction": 0.0364,
+     "learning_rate": 0.0273,
+     "max_depth": 0.0099,
+     "num_leaves": 0.0095,
+     "lambda_l2": 0.0061,
+     "bagging_freq": 0.0033,
+     "lambda_l1": 0.0027
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 6.1813,
+        "std": 0.5132,
+        "min": 5.6149
+       },
+       "True": {
+        "n": 30,
+        "mean": 7.0463,
+        "std": 0.8441,
+        "min": 6.067
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.865,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0365
+       ],
+       "n": 125,
+       "mean_rmse": 6.3728
+      },
+      "Q2": {
+       "range": [
+        0.0365,
+        0.0421
+       ],
+       "n": 125,
+       "mean_rmse": 6.0274
+      },
+      "Q3": {
+       "range": [
+        0.0421,
+        0.0489
+       ],
+       "n": 125,
+       "mean_rmse": 6.1293
+      },
+      "Q4": {
+       "range": [
+        0.0489,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.4032
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        58.0
+       ],
+       "n": 122,
+       "mean_rmse": 6.2477
+      },
+      "Q2": {
+       "range": [
+        58.0,
+        84.0
+       ],
+       "n": 122,
+       "mean_rmse": 6.2705
+      },
+      "Q3": {
+       "range": [
+        84.0,
+        109.0
+       ],
+       "n": 130,
+       "mean_rmse": 6.1595
+      },
+      "Q4": {
+       "range": [
+        109.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 6.2592
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 109,
+       "mean_rmse": 6.3497
+      },
+      "Q2": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 76,
+       "mean_rmse": 6.0993
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 114,
+       "mean_rmse": 6.2599
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 201,
+       "mean_rmse": 6.2055
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 110,
+       "mean_rmse": 5.999
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.5
+       ],
+       "n": 140,
+       "mean_rmse": 6.0231
+      },
+      "Q3": {
+       "range": [
+        8.5,
+        12.0
+       ],
+       "n": 107,
+       "mean_rmse": 6.1054
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 143,
+       "mean_rmse": 6.7147
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0588
+       ],
+       "n": 125,
+       "mean_rmse": 6.6018
+      },
+      "Q2": {
+       "range": [
+        0.0588,
+        0.3447
+       ],
+       "n": 125,
+       "mean_rmse": 6.0186
+      },
+      "Q3": {
+       "range": [
+        0.3447,
+        1.651
+       ],
+       "n": 125,
+       "mean_rmse": 6.136
+      },
+      "Q4": {
+       "range": [
+        1.651,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.1764
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 6.2222
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0021
+       ],
+       "n": 125,
+       "mean_rmse": 6.5009
+      },
+      "Q3": {
+       "range": [
+        0.0021,
+        0.2991
+       ],
+       "n": 125,
+       "mean_rmse": 6.0797
+      },
+      "Q4": {
+       "range": [
+        0.2991,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.13
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9027
+       ],
+       "n": 125,
+       "mean_rmse": 6.6824
+      },
+      "Q2": {
+       "range": [
+        0.9027,
+        0.9382
+       ],
+       "n": 125,
+       "mean_rmse": 6.007
+      },
+      "Q3": {
+       "range": [
+        0.9382,
+        0.9663
+       ],
+       "n": 125,
+       "mean_rmse": 6.1069
+      },
+      "Q4": {
+       "range": [
+        0.9663,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 6.1366
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5979
+       ],
+       "n": 125,
+       "mean_rmse": 6.3217
+      },
+      "Q2": {
+       "range": [
+        0.5979,
+        0.7435
+       ],
+       "n": 125,
+       "mean_rmse": 6.3795
+      },
+      "Q3": {
+       "range": [
+        0.7435,
+        0.9424
+       ],
+       "n": 125,
+       "mean_rmse": 6.2683
+      },
+      "Q4": {
+       "range": [
+        0.9424,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.9634
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 307.3,
+    "holdout": {
+     "holdout_rmse": 5.027514507549071,
+     "retrain_s": 0.1464,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 5.614859466168736
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 3.4794165911371335,
+    "rmse_p10": 3.8169874836465567,
+    "rmse_median": 4.542154923352035,
+    "train_s_median": 0.22778096832334993,
+    "train_s_mean": 0.27242523328438406,
+    "train_s_p90": 0.3637630169838668,
+    "best_params": {
+     "mixture_r_smoothing": "markov",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 2,
+     "learning_rate": 0.2997737950145432,
+     "num_leaves": 76,
+     "max_depth": 3,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.493109923281034,
+     "lambda_l2": 5.2623499946476425e-06,
+     "feature_fraction": 0.9832651283192578,
+     "bagging_fraction": 0.7144080895312406,
+     "bagging_freq": 0,
+     "extra_trees": true,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 18,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.37149090957733133,
+     "mixture_diversity_lambda": 0.47446099204787356,
+     "mixture_hard_m_step": true,
+     "mixture_expert_dropout_rate": 0.006661543291075156,
+     "mixture_load_balance_alpha": 0.42834769636873316,
+     "mixture_gate_max_depth": 7,
+     "mixture_gate_num_leaves": 13,
+     "mixture_gate_learning_rate": 0.14857265077255147,
+     "mixture_gate_lambda_l2": 0.030357556062119328,
+     "mixture_gate_iters_per_round": 3,
+     "mixture_gate_entropy_lambda": 8.991550445015996e-05,
+     "mixture_gate_temperature_init": 1.1710276710823877,
+     "gate_temp_final_ratio": 0.2972655680399817,
+     "mixture_expert_capacity_factor": 1.3206532805754936,
+     "mixture_expert_choice_boost": 26.09397518908511,
+     "mixture_expert_choice_hard": true,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "mixture_gate_type": 0.7271,
+     "mixture_init": 0.092,
+     "min_data_in_leaf": 0.0592,
+     "learning_rate": 0.0332,
+     "mixture_hard_m_step": 0.0223,
+     "bagging_freq": 0.0127,
+     "mixture_load_balance_alpha": 0.0086,
+     "mixture_expert_dropout_rate": 0.0069,
+     "mixture_refit_leaves": 0.005,
+     "mixture_num_experts": 0.0048,
+     "num_leaves": 0.0042,
+     "mixture_r_smoothing": 0.0039,
+     "mixture_diversity_lambda": 0.0036,
+     "mixture_balance_factor": 0.0033,
+     "bagging_fraction": 0.0027,
+     "max_depth": 0.002,
+     "mixture_routing_mode": 0.0019,
+     "mixture_warmup_iters": 0.0016,
+     "lambda_l1": 0.0016,
+     "feature_fraction": 0.0013,
+     "extra_trees": 0.0012,
+     "mixture_e_step_mode": 0.0007,
+     "lambda_l2": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 446,
+        "mean": 4.7813,
+        "std": 1.126,
+        "min": 3.4794
+       },
+       "none": {
+        "n": 29,
+        "mean": 10.4687,
+        "std": 1.9232,
+        "min": 6.3885
+       },
+       "leaf_reuse": {
+        "n": 25,
+        "mean": 7.9858,
+        "std": 1.0044,
+        "min": 6.272
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 3.2045,
+       "p_value": 0.0,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 60,
+        "mean": 6.4861,
+        "std": 1.8522,
+        "min": 3.7297
+       },
+       "expert_choice": {
+        "n": 440,
+        "mean": 5.1057,
+        "std": 1.8254,
+        "min": 3.4794
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 1.3804,
+       "p_value": 1e-06,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 75,
+        "mean": 5.7473,
+        "std": 1.9437,
+        "min": 3.6513
+       },
+       "gate_only": {
+        "n": 395,
+        "mean": 5.1302,
+        "std": 1.839,
+        "min": 3.4794
+       },
+       "loss_only": {
+        "n": 30,
+        "mean": 5.9406,
+        "std": 1.9588,
+        "min": 3.8284
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.6171,
+       "p_value": 0.013057,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 22,
+        "mean": 6.976,
+        "std": 0.9869,
+        "min": 5.8698
+       },
+       "tree_hierarchical": {
+        "n": 33,
+        "mean": 5.904,
+        "std": 1.8558,
+        "min": 3.8861
+       },
+       "random": {
+        "n": 19,
+        "mean": 6.9308,
+        "std": 1.2982,
+        "min": 5.9999
+       },
+       "gmm": {
+        "n": 382,
+        "mean": 4.9002,
+        "std": 1.868,
+        "min": 3.4794
+       },
+       "gmm_features": {
+        "n": 26,
+        "mean": 6.6015,
+        "std": 0.8693,
+        "min": 5.0048
+       },
+       "uniform": {
+        "n": 18,
+        "mean": 6.2323,
+        "std": 0.6778,
+        "min": 5.3635
+       }
+      },
+      "best": {
+       "value": "gmm",
+       "runner_up": "tree_hierarchical",
+       "delta_mean": 1.0038,
+       "p_value": 0.005623,
+       "significant": "True"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 198,
+        "mean": 5.2939,
+        "std": 1.7886,
+        "min": 3.7299
+       },
+       "ema": {
+        "n": 27,
+        "mean": 6.9582,
+        "std": 1.7699,
+        "min": 4.4371
+       },
+       "markov": {
+        "n": 275,
+        "mean": 5.0895,
+        "std": 1.8767,
+        "min": 3.4794
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "none",
+       "delta_mean": 0.2044,
+       "p_value": 0.231491,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 47,
+        "mean": 6.763,
+        "std": 1.7023,
+        "min": 3.8285
+       },
+       "True": {
+        "n": 453,
+        "mean": 5.1166,
+        "std": 1.8324,
+        "min": 3.4794
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 1.6464,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 465,
+        "mean": 5.1733,
+        "std": 1.8546,
+        "min": 3.4794
+       },
+       "False": {
+        "n": 35,
+        "mean": 6.575,
+        "std": 1.7663,
+        "min": 4.6399
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 1.4017,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q4": {
+       "range": [
+        2.0,
+        null
+       ],
+       "n": 500,
+       "mean_rmse": 5.2714
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2907
+       ],
+       "n": 125,
+       "mean_rmse": 5.6791
+      },
+      "Q2": {
+       "range": [
+        0.2907,
+        0.418
+       ],
+       "n": 125,
+       "mean_rmse": 5.1389
+      },
+      "Q3": {
+       "range": [
+        0.418,
+        0.4508
+       ],
+       "n": 125,
+       "mean_rmse": 5.073
+      },
+      "Q4": {
+       "range": [
+        0.4508,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.1946
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 92,
+       "mean_rmse": 5.358
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        21.0
+       ],
+       "n": 142,
+       "mean_rmse": 4.9184
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        29.0
+       ],
+       "n": 133,
+       "mean_rmse": 5.265
+      },
+      "Q4": {
+       "range": [
+        29.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 5.5947
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q3": {
+       "range": [
+        2.0,
+        8.0
+       ],
+       "n": 365,
+       "mean_rmse": 5.2464
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 5.3389
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.2093
+       ],
+       "n": 125,
+       "mean_rmse": 6.0869
+      },
+      "Q2": {
+       "range": [
+        0.2093,
+        0.2473
+       ],
+       "n": 125,
+       "mean_rmse": 5.0747
+      },
+      "Q3": {
+       "range": [
+        0.2473,
+        0.2714
+       ],
+       "n": 125,
+       "mean_rmse": 4.9892
+      },
+      "Q4": {
+       "range": [
+        0.2714,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 4.9348
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        63.0
+       ],
+       "n": 123,
+       "mean_rmse": 5.6035
+      },
+      "Q2": {
+       "range": [
+        63.0,
+        72.0
+       ],
+       "n": 117,
+       "mean_rmse": 5.1656
+      },
+      "Q3": {
+       "range": [
+        72.0,
+        99.25
+       ],
+       "n": 135,
+       "mean_rmse": 4.9372
+      },
+      "Q4": {
+       "range": [
+        99.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 5.4045
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        8.0
+       ],
+       "n": 373,
+       "mean_rmse": 5.1988
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 5.4845
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 92,
+       "mean_rmse": 4.8853
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 128,
+       "mean_rmse": 4.9747
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        13.0
+       ],
+       "n": 150,
+       "mean_rmse": 4.9725
+      },
+      "Q4": {
+       "range": [
+        13.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 6.1816
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 711.4,
+    "holdout": {
+     "holdout_rmse": 3.5019220934340702,
+     "retrain_s": 0.313,
+     "predict_s": 0.0029,
+     "cv_rmse_of_winner": 3.4794165911371335
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_vix_ensemble_report.md
+++ b/bench_results/wide_v081/ds_vix_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['vix'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| vix | naive-ensemble | **1.73943** ± 0.05112 | 2.64216 | 0.0% | 0.12 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| vix@s42 | naive-ensemble | 2.6508 | 2.7183 | 0.067 | 224 |
+| vix@s43 | naive-ensemble | 2.6426 | 2.7052 | 0.123 | 383 |
+| vix@s44 | naive-ensemble | 2.6331 | 2.7077 | 0.181 | 478 |
+
+
+
+---
+
+## vix@s42  (search X=[3011, 13], holdout n=752)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.69842** (winner retrained in 0.07s, cv score of winner: 2.6508)
+- cv best RMSE: 2.6508, median: 2.7183, p10: 2.6885
+- train: median 0.067s/fold, mean 0.086s, p90 0.147s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.553 |
+| `min_data_in_leaf` | 0.340 |
+| `bagging_fraction` | 0.036 |
+| `feature_fraction` | 0.022 |
+| `extra_trees` | 0.016 |
+| `max_depth` | 0.016 |
+| `bagging_freq` | 0.013 |
+| `num_leaves` | 0.004 |
+| `n_models` | 0.001 |
+| `lambda_l2` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 2.7479 | 0.1438 | 2.6508 |
+| True | 31 | 2.9925 | 0.3982 | 2.7016 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8636 | 2.7229 | 2.7255 | 2.7404 | **Q2** [0.0868, 0.1006] |
+| `num_leaves` | 2.8205 | 2.7400 | 2.7437 | 2.7505 | **Q2** [80.0, 89.0] |
+| `max_depth` | — | — | 2.7368 | 2.8333 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.7352 | 2.7226 | 2.7294 | 2.8555 | **Q2** [25.0, 27.0] |
+| `lambda_l1` | 2.7623 | 2.7261 | 2.7874 | 2.7765 | **Q2** [0.0, 0.0] |
+| `lambda_l2` | 2.7617 | 2.7361 | 2.7734 | 2.7811 | **Q2** [0.0, 0.0001] |
+| `feature_fraction` | 2.7847 | 2.7610 | 2.7279 | 2.7786 | **Q3** [0.7743, 0.8111] |
+| `bagging_fraction` | 2.8401 | 2.7338 | 2.7358 | 2.7426 | **Q2** [0.9019, 0.9562] |
+
+#### E. Slice plot
+
+![vix@s42/naive-ensemble](slice_vix@s42_naive-ensemble.png)
+
+
+---
+
+## vix@s43  (search X=[3011, 13], holdout n=752)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.70837** (winner retrained in 0.13s, cv score of winner: 2.6426)
+- cv best RMSE: 2.6426, median: 2.7052, p10: 2.6666
+- train: median 0.123s/fold, mean 0.150s, p90 0.246s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.495 |
+| `learning_rate` | 0.467 |
+| `extra_trees` | 0.011 |
+| `bagging_fraction` | 0.009 |
+| `num_leaves` | 0.007 |
+| `feature_fraction` | 0.004 |
+| `bagging_freq` | 0.002 |
+| `lambda_l2` | 0.002 |
+| `max_depth` | 0.002 |
+| `n_models` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 467 | 2.7302 | 0.1234 | 2.6426 |
+| True | 33 | 3.0072 | 0.3737 | 2.6878 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8245 | 2.7048 | 2.7138 | 2.7509 | **Q2** [0.0624, 0.0699] |
+| `num_leaves` | 2.7716 | 2.7405 | 2.7202 | 2.7653 | **Q3** [53.0, 64.0] |
+| `max_depth` | 2.7492 | — | — | 2.7483 | **Q4** [5.0, ∞) |
+| `min_data_in_leaf` | 2.7481 | 2.6963 | 2.7083 | 2.8322 | **Q2** [18.0, 21.0] |
+| `lambda_l1` | 2.7320 | 2.7319 | 2.7170 | 2.8131 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 2.7910 | 2.7296 | 2.7289 | 2.7445 | **Q3** [0.0359, 0.0975] |
+| `feature_fraction` | 2.7846 | 2.7343 | 2.7328 | 2.7422 | **Q3** [0.8128, 0.852] |
+| `bagging_fraction` | 2.7907 | 2.7340 | 2.7161 | 2.7531 | **Q3** [0.7776, 0.7961] |
+
+#### E. Slice plot
+
+![vix@s43/naive-ensemble](slice_vix@s43_naive-ensemble.png)
+
+
+---
+
+## vix@s44  (search X=[3011, 13], holdout n=752)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 1.81150** (winner retrained in 0.17s, cv score of winner: 2.6331)
+- cv best RMSE: 2.6331, median: 2.7077, p10: 2.6688
+- train: median 0.181s/fold, mean 0.188s, p90 0.250s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.859 |
+| `min_data_in_leaf` | 0.111 |
+| `bagging_fraction` | 0.013 |
+| `num_leaves` | 0.007 |
+| `extra_trees` | 0.005 |
+| `max_depth` | 0.001 |
+| `n_models` | 0.001 |
+| `feature_fraction` | 0.001 |
+| `lambda_l1` | 0.001 |
+| `bagging_freq` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 468 | 2.7414 | 0.1586 | 2.6331 |
+| False | 32 | 2.9614 | 0.2773 | 2.7407 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8571 | 2.7134 | 2.7307 | 2.7208 | **Q2** [0.1588, 0.1929] |
+| `num_leaves` | 2.7925 | 2.7255 | 2.7544 | 2.7501 | **Q2** [62.0, 69.0] |
+| `max_depth` | 2.8207 | 2.7326 | — | 2.7434 | **Q2** [10.0, 11.0] |
+| `min_data_in_leaf` | 2.7576 | 2.7098 | 2.7413 | 2.8087 | **Q2** [10.0, 14.0] |
+| `lambda_l1` | 2.8110 | 2.7343 | 2.7366 | 2.7401 | **Q2** [0.8139, 1.8887] |
+| `lambda_l2` | 2.7285 | 2.7435 | 2.7323 | 2.8178 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.8208 | 2.7300 | 2.7250 | 2.7462 | **Q3** [0.9634, 0.9799] |
+| `bagging_fraction` | 2.8314 | 2.7256 | 2.7409 | 2.7242 | **Q4** [0.9836, ∞) |
+
+#### E. Slice plot
+
+![vix@s44/naive-ensemble](slice_vix@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_vix_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_vix_ensemble_summary.json
@@ -1,0 +1,1153 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "vix"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "vix": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.6984203942377865,
+      "cv_best": 2.6507614413751055,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0662
+     },
+     "43": {
+      "holdout_rmse": 1.7083695869096656,
+      "cv_best": 2.6426356542246916,
+      "crash_rate": 0.0,
+      "retrain_s": 0.1261
+     },
+     "44": {
+      "holdout_rmse": 1.811500591733026,
+      "cv_best": 2.633096302256512,
+      "crash_rate": 0.0,
+      "retrain_s": 0.169
+     }
+    },
+    "holdout_mean": 1.73943,
+    "holdout_std": 0.051123,
+    "cv_best_mean": 2.642164
+   }
+  }
+ },
+ "runs": {
+  "vix@s42": {
+   "dataset": "vix",
+   "seed": 42,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.6507614413751055,
+    "rmse_p10": 2.688543749687508,
+    "rmse_median": 2.7183185666383682,
+    "train_s_median": 0.06677045822143554,
+    "train_s_mean": 0.08631852532625198,
+    "train_s_p90": 0.14713067624717957,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.09940952660721383,
+     "num_leaves": 128,
+     "max_depth": 3,
+     "min_data_in_leaf": 27,
+     "lambda_l1": 5.269839727530459e-07,
+     "lambda_l2": 0.00019633880640960592,
+     "feature_fraction": 0.8219526837321602,
+     "bagging_fraction": 0.915221583149328,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.5532,
+     "min_data_in_leaf": 0.3397,
+     "bagging_fraction": 0.0356,
+     "feature_fraction": 0.0225,
+     "extra_trees": 0.0159,
+     "max_depth": 0.0156,
+     "bagging_freq": 0.0125,
+     "num_leaves": 0.0039,
+     "n_models": 0.0006,
+     "lambda_l2": 0.0005,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 469,
+        "mean": 2.7479,
+        "std": 0.1438,
+        "min": 2.6508
+       },
+       "True": {
+        "n": 31,
+        "mean": 2.9925,
+        "std": 0.3982,
+        "min": 2.7016
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.2446,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0868
+       ],
+       "n": 125,
+       "mean_rmse": 2.8636
+      },
+      "Q2": {
+       "range": [
+        0.0868,
+        0.1006
+       ],
+       "n": 125,
+       "mean_rmse": 2.7229
+      },
+      "Q3": {
+       "range": [
+        0.1006,
+        0.1133
+       ],
+       "n": 125,
+       "mean_rmse": 2.7255
+      },
+      "Q4": {
+       "range": [
+        0.1133,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7404
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        80.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.8205
+      },
+      "Q2": {
+       "range": [
+        80.0,
+        89.0
+       ],
+       "n": 129,
+       "mean_rmse": 2.74
+      },
+      "Q3": {
+       "range": [
+        89.0,
+        95.0
+       ],
+       "n": 112,
+       "mean_rmse": 2.7437
+      },
+      "Q4": {
+       "range": [
+        95.0,
+        null
+       ],
+       "n": 139,
+       "mean_rmse": 2.7505
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 364,
+       "mean_rmse": 2.7368
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 136,
+       "mean_rmse": 2.8333
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        25.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.7352
+      },
+      "Q2": {
+       "range": [
+        25.0,
+        27.0
+       ],
+       "n": 77,
+       "mean_rmse": 2.7226
+      },
+      "Q3": {
+       "range": [
+        27.0,
+        31.0
+       ],
+       "n": 168,
+       "mean_rmse": 2.7294
+      },
+      "Q4": {
+       "range": [
+        31.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 2.8555
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7623
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7261
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0301
+       ],
+       "n": 125,
+       "mean_rmse": 2.7874
+      },
+      "Q4": {
+       "range": [
+        0.0301,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7765
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7617
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 2.7361
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0003
+       ],
+       "n": 125,
+       "mean_rmse": 2.7734
+      },
+      "Q4": {
+       "range": [
+        0.0003,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7811
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6807
+       ],
+       "n": 125,
+       "mean_rmse": 2.7847
+      },
+      "Q2": {
+       "range": [
+        0.6807,
+        0.7743
+       ],
+       "n": 125,
+       "mean_rmse": 2.761
+      },
+      "Q3": {
+       "range": [
+        0.7743,
+        0.8111
+       ],
+       "n": 125,
+       "mean_rmse": 2.7279
+      },
+      "Q4": {
+       "range": [
+        0.8111,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7786
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9019
+       ],
+       "n": 125,
+       "mean_rmse": 2.8401
+      },
+      "Q2": {
+       "range": [
+        0.9019,
+        0.9562
+       ],
+       "n": 125,
+       "mean_rmse": 2.7338
+      },
+      "Q3": {
+       "range": [
+        0.9562,
+        0.9818
+       ],
+       "n": 125,
+       "mean_rmse": 2.7358
+      },
+      "Q4": {
+       "range": [
+        0.9818,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7426
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 224.3,
+    "holdout": {
+     "holdout_rmse": 1.6984203942377865,
+     "retrain_s": 0.0662,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.6507614413751055
+    }
+   }
+  },
+  "vix@s43": {
+   "dataset": "vix",
+   "seed": 43,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.6426356542246916,
+    "rmse_p10": 2.666568247147142,
+    "rmse_median": 2.705228917018183,
+    "train_s_median": 0.1228902019560337,
+    "train_s_mean": 0.14979226953312755,
+    "train_s_p90": 0.24581095073372128,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.07188494115759617,
+     "num_leaves": 44,
+     "max_depth": 5,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 1.2582784259121393e-07,
+     "lambda_l2": 0.012262992194084464,
+     "feature_fraction": 0.826655206080592,
+     "bagging_fraction": 0.7673749892067744,
+     "bagging_freq": 5,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.4955,
+     "learning_rate": 0.4672,
+     "extra_trees": 0.0115,
+     "bagging_fraction": 0.0086,
+     "num_leaves": 0.0069,
+     "feature_fraction": 0.0044,
+     "bagging_freq": 0.0024,
+     "lambda_l2": 0.0018,
+     "max_depth": 0.0015,
+     "n_models": 0.0002,
+     "lambda_l1": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 467,
+        "mean": 2.7302,
+        "std": 0.1234,
+        "min": 2.6426
+       },
+       "True": {
+        "n": 33,
+        "mean": 3.0072,
+        "std": 0.3737,
+        "min": 2.6878
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.277,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0624
+       ],
+       "n": 125,
+       "mean_rmse": 2.8245
+      },
+      "Q2": {
+       "range": [
+        0.0624,
+        0.0699
+       ],
+       "n": 125,
+       "mean_rmse": 2.7048
+      },
+      "Q3": {
+       "range": [
+        0.0699,
+        0.0794
+       ],
+       "n": 125,
+       "mean_rmse": 2.7138
+      },
+      "Q4": {
+       "range": [
+        0.0794,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7509
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        45.0
+       ],
+       "n": 114,
+       "mean_rmse": 2.7716
+      },
+      "Q2": {
+       "range": [
+        45.0,
+        53.0
+       ],
+       "n": 126,
+       "mean_rmse": 2.7405
+      },
+      "Q3": {
+       "range": [
+        53.0,
+        64.0
+       ],
+       "n": 133,
+       "mean_rmse": 2.7202
+      },
+      "Q4": {
+       "range": [
+        64.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 2.7653
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.7492
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 387,
+       "mean_rmse": 2.7483
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 112,
+       "mean_rmse": 2.7481
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        21.0
+       ],
+       "n": 111,
+       "mean_rmse": 2.6963
+      },
+      "Q3": {
+       "range": [
+        21.0,
+        25.0
+       ],
+       "n": 140,
+       "mean_rmse": 2.7083
+      },
+      "Q4": {
+       "range": [
+        25.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 2.8322
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.732
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7319
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.717
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8131
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0087
+       ],
+       "n": 125,
+       "mean_rmse": 2.791
+      },
+      "Q2": {
+       "range": [
+        0.0087,
+        0.0359
+       ],
+       "n": 125,
+       "mean_rmse": 2.7296
+      },
+      "Q3": {
+       "range": [
+        0.0359,
+        0.0975
+       ],
+       "n": 125,
+       "mean_rmse": 2.7289
+      },
+      "Q4": {
+       "range": [
+        0.0975,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7445
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7826
+       ],
+       "n": 125,
+       "mean_rmse": 2.7846
+      },
+      "Q2": {
+       "range": [
+        0.7826,
+        0.8128
+       ],
+       "n": 125,
+       "mean_rmse": 2.7343
+      },
+      "Q3": {
+       "range": [
+        0.8128,
+        0.852
+       ],
+       "n": 125,
+       "mean_rmse": 2.7328
+      },
+      "Q4": {
+       "range": [
+        0.852,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7422
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.754
+       ],
+       "n": 125,
+       "mean_rmse": 2.7907
+      },
+      "Q2": {
+       "range": [
+        0.754,
+        0.7776
+       ],
+       "n": 125,
+       "mean_rmse": 2.734
+      },
+      "Q3": {
+       "range": [
+        0.7776,
+        0.7961
+       ],
+       "n": 125,
+       "mean_rmse": 2.7161
+      },
+      "Q4": {
+       "range": [
+        0.7961,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7531
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 382.9,
+    "holdout": {
+     "holdout_rmse": 1.7083695869096656,
+     "retrain_s": 0.1261,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.6426356542246916
+    }
+   }
+  },
+  "vix@s44": {
+   "dataset": "vix",
+   "seed": 44,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.633096302256512,
+    "rmse_p10": 2.668827110649905,
+    "rmse_median": 2.707707108258448,
+    "train_s_median": 0.181195280700922,
+    "train_s_mean": 0.1883572105333209,
+    "train_s_p90": 0.2496734020113945,
+    "best_params": {
+     "n_models": 2,
+     "learning_rate": 0.15715626730370527,
+     "num_leaves": 61,
+     "max_depth": 11,
+     "min_data_in_leaf": 13,
+     "lambda_l1": 1.2742683441394453,
+     "lambda_l2": 0.04766302914827998,
+     "feature_fraction": 0.9534069471769491,
+     "bagging_fraction": 0.9801652079707892,
+     "bagging_freq": 4,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.8591,
+     "min_data_in_leaf": 0.1105,
+     "bagging_fraction": 0.013,
+     "num_leaves": 0.0068,
+     "extra_trees": 0.0049,
+     "max_depth": 0.0014,
+     "n_models": 0.0013,
+     "feature_fraction": 0.0012,
+     "lambda_l1": 0.0011,
+     "bagging_freq": 0.0007,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 468,
+        "mean": 2.7414,
+        "std": 0.1586,
+        "min": 2.6331
+       },
+       "False": {
+        "n": 32,
+        "mean": 2.9614,
+        "std": 0.2773,
+        "min": 2.7407
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.22,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1588
+       ],
+       "n": 125,
+       "mean_rmse": 2.8571
+      },
+      "Q2": {
+       "range": [
+        0.1588,
+        0.1929
+       ],
+       "n": 125,
+       "mean_rmse": 2.7134
+      },
+      "Q3": {
+       "range": [
+        0.1929,
+        0.2328
+       ],
+       "n": 125,
+       "mean_rmse": 2.7307
+      },
+      "Q4": {
+       "range": [
+        0.2328,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7208
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        62.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.7925
+      },
+      "Q2": {
+       "range": [
+        62.0,
+        69.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.7255
+      },
+      "Q3": {
+       "range": [
+        69.0,
+        76.0
+       ],
+       "n": 136,
+       "mean_rmse": 2.7544
+      },
+      "Q4": {
+       "range": [
+        76.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 2.7501
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 99,
+       "mean_rmse": 2.8207
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 148,
+       "mean_rmse": 2.7326
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 253,
+       "mean_rmse": 2.7434
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 109,
+       "mean_rmse": 2.7576
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        14.0
+       ],
+       "n": 124,
+       "mean_rmse": 2.7098
+      },
+      "Q3": {
+       "range": [
+        14.0,
+        18.0
+       ],
+       "n": 130,
+       "mean_rmse": 2.7413
+      },
+      "Q4": {
+       "range": [
+        18.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 2.8087
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.8139
+       ],
+       "n": 125,
+       "mean_rmse": 2.811
+      },
+      "Q2": {
+       "range": [
+        0.8139,
+        1.8887
+       ],
+       "n": 125,
+       "mean_rmse": 2.7343
+      },
+      "Q3": {
+       "range": [
+        1.8887,
+        3.7295
+       ],
+       "n": 125,
+       "mean_rmse": 2.7366
+      },
+      "Q4": {
+       "range": [
+        3.7295,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7401
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7285
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7435
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7323
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8178
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9387
+       ],
+       "n": 125,
+       "mean_rmse": 2.8208
+      },
+      "Q2": {
+       "range": [
+        0.9387,
+        0.9634
+       ],
+       "n": 125,
+       "mean_rmse": 2.73
+      },
+      "Q3": {
+       "range": [
+        0.9634,
+        0.9799
+       ],
+       "n": 125,
+       "mean_rmse": 2.725
+      },
+      "Q4": {
+       "range": [
+        0.9799,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7462
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.9299
+       ],
+       "n": 125,
+       "mean_rmse": 2.8314
+      },
+      "Q2": {
+       "range": [
+        0.9299,
+        0.9648
+       ],
+       "n": 125,
+       "mean_rmse": 2.7256
+      },
+      "Q3": {
+       "range": [
+        0.9648,
+        0.9836
+       ],
+       "n": 125,
+       "mean_rmse": 2.7409
+      },
+      "Q4": {
+       "range": [
+        0.9836,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7242
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 478.4,
+    "holdout": {
+     "holdout_rmse": 1.811500591733026,
+     "retrain_s": 0.169,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 2.633096302256512
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_vix_report.md
+++ b/bench_results/wide_v081/ds_vix_report.md
@@ -1,0 +1,507 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['vix'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| vix | naive-lightgbm | **1.76822** ± 0.09140 | 2.61915 | 0.0% | 0.07 |
+| vix | moe | **1.65253** ± 0.03007 | 2.38125 | 0.0% | 1.98 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| vix@s42 | naive-lightgbm | 2.6235 | 2.7139 | 0.078 | 216 |
+| vix@s42 | moe | 2.3922 | 2.6010 | 0.472 | 1431 |
+| vix@s43 | naive-lightgbm | 2.5849 | 2.6917 | 0.053 | 168 |
+| vix@s43 | moe | 2.3760 | 2.5739 | 0.376 | 7444 |
+| vix@s44 | naive-lightgbm | 2.6491 | 2.7244 | 0.066 | 186 |
+| vix@s44 | moe | 2.3756 | 2.5804 | 0.622 | 3192 |
+
+
+
+---
+
+## vix@s42  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.67713** (winner retrained in 0.05s, cv score of winner: 2.6235)
+- cv best RMSE: 2.6235, median: 2.7139, p10: 2.6728
+- train: median 0.078s/fold, mean 0.082s, p90 0.116s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.699 |
+| `min_data_in_leaf` | 0.180 |
+| `extra_trees` | 0.087 |
+| `feature_fraction` | 0.015 |
+| `max_depth` | 0.009 |
+| `num_leaves` | 0.004 |
+| `bagging_freq` | 0.003 |
+| `bagging_fraction` | 0.003 |
+| `lambda_l2` | 0.000 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 2.7351 | 0.1102 | 2.6235 |
+| True | 32 | 3.1497 | 0.4330 | 2.7210 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8230 | 2.7158 | 2.7369 | 2.7708 | **Q2** [0.0357, 0.0412] |
+| `num_leaves` | 2.7549 | 2.7697 | 2.7813 | 2.7432 | **Q4** [122.0, ∞) |
+| `max_depth` | — | 2.7358 | 2.7560 | 2.8102 | **Q2** [3.0, 5.0] |
+| `min_data_in_leaf` | 2.7283 | 2.7534 | 2.7232 | 2.8354 | **Q3** [25.0, 30.0] |
+| `lambda_l1` | 2.7318 | 2.7470 | 2.7421 | 2.8255 | **Q1** [None, 0.0] |
+| `lambda_l2` | 2.7783 | 2.7428 | 2.7554 | 2.7700 | **Q2** [0.0, 0.002] |
+| `feature_fraction` | 2.8182 | 2.7281 | 2.7358 | 2.7642 | **Q2** [0.7079, 0.7368] |
+| `bagging_fraction` | 2.7370 | 2.7555 | 2.7556 | 2.7984 | **Q1** [None, 0.6106] |
+
+#### E. Slice plot
+
+![vix@s42/naive-lightgbm](slice_vix@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.68475** (winner retrained in 0.21s, cv score of winner: 2.3922)
+- cv best RMSE: 2.3922, median: 2.6010, p10: 2.4761
+- train: median 0.472s/fold, mean 0.558s, p90 0.927s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.257 |
+| `learning_rate` | 0.228 |
+| `mixture_diversity_lambda` | 0.223 |
+| `mixture_init` | 0.086 |
+| `mixture_expert_dropout_rate` | 0.057 |
+| `mixture_gate_type` | 0.032 |
+| `bagging_fraction` | 0.031 |
+| `max_depth` | 0.017 |
+| `mixture_num_experts` | 0.012 |
+| `feature_fraction` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 105 | 2.7362 | 0.5407 | 2.3922 |
+| leaf_reuse | 351 | 2.7944 | 0.7703 | 2.4078 |
+| gbdt | 44 | 3.1943 | 2.0600 | 2.6051 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 453 | 2.7581 | 0.7788 | 2.3922 |
+| token_choice | 47 | 3.3881 | 1.7331 | 2.5232 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 286 | 2.7819 | 0.6365 | 2.4592 |
+| em | 170 | 2.8088 | 1.0544 | 2.3922 |
+| loss_only | 44 | 3.0809 | 1.6823 | 2.6051 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 151 | 2.6059 | 0.5691 | 2.3922 |
+| uniform | 266 | 2.7512 | 0.7589 | 2.5166 |
+| kmeans_features | 35 | 3.0356 | 1.7968 | 2.6051 |
+| tree_hierarchical | 15 | 3.1467 | 0.6490 | 2.6185 |
+| gmm_features | 16 | 3.8342 | 1.2837 | 2.7617 |
+| gmm | 17 | 4.0340 | 1.3746 | 2.6817 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| markov | 238 | 2.7406 | 0.5238 | 2.5347 |
+| ema | 204 | 2.7947 | 1.0837 | 2.3922 |
+| none | 58 | 3.2119 | 1.4229 | 2.5598 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 2.7828 | 0.8167 | 2.3922 |
+| True | 30 | 3.3586 | 1.9145 | 2.6000 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 431 | 2.7227 | 0.7560 | 2.3922 |
+| True | 69 | 3.4086 | 1.5156 | 2.6729 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 2.7364 | — | 2.8920 | **Q2** [2.0, 3.0] |
+| `mixture_diversity_lambda` | 2.7452 | 2.6973 | 2.8150 | 3.0120 | **Q2** [0.2239, 0.3045] |
+| `mixture_warmup_iters` | 2.8629 | 2.7033 | 2.7300 | 2.9706 | **Q2** [22.0, 25.0] |
+| `mixture_balance_factor` | 2.6914 | 2.8342 | 3.1705 | 2.8058 | **Q1** [None, 4.0] |
+| `learning_rate` | 3.0307 | 2.7520 | 2.6736 | 2.8132 | **Q3** [0.0754, 0.0951] |
+| `num_leaves` | 2.7378 | 2.9685 | 2.7124 | 2.8486 | **Q3** [94.0, 108.0] |
+| `max_depth` | — | 2.7774 | 2.8727 | 2.8464 | **Q2** [3.0, 8.0] |
+| `min_data_in_leaf` | 2.7109 | 2.8340 | 2.7945 | 2.9264 | **Q1** [None, 12.0] |
+
+#### E. Slice plot
+
+![vix@s42/moe](slice_vix@s42_moe.png)
+
+
+---
+
+## vix@s43  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.89318** (winner retrained in 0.06s, cv score of winner: 2.5849)
+- cv best RMSE: 2.5849, median: 2.6917, p10: 2.6212
+- train: median 0.053s/fold, mean 0.062s, p90 0.087s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.667 |
+| `min_data_in_leaf` | 0.289 |
+| `feature_fraction` | 0.012 |
+| `bagging_fraction` | 0.012 |
+| `max_depth` | 0.008 |
+| `num_leaves` | 0.006 |
+| `lambda_l1` | 0.004 |
+| `bagging_freq` | 0.002 |
+| `extra_trees` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| True | 449 | 2.7273 | 0.1776 | 2.5849 |
+| False | 51 | 2.8425 | 0.2538 | 2.6431 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8429 | 2.7242 | 2.6824 | 2.7067 | **Q3** [0.1774, 0.2016] |
+| `num_leaves` | 2.7385 | 2.7214 | 2.7456 | 2.7507 | **Q2** [42.0, 61.0] |
+| `max_depth` | — | — | 2.7044 | 2.8420 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.7062 | 2.7117 | 2.7122 | 2.8150 | **Q1** [None, 8.0] |
+| `lambda_l1` | 2.7896 | 2.7304 | 2.7068 | 2.7295 | **Q3** [0.0416, 0.1672] |
+| `lambda_l2` | 2.6942 | 2.7393 | 2.7290 | 2.7938 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.7439 | 2.7254 | 2.7169 | 2.7701 | **Q3** [0.7498, 0.7833] |
+| `bagging_fraction` | 2.7425 | 2.7329 | 2.7788 | 2.7021 | **Q4** [0.9348, ∞) |
+
+#### E. Slice plot
+
+![vix@s43/naive-lightgbm](slice_vix@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.61238** (winner retrained in 0.25s, cv score of winner: 2.3760)
+- cv best RMSE: 2.3760, median: 2.5739, p10: 2.4197
+- train: median 0.376s/fold, mean 2.964s, p90 8.992s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.488 |
+| `mixture_diversity_lambda` | 0.168 |
+| `lambda_l1` | 0.051 |
+| `mixture_gate_type` | 0.047 |
+| `mixture_init` | 0.036 |
+| `num_leaves` | 0.031 |
+| `mixture_balance_factor` | 0.027 |
+| `mixture_warmup_iters` | 0.024 |
+| `mixture_refit_leaves` | 0.023 |
+| `mixture_load_balance_alpha` | 0.016 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_gate_type` | **leaf_reuse** | 2.6639 (n=307) | gbdt | Δ +0.5453 | p=3.10e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| leaf_reuse | 307 | 2.6639 | 0.6333 | 2.3760 |
+| gbdt | 170 | 3.2092 | 2.3174 | 2.4002 |
+| none | 23 | 3.7623 | 1.4888 | 2.4571 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 457 | 2.8184 | 1.2728 | 2.3760 |
+| expert_choice | 43 | 3.7652 | 2.9013 | 2.3826 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gate_only | 445 | 2.8346 | 1.3947 | 2.3760 |
+| em | 25 | 2.9303 | 0.8025 | 2.4206 |
+| loss_only | 30 | 3.8422 | 2.7528 | 2.4344 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 402 | 2.7825 | 1.3325 | 2.3760 |
+| uniform | 20 | 2.8916 | 0.4949 | 2.5328 |
+| tree_hierarchical | 19 | 2.9529 | 0.5744 | 2.5835 |
+| kmeans_features | 19 | 3.1616 | 1.1931 | 2.6313 |
+| gmm | 20 | 3.6724 | 2.5959 | 2.5732 |
+| gmm_features | 20 | 4.1952 | 3.1497 | 2.6524 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 414 | 2.8016 | 1.3344 | 2.3760 |
+| markov | 55 | 3.0908 | 1.9192 | 2.3953 |
+| none | 31 | 3.8727 | 2.2891 | 2.4451 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 2.8453 | 1.4008 | 2.3760 |
+| True | 32 | 3.6983 | 2.4836 | 2.5771 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 2.8232 | 1.3070 | 2.3760 |
+| True | 31 | 4.0589 | 3.0690 | 2.7129 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 3.8366 | — | — | 2.8379 | **Q4** [4.0, ∞) |
+| `mixture_diversity_lambda` | 2.7451 | 2.7374 | 2.6120 | 3.5050 | **Q3** [0.237, 0.279] |
+| `mixture_warmup_iters` | 2.8472 | 2.7200 | 2.8294 | 3.1732 | **Q2** [36.0, 39.0] |
+| `mixture_balance_factor` | 3.2406 | 3.0562 | — | 2.7257 | **Q4** [7.0, ∞) |
+| `learning_rate` | 3.5317 | 2.8098 | 2.5615 | 2.6964 | **Q3** [0.0818, 0.1011] |
+| `num_leaves` | 2.6542 | 2.7849 | 2.8689 | 3.2772 | **Q1** [None, 38.0] |
+| `max_depth` | — | — | 2.7284 | 3.3635 | **Q3** [3.0, 4.0] |
+| `min_data_in_leaf` | 2.6373 | 2.7124 | 2.8311 | 3.3668 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![vix@s43/moe](slice_vix@s43_moe.png)
+
+
+---
+
+## vix@s44  (search X=[3011, 13], holdout n=752)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 1.73436** (winner retrained in 0.08s, cv score of winner: 2.6491)
+- cv best RMSE: 2.6491, median: 2.7244, p10: 2.6847
+- train: median 0.066s/fold, mean 0.070s, p90 0.103s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `min_data_in_leaf` | 0.480 |
+| `learning_rate` | 0.363 |
+| `extra_trees` | 0.036 |
+| `num_leaves` | 0.035 |
+| `max_depth` | 0.035 |
+| `bagging_fraction` | 0.020 |
+| `bagging_freq` | 0.014 |
+| `feature_fraction` | 0.012 |
+| `lambda_l2` | 0.005 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 2.7555 | 0.1315 | 2.6491 |
+| True | 30 | 2.9885 | 0.2639 | 2.7179 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 2.8129 | 2.7511 | 2.7380 | 2.7760 | **Q3** [0.0489, 0.0709] |
+| `num_leaves` | 2.7794 | 2.7623 | 2.7505 | 2.7881 | **Q3** [68.0, 73.25] |
+| `max_depth` | 2.7848 | 2.7764 | — | 2.7647 | **Q4** [5.0, ∞) |
+| `min_data_in_leaf` | 2.7802 | 2.7276 | 2.7353 | 2.8236 | **Q2** [20.0, 24.0] |
+| `lambda_l1` | 2.7709 | 2.7526 | 2.7812 | 2.7733 | **Q2** [0.0, 0.0001] |
+| `lambda_l2` | 2.7519 | 2.7682 | 2.7522 | 2.8058 | **Q1** [None, 0.0] |
+| `feature_fraction` | 2.7956 | 2.7418 | 2.7627 | 2.7779 | **Q2** [0.7376, 0.766] |
+| `bagging_fraction` | 2.8315 | 2.7451 | 2.7405 | 2.7611 | **Q3** [0.8748, 0.8987] |
+
+#### E. Slice plot
+
+![vix@s44/naive-lightgbm](slice_vix@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 1.66045** (winner retrained in 5.47s, cv score of winner: 2.3756)
+- cv best RMSE: 2.3756, median: 2.5804, p10: 2.4598
+- train: median 0.622s/fold, mean 1.264s, p90 4.185s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_warmup_iters` | 0.428 |
+| `mixture_init` | 0.205 |
+| `mixture_gate_type` | 0.073 |
+| `feature_fraction` | 0.064 |
+| `learning_rate` | 0.059 |
+| `num_leaves` | 0.045 |
+| `lambda_l1` | 0.018 |
+| `mixture_diversity_lambda` | 0.015 |
+| `bagging_freq` | 0.015 |
+| `mixture_hard_m_step` | 0.012 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| gbdt | 110 | 2.9130 | 1.0253 | 2.3756 |
+| leaf_reuse | 342 | 3.0246 | 1.5127 | 2.4058 |
+| none | 48 | 3.4747 | 2.2942 | 2.4747 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 420 | 3.0297 | 1.5477 | 2.3756 |
+| expert_choice | 80 | 3.1146 | 1.3933 | 2.5366 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 163 | 2.8566 | 1.0045 | 2.4399 |
+| loss_only | 282 | 3.0784 | 1.6036 | 2.3756 |
+| gate_only | 55 | 3.4167 | 2.1677 | 2.5226 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 371 | 2.7217 | 0.9154 | 2.3756 |
+| uniform | 48 | 2.8709 | 0.9621 | 2.5366 |
+| tree_hierarchical | 20 | 3.1917 | 0.5085 | 2.6735 |
+| kmeans_features | 23 | 3.9873 | 2.1175 | 2.7784 |
+| gmm_features | 18 | 5.7448 | 3.0133 | 2.8328 |
+| gmm | 20 | 5.7562 | 3.1260 | 2.8129 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 386 | 2.9424 | 1.3422 | 2.3756 |
+| ema | 71 | 3.3742 | 2.0379 | 2.4787 |
+| markov | 43 | 3.4028 | 1.8944 | 2.4218 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 2.9871 | 1.4394 | 2.3756 |
+| True | 32 | 3.8642 | 2.2992 | 2.7441 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 3.0187 | 1.5359 | 2.3756 |
+| True | 32 | 3.4022 | 1.2915 | 2.7902 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 3.1982 | — | — | 3.0253 | **Q4** [5.0, ∞) |
+| `mixture_diversity_lambda` | 2.8140 | 3.0862 | 3.2380 | 3.0349 | **Q1** [None, 0.2017] |
+| `mixture_warmup_iters` | 3.2073 | 2.9164 | 3.2332 | 2.8747 | **Q4** [41.0, ∞) |
+| `mixture_balance_factor` | 2.8302 | — | 3.0892 | 3.0235 | **Q1** [None, 3.0] |
+| `learning_rate` | 3.4137 | 2.9281 | 3.1677 | 2.6636 | **Q4** [0.2269, ∞) |
+| `num_leaves` | 2.9488 | 3.1454 | 3.0754 | 2.9992 | **Q1** [None, 13.0] |
+| `max_depth` | 3.1466 | 3.0045 | 3.4204 | 2.9922 | **Q4** [9.0, ∞) |
+| `min_data_in_leaf` | 2.9464 | 3.2144 | 2.7946 | 3.2176 | **Q3** [23.0, 27.0] |
+
+#### E. Slice plot
+
+![vix@s44/moe](slice_vix@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| vix@s43 | `mixture_gate_type` | **leaf_reuse** | +0.5453 | 3.10e-03 |

--- a/bench_results/wide_v081/ds_vix_summary.json
+++ b/bench_results/wide_v081/ds_vix_summary.json
@@ -1,0 +1,2785 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "vix"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "vix": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.677127623602778,
+      "cv_best": 2.6234510153140738,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0489
+     },
+     "43": {
+      "holdout_rmse": 1.8931841595601477,
+      "cv_best": 2.584923207859547,
+      "crash_rate": 0.0,
+      "retrain_s": 0.063
+     },
+     "44": {
+      "holdout_rmse": 1.734364414075465,
+      "cv_best": 2.6490625795105567,
+      "crash_rate": 0.0,
+      "retrain_s": 0.0844
+     }
+    },
+    "holdout_mean": 1.768225,
+    "holdout_std": 0.091397,
+    "cv_best_mean": 2.619146
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 1.6847534615633177,
+      "cv_best": 2.3921847688588564,
+      "crash_rate": 0.0,
+      "retrain_s": 0.213
+     },
+     "43": {
+      "holdout_rmse": 1.6123804725640898,
+      "cv_best": 2.3759914339602117,
+      "crash_rate": 0.0,
+      "retrain_s": 0.246
+     },
+     "44": {
+      "holdout_rmse": 1.660445704759538,
+      "cv_best": 2.3755639555270784,
+      "crash_rate": 0.0,
+      "retrain_s": 5.4683
+     }
+    },
+    "holdout_mean": 1.652527,
+    "holdout_std": 0.030072,
+    "cv_best_mean": 2.381247
+   }
+  }
+ },
+ "runs": {
+  "vix@s42": {
+   "dataset": "vix",
+   "seed": 42,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.6234510153140738,
+    "rmse_p10": 2.6728164261782683,
+    "rmse_median": 2.7139165786188406,
+    "train_s_median": 0.07826210949569941,
+    "train_s_mean": 0.08161991912201046,
+    "train_s_p90": 0.11633065197616815,
+    "best_params": {
+     "learning_rate": 0.04862827213309885,
+     "num_leaves": 47,
+     "max_depth": 3,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 9.460771418699148e-07,
+     "lambda_l2": 0.006060654078499374,
+     "feature_fraction": 0.7441893936143491,
+     "bagging_fraction": 0.6170760857577333,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.6994,
+     "min_data_in_leaf": 0.1796,
+     "extra_trees": 0.0868,
+     "feature_fraction": 0.0148,
+     "max_depth": 0.0095,
+     "num_leaves": 0.0038,
+     "bagging_freq": 0.003,
+     "bagging_fraction": 0.0026,
+     "lambda_l2": 0.0004,
+     "lambda_l1": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 3.1497,
+        "std": 0.433,
+        "min": 2.721
+       },
+       "False": {
+        "n": 468,
+        "mean": 2.7351,
+        "std": 0.1102,
+        "min": 2.6235
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.4146,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0357
+       ],
+       "n": 125,
+       "mean_rmse": 2.823
+      },
+      "Q2": {
+       "range": [
+        0.0357,
+        0.0412
+       ],
+       "n": 125,
+       "mean_rmse": 2.7158
+      },
+      "Q3": {
+       "range": [
+        0.0412,
+        0.0521
+       ],
+       "n": 125,
+       "mean_rmse": 2.7369
+      },
+      "Q4": {
+       "range": [
+        0.0521,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7708
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        28.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.7549
+      },
+      "Q2": {
+       "range": [
+        28.0,
+        57.0
+       ],
+       "n": 128,
+       "mean_rmse": 2.7697
+      },
+      "Q3": {
+       "range": [
+        57.0,
+        122.0
+       ],
+       "n": 116,
+       "mean_rmse": 2.7813
+      },
+      "Q4": {
+       "range": [
+        122.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 2.7432
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q2": {
+       "range": [
+        3.0,
+        5.0
+       ],
+       "n": 221,
+       "mean_rmse": 2.7358
+      },
+      "Q3": {
+       "range": [
+        5.0,
+        6.0
+       ],
+       "n": 145,
+       "mean_rmse": 2.756
+      },
+      "Q4": {
+       "range": [
+        6.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 2.8102
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        11.75
+       ],
+       "n": 125,
+       "mean_rmse": 2.7283
+      },
+      "Q2": {
+       "range": [
+        11.75,
+        25.0
+       ],
+       "n": 106,
+       "mean_rmse": 2.7534
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        30.0
+       ],
+       "n": 132,
+       "mean_rmse": 2.7232
+      },
+      "Q4": {
+       "range": [
+        30.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 2.8354
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7318
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.747
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7421
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8255
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7783
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.002
+       ],
+       "n": 125,
+       "mean_rmse": 2.7428
+      },
+      "Q3": {
+       "range": [
+        0.002,
+        0.2768
+       ],
+       "n": 125,
+       "mean_rmse": 2.7554
+      },
+      "Q4": {
+       "range": [
+        0.2768,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.77
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7079
+       ],
+       "n": 125,
+       "mean_rmse": 2.8182
+      },
+      "Q2": {
+       "range": [
+        0.7079,
+        0.7368
+       ],
+       "n": 125,
+       "mean_rmse": 2.7281
+      },
+      "Q3": {
+       "range": [
+        0.7368,
+        0.7653
+       ],
+       "n": 125,
+       "mean_rmse": 2.7358
+      },
+      "Q4": {
+       "range": [
+        0.7653,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7642
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6106
+       ],
+       "n": 125,
+       "mean_rmse": 2.737
+      },
+      "Q2": {
+       "range": [
+        0.6106,
+        0.6766
+       ],
+       "n": 125,
+       "mean_rmse": 2.7555
+      },
+      "Q3": {
+       "range": [
+        0.6766,
+        0.7686
+       ],
+       "n": 125,
+       "mean_rmse": 2.7556
+      },
+      "Q4": {
+       "range": [
+        0.7686,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7984
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 216.1,
+    "holdout": {
+     "holdout_rmse": 1.677127623602778,
+     "retrain_s": 0.0489,
+     "predict_s": 0.0003,
+     "cv_rmse_of_winner": 2.6234510153140738
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.3921847688588564,
+    "rmse_p10": 2.4761302545277095,
+    "rmse_median": 2.6009513333997187,
+    "train_s_median": 0.4716874917969108,
+    "train_s_mean": 0.5584517306864261,
+    "train_s_p90": 0.9266213985905052,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "expert_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.06643251201537773,
+     "num_leaves": 28,
+     "max_depth": 3,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.321874962967782,
+     "lambda_l2": 2.4464702349519698e-06,
+     "feature_fraction": 0.980646457659205,
+     "bagging_fraction": 0.9568122572052136,
+     "bagging_freq": 6,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 38,
+     "mixture_balance_factor": 2,
+     "mixture_smoothing_lambda": 0.12878055816973075,
+     "mixture_diversity_lambda": 0.21152379192721094,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.16575858447168124,
+     "mixture_load_balance_alpha": 0.3992533507253693,
+     "mixture_expert_capacity_factor": 0.8170726333481381,
+     "mixture_expert_choice_boost": 29.985621271546336,
+     "mixture_expert_choice_hard": false,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "lambda_l2": 0.2574,
+     "learning_rate": 0.2283,
+     "mixture_diversity_lambda": 0.2231,
+     "mixture_init": 0.0864,
+     "mixture_expert_dropout_rate": 0.0565,
+     "mixture_gate_type": 0.0323,
+     "bagging_fraction": 0.0307,
+     "max_depth": 0.0166,
+     "mixture_num_experts": 0.0123,
+     "feature_fraction": 0.0121,
+     "mixture_warmup_iters": 0.0072,
+     "mixture_r_smoothing": 0.0068,
+     "num_leaves": 0.0052,
+     "min_data_in_leaf": 0.0049,
+     "mixture_e_step_mode": 0.0048,
+     "mixture_load_balance_alpha": 0.0041,
+     "mixture_balance_factor": 0.0027,
+     "mixture_hard_m_step": 0.0025,
+     "mixture_routing_mode": 0.0024,
+     "bagging_freq": 0.0023,
+     "lambda_l1": 0.0009,
+     "extra_trees": 0.0004,
+     "mixture_refit_leaves": 0.0001
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 351,
+        "mean": 2.7944,
+        "std": 0.7703,
+        "min": 2.4078
+       },
+       "none": {
+        "n": 105,
+        "mean": 2.7362,
+        "std": 0.5407,
+        "min": 2.3922
+       },
+       "gbdt": {
+        "n": 44,
+        "mean": 3.1943,
+        "std": 2.06,
+        "min": 2.6051
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0582,
+       "p_value": 0.386632,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 47,
+        "mean": 3.3881,
+        "std": 1.7331,
+        "min": 2.5232
+       },
+       "expert_choice": {
+        "n": 453,
+        "mean": 2.7581,
+        "std": 0.7788,
+        "min": 2.3922
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.63,
+       "p_value": 0.018417,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 286,
+        "mean": 2.7819,
+        "std": 0.6365,
+        "min": 2.4592
+       },
+       "loss_only": {
+        "n": 44,
+        "mean": 3.0809,
+        "std": 1.6823,
+        "min": 2.6051
+       },
+       "em": {
+        "n": 170,
+        "mean": 2.8088,
+        "std": 1.0544,
+        "min": 2.3922
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0269,
+       "p_value": 0.763343,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 266,
+        "mean": 2.7512,
+        "std": 0.7589,
+        "min": 2.5166
+       },
+       "gmm": {
+        "n": 17,
+        "mean": 4.034,
+        "std": 1.3746,
+        "min": 2.6817
+       },
+       "random": {
+        "n": 151,
+        "mean": 2.6059,
+        "std": 0.5691,
+        "min": 2.3922
+       },
+       "gmm_features": {
+        "n": 16,
+        "mean": 3.8342,
+        "std": 1.2837,
+        "min": 2.7617
+       },
+       "kmeans_features": {
+        "n": 35,
+        "mean": 3.0356,
+        "std": 1.7968,
+        "min": 2.6051
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 3.1467,
+        "std": 0.649,
+        "min": 2.6185
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.1453,
+       "p_value": 0.027902,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 204,
+        "mean": 2.7947,
+        "std": 1.0837,
+        "min": 2.3922
+       },
+       "markov": {
+        "n": 238,
+        "mean": 2.7406,
+        "std": 0.5238,
+        "min": 2.5347
+       },
+       "none": {
+        "n": 58,
+        "mean": 3.2119,
+        "std": 1.4229,
+        "min": 2.5598
+       }
+      },
+      "best": {
+       "value": "markov",
+       "runner_up": "ema",
+       "delta_mean": 0.0541,
+       "p_value": 0.51653,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 2.7828,
+        "std": 0.8167,
+        "min": 2.3922
+       },
+       "True": {
+        "n": 30,
+        "mean": 3.3586,
+        "std": 1.9145,
+        "min": 2.6
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5758,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 69,
+        "mean": 3.4086,
+        "std": 1.5156,
+        "min": 2.6729
+       },
+       "False": {
+        "n": 431,
+        "mean": 2.7227,
+        "std": 0.756,
+        "min": 2.3922
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.6859,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 240,
+       "mean_rmse": 2.7364
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 260,
+       "mean_rmse": 2.892
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2239
+       ],
+       "n": 125,
+       "mean_rmse": 2.7452
+      },
+      "Q2": {
+       "range": [
+        0.2239,
+        0.3045
+       ],
+       "n": 125,
+       "mean_rmse": 2.6973
+      },
+      "Q3": {
+       "range": [
+        0.3045,
+        0.3386
+       ],
+       "n": 125,
+       "mean_rmse": 2.815
+      },
+      "Q4": {
+       "range": [
+        0.3386,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.012
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        22.0
+       ],
+       "n": 117,
+       "mean_rmse": 2.8629
+      },
+      "Q2": {
+       "range": [
+        22.0,
+        25.0
+       ],
+       "n": 109,
+       "mean_rmse": 2.7033
+      },
+      "Q3": {
+       "range": [
+        25.0,
+        33.0
+       ],
+       "n": 145,
+       "mean_rmse": 2.73
+      },
+      "Q4": {
+       "range": [
+        33.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 2.9706
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 88,
+       "mean_rmse": 2.6914
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        8.0
+       ],
+       "n": 160,
+       "mean_rmse": 2.8342
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 31,
+       "mean_rmse": 3.1705
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 221,
+       "mean_rmse": 2.8058
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0582
+       ],
+       "n": 125,
+       "mean_rmse": 3.0307
+      },
+      "Q2": {
+       "range": [
+        0.0582,
+        0.0754
+       ],
+       "n": 125,
+       "mean_rmse": 2.752
+      },
+      "Q3": {
+       "range": [
+        0.0754,
+        0.0951
+       ],
+       "n": 125,
+       "mean_rmse": 2.6736
+      },
+      "Q4": {
+       "range": [
+        0.0951,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8132
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        67.0
+       ],
+       "n": 124,
+       "mean_rmse": 2.7378
+      },
+      "Q2": {
+       "range": [
+        67.0,
+        94.0
+       ],
+       "n": 124,
+       "mean_rmse": 2.9685
+      },
+      "Q3": {
+       "range": [
+        94.0,
+        108.0
+       ],
+       "n": 123,
+       "mean_rmse": 2.7124
+      },
+      "Q4": {
+       "range": [
+        108.0,
+        null
+       ],
+       "n": 129,
+       "mean_rmse": 2.8486
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q2": {
+       "range": [
+        3.0,
+        8.0
+       ],
+       "n": 244,
+       "mean_rmse": 2.7774
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 88,
+       "mean_rmse": 2.8727
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 168,
+       "mean_rmse": 2.8464
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        12.0
+       ],
+       "n": 122,
+       "mean_rmse": 2.7109
+      },
+      "Q2": {
+       "range": [
+        12.0,
+        28.0
+       ],
+       "n": 120,
+       "mean_rmse": 2.834
+      },
+      "Q3": {
+       "range": [
+        28.0,
+        35.0
+       ],
+       "n": 130,
+       "mean_rmse": 2.7945
+      },
+      "Q4": {
+       "range": [
+        35.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 2.9264
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 1431.3,
+    "holdout": {
+     "holdout_rmse": 1.6847534615633177,
+     "retrain_s": 0.213,
+     "predict_s": 0.0009,
+     "cv_rmse_of_winner": 2.3921847688588564
+    }
+   }
+  },
+  "vix@s43": {
+   "dataset": "vix",
+   "seed": 43,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.584923207859547,
+    "rmse_p10": 2.621205851292068,
+    "rmse_median": 2.6917008431883676,
+    "train_s_median": 0.05274149179458618,
+    "train_s_mean": 0.06207907724902033,
+    "train_s_p90": 0.08692184858024124,
+    "best_params": {
+     "learning_rate": 0.194422840223418,
+     "num_leaves": 53,
+     "max_depth": 3,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 0.19167336526053383,
+     "lambda_l2": 6.807268258907019e-08,
+     "feature_fraction": 0.788780781595847,
+     "bagging_fraction": 0.9774219305166723,
+     "bagging_freq": 5,
+     "extra_trees": true
+    },
+    "importance": {
+     "learning_rate": 0.6666,
+     "min_data_in_leaf": 0.2888,
+     "feature_fraction": 0.0119,
+     "bagging_fraction": 0.0119,
+     "max_depth": 0.0082,
+     "num_leaves": 0.0057,
+     "lambda_l1": 0.0035,
+     "bagging_freq": 0.0019,
+     "extra_trees": 0.0011,
+     "lambda_l2": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 449,
+        "mean": 2.7273,
+        "std": 0.1776,
+        "min": 2.5849
+       },
+       "False": {
+        "n": 51,
+        "mean": 2.8425,
+        "std": 0.2538,
+        "min": 2.6431
+       }
+      },
+      "best": {
+       "value": "True",
+       "runner_up": "False",
+       "delta_mean": 0.1152,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1412
+       ],
+       "n": 125,
+       "mean_rmse": 2.8429
+      },
+      "Q2": {
+       "range": [
+        0.1412,
+        0.1774
+       ],
+       "n": 125,
+       "mean_rmse": 2.7242
+      },
+      "Q3": {
+       "range": [
+        0.1774,
+        0.2016
+       ],
+       "n": 125,
+       "mean_rmse": 2.6824
+      },
+      "Q4": {
+       "range": [
+        0.2016,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7067
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        42.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.7385
+      },
+      "Q2": {
+       "range": [
+        42.0,
+        61.0
+       ],
+       "n": 127,
+       "mean_rmse": 2.7214
+      },
+      "Q3": {
+       "range": [
+        61.0,
+        90.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.7456
+      },
+      "Q4": {
+       "range": [
+        90.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 2.7507
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 374,
+       "mean_rmse": 2.7044
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 2.842
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        8.0
+       ],
+       "n": 115,
+       "mean_rmse": 2.7062
+      },
+      "Q2": {
+       "range": [
+        8.0,
+        12.0
+       ],
+       "n": 129,
+       "mean_rmse": 2.7117
+      },
+      "Q3": {
+       "range": [
+        12.0,
+        17.0
+       ],
+       "n": 118,
+       "mean_rmse": 2.7122
+      },
+      "Q4": {
+       "range": [
+        17.0,
+        null
+       ],
+       "n": 138,
+       "mean_rmse": 2.815
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 2.7896
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0416
+       ],
+       "n": 125,
+       "mean_rmse": 2.7304
+      },
+      "Q3": {
+       "range": [
+        0.0416,
+        0.1672
+       ],
+       "n": 125,
+       "mean_rmse": 2.7068
+      },
+      "Q4": {
+       "range": [
+        0.1672,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7295
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.6942
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7393
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.729
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7938
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7113
+       ],
+       "n": 125,
+       "mean_rmse": 2.7439
+      },
+      "Q2": {
+       "range": [
+        0.7113,
+        0.7498
+       ],
+       "n": 125,
+       "mean_rmse": 2.7254
+      },
+      "Q3": {
+       "range": [
+        0.7498,
+        0.7833
+       ],
+       "n": 125,
+       "mean_rmse": 2.7169
+      },
+      "Q4": {
+       "range": [
+        0.7833,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7701
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6156
+       ],
+       "n": 125,
+       "mean_rmse": 2.7425
+      },
+      "Q2": {
+       "range": [
+        0.6156,
+        0.7021
+       ],
+       "n": 125,
+       "mean_rmse": 2.7329
+      },
+      "Q3": {
+       "range": [
+        0.7021,
+        0.9348
+       ],
+       "n": 125,
+       "mean_rmse": 2.7788
+      },
+      "Q4": {
+       "range": [
+        0.9348,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7021
+      },
+      "best_quartile": "Q4"
+     }
+    },
+    "wall_s": 167.6,
+    "holdout": {
+     "holdout_rmse": 1.8931841595601477,
+     "retrain_s": 0.063,
+     "predict_s": 0.0005,
+     "cv_rmse_of_winner": 2.584923207859547
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.3759914339602117,
+    "rmse_p10": 2.4197490482281316,
+    "rmse_median": 2.5739197963127722,
+    "train_s_median": 0.3763253100216388,
+    "train_s_mean": 2.964041685414314,
+    "train_s_p90": 8.991569668315352,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "leaf_reuse",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.16601597254422545,
+     "num_leaves": 37,
+     "max_depth": 3,
+     "min_data_in_leaf": 10,
+     "lambda_l1": 1.9355062195524275,
+     "lambda_l2": 5.233092157427515e-06,
+     "feature_fraction": 0.9477746166749084,
+     "bagging_fraction": 0.8293674569934311,
+     "bagging_freq": 2,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 35,
+     "mixture_balance_factor": 7,
+     "mixture_smoothing_lambda": 0.6999432613642039,
+     "mixture_diversity_lambda": 0.24594348495229895,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.17872148230093046,
+     "mixture_load_balance_alpha": 0.24936389515418106,
+     "mixture_gate_max_depth": 2,
+     "mixture_gate_num_leaves": 64,
+     "mixture_gate_learning_rate": 0.08340678245958488,
+     "mixture_gate_lambda_l2": 0.06749177368206609,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.12763834606767008,
+     "mixture_gate_temperature_init": 2.8440281400686724,
+     "gate_temp_final_ratio": 0.6005726143394411,
+     "mixture_gate_retrain_interval": 9,
+     "mixture_refit_leaves": false
+    },
+    "importance": {
+     "learning_rate": 0.488,
+     "mixture_diversity_lambda": 0.1677,
+     "lambda_l1": 0.0514,
+     "mixture_gate_type": 0.0467,
+     "mixture_init": 0.036,
+     "num_leaves": 0.031,
+     "mixture_balance_factor": 0.0269,
+     "mixture_warmup_iters": 0.0239,
+     "mixture_refit_leaves": 0.0227,
+     "mixture_load_balance_alpha": 0.0157,
+     "max_depth": 0.0149,
+     "mixture_expert_dropout_rate": 0.0149,
+     "lambda_l2": 0.0144,
+     "min_data_in_leaf": 0.0088,
+     "mixture_routing_mode": 0.0073,
+     "mixture_num_experts": 0.0073,
+     "extra_trees": 0.0067,
+     "feature_fraction": 0.0042,
+     "mixture_hard_m_step": 0.0035,
+     "bagging_freq": 0.0033,
+     "bagging_fraction": 0.0025,
+     "mixture_r_smoothing": 0.0023,
+     "mixture_e_step_mode": 0.0002
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 170,
+        "mean": 3.2092,
+        "std": 2.3174,
+        "min": 2.4002
+       },
+       "leaf_reuse": {
+        "n": 307,
+        "mean": 2.6639,
+        "std": 0.6333,
+        "min": 2.376
+       },
+       "none": {
+        "n": 23,
+        "mean": 3.7623,
+        "std": 1.4888,
+        "min": 2.4571
+       }
+      },
+      "best": {
+       "value": "leaf_reuse",
+       "runner_up": "gbdt",
+       "delta_mean": 0.5453,
+       "p_value": 0.003098,
+       "significant": "True"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 43,
+        "mean": 3.7652,
+        "std": 2.9013,
+        "min": 2.3826
+       },
+       "token_choice": {
+        "n": 457,
+        "mean": 2.8184,
+        "std": 1.2728,
+        "min": 2.376
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.9468,
+       "p_value": 0.041908,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 30,
+        "mean": 3.8422,
+        "std": 2.7528,
+        "min": 2.4344
+       },
+       "gate_only": {
+        "n": 445,
+        "mean": 2.8346,
+        "std": 1.3947,
+        "min": 2.376
+       },
+       "em": {
+        "n": 25,
+        "mean": 2.9303,
+        "std": 0.8025,
+        "min": 2.4206
+       }
+      },
+      "best": {
+       "value": "gate_only",
+       "runner_up": "em",
+       "delta_mean": 0.0957,
+       "p_value": 0.591786,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 20,
+        "mean": 3.6724,
+        "std": 2.5959,
+        "min": 2.5732
+       },
+       "tree_hierarchical": {
+        "n": 19,
+        "mean": 2.9529,
+        "std": 0.5744,
+        "min": 2.5835
+       },
+       "uniform": {
+        "n": 20,
+        "mean": 2.8916,
+        "std": 0.4949,
+        "min": 2.5328
+       },
+       "kmeans_features": {
+        "n": 19,
+        "mean": 3.1616,
+        "std": 1.1931,
+        "min": 2.6313
+       },
+       "gmm_features": {
+        "n": 20,
+        "mean": 4.1952,
+        "std": 3.1497,
+        "min": 2.6524
+       },
+       "random": {
+        "n": 402,
+        "mean": 2.7825,
+        "std": 1.3325,
+        "min": 2.376
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.1091,
+       "p_value": 0.412857,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 414,
+        "mean": 2.8016,
+        "std": 1.3344,
+        "min": 2.376
+       },
+       "none": {
+        "n": 31,
+        "mean": 3.8727,
+        "std": 2.2891,
+        "min": 2.4451
+       },
+       "markov": {
+        "n": 55,
+        "mean": 3.0908,
+        "std": 1.9192,
+        "min": 2.3953
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "markov",
+       "delta_mean": 0.2892,
+       "p_value": 0.287193,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 2.8453,
+        "std": 1.4008,
+        "min": 2.376
+       },
+       "True": {
+        "n": 32,
+        "mean": 3.6983,
+        "std": 2.4836,
+        "min": 2.5771
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.853,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 469,
+        "mean": 2.8232,
+        "std": 1.307,
+        "min": 2.376
+       },
+       "True": {
+        "n": 31,
+        "mean": 4.0589,
+        "std": 3.069,
+        "min": 2.7129
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 1.2357,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 31,
+       "mean_rmse": 3.8366
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 469,
+       "mean_rmse": 2.8379
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2115
+       ],
+       "n": 125,
+       "mean_rmse": 2.7451
+      },
+      "Q2": {
+       "range": [
+        0.2115,
+        0.237
+       ],
+       "n": 125,
+       "mean_rmse": 2.7374
+      },
+      "Q3": {
+       "range": [
+        0.237,
+        0.279
+       ],
+       "n": 125,
+       "mean_rmse": 2.612
+      },
+      "Q4": {
+       "range": [
+        0.279,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.505
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        36.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.8472
+      },
+      "Q2": {
+       "range": [
+        36.0,
+        39.0
+       ],
+       "n": 109,
+       "mean_rmse": 2.72
+      },
+      "Q3": {
+       "range": [
+        39.0,
+        45.0
+       ],
+       "n": 141,
+       "mean_rmse": 2.8294
+      },
+      "Q4": {
+       "range": [
+        45.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 3.1732
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 103,
+       "mean_rmse": 3.2406
+      },
+      "Q2": {
+       "range": [
+        3.0,
+        7.0
+       ],
+       "n": 103,
+       "mean_rmse": 3.0562
+      },
+      "Q4": {
+       "range": [
+        7.0,
+        null
+       ],
+       "n": 294,
+       "mean_rmse": 2.7257
+      },
+      "best_quartile": "Q4"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0587
+       ],
+       "n": 125,
+       "mean_rmse": 3.5317
+      },
+      "Q2": {
+       "range": [
+        0.0587,
+        0.0818
+       ],
+       "n": 125,
+       "mean_rmse": 2.8098
+      },
+      "Q3": {
+       "range": [
+        0.0818,
+        0.1011
+       ],
+       "n": 125,
+       "mean_rmse": 2.5615
+      },
+      "Q4": {
+       "range": [
+        0.1011,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6964
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        38.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.6542
+      },
+      "Q2": {
+       "range": [
+        38.0,
+        71.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.7849
+      },
+      "Q3": {
+       "range": [
+        71.0,
+        107.0
+       ],
+       "n": 134,
+       "mean_rmse": 2.8689
+      },
+      "Q4": {
+       "range": [
+        107.0,
+        null
+       ],
+       "n": 126,
+       "mean_rmse": 3.2772
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 365,
+       "mean_rmse": 2.7284
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 3.3635
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.6373
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 162,
+       "mean_rmse": 2.7124
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        13.25
+       ],
+       "n": 144,
+       "mean_rmse": 2.8311
+      },
+      "Q4": {
+       "range": [
+        13.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.3668
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 7443.7,
+    "holdout": {
+     "holdout_rmse": 1.6123804725640898,
+     "retrain_s": 0.246,
+     "predict_s": 0.0013,
+     "cv_rmse_of_winner": 2.3759914339602117
+    }
+   }
+  },
+  "vix@s44": {
+   "dataset": "vix",
+   "seed": 44,
+   "X_search_shape": [
+    3011,
+    13
+   ],
+   "n_holdout": 752,
+   "y_stats": {
+    "mean": 18.128854196359057,
+    "std": 7.228188917710279
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.6490625795105567,
+    "rmse_p10": 2.68471630143661,
+    "rmse_median": 2.7244154505151315,
+    "train_s_median": 0.06567550096660853,
+    "train_s_mean": 0.0700199059061706,
+    "train_s_p90": 0.1026005368307233,
+    "best_params": {
+     "learning_rate": 0.05049464095070087,
+     "num_leaves": 73,
+     "max_depth": 5,
+     "min_data_in_leaf": 20,
+     "lambda_l1": 2.9494631960961425e-05,
+     "lambda_l2": 0.00011827678006559123,
+     "feature_fraction": 0.7316964550071715,
+     "bagging_fraction": 0.9013867255479072,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "min_data_in_leaf": 0.48,
+     "learning_rate": 0.3628,
+     "extra_trees": 0.0365,
+     "num_leaves": 0.0349,
+     "max_depth": 0.0345,
+     "bagging_fraction": 0.0203,
+     "bagging_freq": 0.0138,
+     "feature_fraction": 0.0117,
+     "lambda_l2": 0.0051,
+     "lambda_l1": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 2.7555,
+        "std": 0.1315,
+        "min": 2.6491
+       },
+       "True": {
+        "n": 30,
+        "mean": 2.9885,
+        "std": 0.2639,
+        "min": 2.7179
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.233,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0404
+       ],
+       "n": 125,
+       "mean_rmse": 2.8129
+      },
+      "Q2": {
+       "range": [
+        0.0404,
+        0.0489
+       ],
+       "n": 125,
+       "mean_rmse": 2.7511
+      },
+      "Q3": {
+       "range": [
+        0.0489,
+        0.0709
+       ],
+       "n": 125,
+       "mean_rmse": 2.738
+      },
+      "Q4": {
+       "range": [
+        0.0709,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.776
+      },
+      "best_quartile": "Q3"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        61.0
+       ],
+       "n": 113,
+       "mean_rmse": 2.7794
+      },
+      "Q2": {
+       "range": [
+        61.0,
+        68.0
+       ],
+       "n": 131,
+       "mean_rmse": 2.7623
+      },
+      "Q3": {
+       "range": [
+        68.0,
+        73.25
+       ],
+       "n": 131,
+       "mean_rmse": 2.7505
+      },
+      "Q4": {
+       "range": [
+        73.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7881
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 79,
+       "mean_rmse": 2.7848
+      },
+      "Q2": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 69,
+       "mean_rmse": 2.7764
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 352,
+       "mean_rmse": 2.7647
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        20.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.7802
+      },
+      "Q2": {
+       "range": [
+        20.0,
+        24.0
+       ],
+       "n": 102,
+       "mean_rmse": 2.7276
+      },
+      "Q3": {
+       "range": [
+        24.0,
+        28.0
+       ],
+       "n": 137,
+       "mean_rmse": 2.7353
+      },
+      "Q4": {
+       "range": [
+        28.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 2.8236
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7709
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 2.7526
+      },
+      "Q3": {
+       "range": [
+        0.0001,
+        0.0128
+       ],
+       "n": 125,
+       "mean_rmse": 2.7812
+      },
+      "Q4": {
+       "range": [
+        0.0128,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7733
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7519
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 2.7682
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 2.7522
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.8058
+      },
+      "best_quartile": "Q1"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7376
+       ],
+       "n": 125,
+       "mean_rmse": 2.7956
+      },
+      "Q2": {
+       "range": [
+        0.7376,
+        0.766
+       ],
+       "n": 125,
+       "mean_rmse": 2.7418
+      },
+      "Q3": {
+       "range": [
+        0.766,
+        0.8256
+       ],
+       "n": 125,
+       "mean_rmse": 2.7627
+      },
+      "Q4": {
+       "range": [
+        0.8256,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7779
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8213
+       ],
+       "n": 125,
+       "mean_rmse": 2.8315
+      },
+      "Q2": {
+       "range": [
+        0.8213,
+        0.8748
+       ],
+       "n": 125,
+       "mean_rmse": 2.7451
+      },
+      "Q3": {
+       "range": [
+        0.8748,
+        0.8987
+       ],
+       "n": 125,
+       "mean_rmse": 2.7405
+      },
+      "Q4": {
+       "range": [
+        0.8987,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.7611
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 186.0,
+    "holdout": {
+     "holdout_rmse": 1.734364414075465,
+     "retrain_s": 0.0844,
+     "predict_s": 0.0006,
+     "cv_rmse_of_winner": 2.6490625795105567
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 2.3755639555270784,
+    "rmse_p10": 2.45981688450335,
+    "rmse_median": 2.5803674150859806,
+    "train_s_median": 0.6215938819572329,
+    "train_s_mean": 1.2636838970772923,
+    "train_s_p90": 4.184611974135041,
+    "best_params": {
+     "mixture_r_smoothing": "none",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "gbdt",
+     "mixture_num_experts": 5,
+     "learning_rate": 0.23550634918062172,
+     "num_leaves": 37,
+     "max_depth": 6,
+     "min_data_in_leaf": 24,
+     "lambda_l1": 0.00025914858723678026,
+     "lambda_l2": 2.5411465097202393,
+     "feature_fraction": 0.9203347715112081,
+     "bagging_fraction": 0.9915659073047713,
+     "bagging_freq": 1,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 34,
+     "mixture_balance_factor": 3,
+     "mixture_diversity_lambda": 0.31624859683520623,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.11668072270451718,
+     "mixture_load_balance_alpha": 0.002114876508547394,
+     "mixture_gate_max_depth": 4,
+     "mixture_gate_num_leaves": 45,
+     "mixture_gate_learning_rate": 0.3826670228336935,
+     "mixture_gate_lambda_l2": 6.392044916948532,
+     "mixture_gate_iters_per_round": 2,
+     "mixture_gate_entropy_lambda": 0.17705629406806977,
+     "mixture_gate_temperature_init": 2.7900211388562153,
+     "gate_temp_final_ratio": 0.9058381836810635,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.06355251191741608,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "mixture_warmup_iters": 0.4279,
+     "mixture_init": 0.2054,
+     "mixture_gate_type": 0.0731,
+     "feature_fraction": 0.0636,
+     "learning_rate": 0.0586,
+     "num_leaves": 0.0455,
+     "lambda_l1": 0.0183,
+     "mixture_diversity_lambda": 0.0154,
+     "bagging_freq": 0.0148,
+     "mixture_hard_m_step": 0.0123,
+     "bagging_fraction": 0.0117,
+     "lambda_l2": 0.0105,
+     "min_data_in_leaf": 0.0096,
+     "mixture_balance_factor": 0.0086,
+     "mixture_load_balance_alpha": 0.0081,
+     "max_depth": 0.007,
+     "mixture_num_experts": 0.0046,
+     "extra_trees": 0.0014,
+     "mixture_expert_dropout_rate": 0.0012,
+     "mixture_routing_mode": 0.0012,
+     "mixture_r_smoothing": 0.0008,
+     "mixture_e_step_mode": 0.0003,
+     "mixture_refit_leaves": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 110,
+        "mean": 2.913,
+        "std": 1.0253,
+        "min": 2.3756
+       },
+       "none": {
+        "n": 48,
+        "mean": 3.4747,
+        "std": 2.2942,
+        "min": 2.4747
+       },
+       "leaf_reuse": {
+        "n": 342,
+        "mean": 3.0246,
+        "std": 1.5127,
+        "min": 2.4058
+       }
+      },
+      "best": {
+       "value": "gbdt",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.1116,
+       "p_value": 0.383578,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 420,
+        "mean": 3.0297,
+        "std": 1.5477,
+        "min": 2.3756
+       },
+       "expert_choice": {
+        "n": 80,
+        "mean": 3.1146,
+        "std": 1.3933,
+        "min": 2.5366
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.0849,
+       "p_value": 0.626466,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 163,
+        "mean": 2.8566,
+        "std": 1.0045,
+        "min": 2.4399
+       },
+       "gate_only": {
+        "n": 55,
+        "mean": 3.4167,
+        "std": 2.1677,
+        "min": 2.5226
+       },
+       "loss_only": {
+        "n": 282,
+        "mean": 3.0784,
+        "std": 1.6036,
+        "min": 2.3756
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.2218,
+       "p_value": 0.074368,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 23,
+        "mean": 3.9873,
+        "std": 2.1175,
+        "min": 2.7784
+       },
+       "tree_hierarchical": {
+        "n": 20,
+        "mean": 3.1917,
+        "std": 0.5085,
+        "min": 2.6735
+       },
+       "random": {
+        "n": 371,
+        "mean": 2.7217,
+        "std": 0.9154,
+        "min": 2.3756
+       },
+       "gmm": {
+        "n": 20,
+        "mean": 5.7562,
+        "std": 3.126,
+        "min": 2.8129
+       },
+       "gmm_features": {
+        "n": 18,
+        "mean": 5.7448,
+        "std": 3.0133,
+        "min": 2.8328
+       },
+       "uniform": {
+        "n": 48,
+        "mean": 2.8709,
+        "std": 0.9621,
+        "min": 2.5366
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "uniform",
+       "delta_mean": 0.1492,
+       "p_value": 0.318371,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 386,
+        "mean": 2.9424,
+        "std": 1.3422,
+        "min": 2.3756
+       },
+       "ema": {
+        "n": 71,
+        "mean": 3.3742,
+        "std": 2.0379,
+        "min": 2.4787
+       },
+       "markov": {
+        "n": 43,
+        "mean": 3.4028,
+        "std": 1.8944,
+        "min": 2.4218
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "ema",
+       "delta_mean": 0.4318,
+       "p_value": 0.091654,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 2.9871,
+        "std": 1.4394,
+        "min": 2.3756
+       },
+       "True": {
+        "n": 32,
+        "mean": 3.8642,
+        "std": 2.2992,
+        "min": 2.7441
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.8771,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 3.4022,
+        "std": 1.2915,
+        "min": 2.7902
+       },
+       "False": {
+        "n": 468,
+        "mean": 3.0187,
+        "std": 1.5359,
+        "min": 2.3756
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3835,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        5.0
+       ],
+       "n": 52,
+       "mean_rmse": 3.1982
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 448,
+       "mean_rmse": 3.0253
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.2017
+       ],
+       "n": 125,
+       "mean_rmse": 2.814
+      },
+      "Q2": {
+       "range": [
+        0.2017,
+        0.2473
+       ],
+       "n": 125,
+       "mean_rmse": 3.0862
+      },
+      "Q3": {
+       "range": [
+        0.2473,
+        0.3072
+       ],
+       "n": 125,
+       "mean_rmse": 3.238
+      },
+      "Q4": {
+       "range": [
+        0.3072,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 3.0349
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        34.0
+       ],
+       "n": 110,
+       "mean_rmse": 3.2073
+      },
+      "Q2": {
+       "range": [
+        34.0,
+        38.0
+       ],
+       "n": 121,
+       "mean_rmse": 2.9164
+      },
+      "Q3": {
+       "range": [
+        38.0,
+        41.0
+       ],
+       "n": 119,
+       "mean_rmse": 3.2332
+      },
+      "Q4": {
+       "range": [
+        41.0,
+        null
+       ],
+       "n": 150,
+       "mean_rmse": 2.8747
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 42,
+       "mean_rmse": 2.8302
+      },
+      "Q3": {
+       "range": [
+        3.0,
+        4.0
+       ],
+       "n": 274,
+       "mean_rmse": 3.0892
+      },
+      "Q4": {
+       "range": [
+        4.0,
+        null
+       ],
+       "n": 184,
+       "mean_rmse": 3.0235
+      },
+      "best_quartile": "Q1"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1154
+       ],
+       "n": 125,
+       "mean_rmse": 3.4137
+      },
+      "Q2": {
+       "range": [
+        0.1154,
+        0.1648
+       ],
+       "n": 125,
+       "mean_rmse": 2.9281
+      },
+      "Q3": {
+       "range": [
+        0.1648,
+        0.2269
+       ],
+       "n": 125,
+       "mean_rmse": 3.1677
+      },
+      "Q4": {
+       "range": [
+        0.2269,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 2.6636
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        13.0
+       ],
+       "n": 119,
+       "mean_rmse": 2.9488
+      },
+      "Q2": {
+       "range": [
+        13.0,
+        23.0
+       ],
+       "n": 124,
+       "mean_rmse": 3.1454
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        38.0
+       ],
+       "n": 130,
+       "mean_rmse": 3.0754
+      },
+      "Q4": {
+       "range": [
+        38.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 2.9992
+      },
+      "best_quartile": "Q1"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 80,
+       "mean_rmse": 3.1466
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 167,
+       "mean_rmse": 3.0045
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        9.0
+       ],
+       "n": 26,
+       "mean_rmse": 3.4204
+      },
+      "Q4": {
+       "range": [
+        9.0,
+        null
+       ],
+       "n": 227,
+       "mean_rmse": 2.9922
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 122,
+       "mean_rmse": 2.9464
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        23.0
+       ],
+       "n": 112,
+       "mean_rmse": 3.2144
+      },
+      "Q3": {
+       "range": [
+        23.0,
+        27.0
+       ],
+       "n": 127,
+       "mean_rmse": 2.7946
+      },
+      "Q4": {
+       "range": [
+        27.0,
+        null
+       ],
+       "n": 139,
+       "mean_rmse": 3.2176
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 3191.5,
+    "holdout": {
+     "holdout_rmse": 1.660445704759538,
+     "retrain_s": 5.4683,
+     "predict_s": 0.0028,
+     "cv_rmse_of_winner": 2.3755639555270784
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_wine_quality_ensemble_report.md
+++ b/bench_results/wide_v081/ds_wine_quality_ensemble_report.md
@@ -1,0 +1,209 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['wine_quality'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `4e208d83bace`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| wine_quality | naive-ensemble | **0.60653** ± 0.01261 | 0.66314 | 0.0% | 1.45 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| wine_quality@s42 | naive-ensemble | 0.6624 | 0.6697 | 1.094 | 2500 |
+| wine_quality@s43 | naive-ensemble | 0.6569 | 0.6621 | 0.867 | 1988 |
+| wine_quality@s44 | naive-ensemble | 0.6701 | 0.6770 | 0.643 | 1477 |
+
+
+
+---
+
+## wine_quality@s42  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.60192** (winner retrained in 1.74s, cv score of winner: 0.6624)
+- cv best RMSE: 0.6624, median: 0.6697, p10: 0.6661
+- train: median 1.094s/fold, mean 0.997s, p90 1.467s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.403 |
+| `learning_rate` | 0.370 |
+| `min_data_in_leaf` | 0.141 |
+| `feature_fraction` | 0.036 |
+| `max_depth` | 0.029 |
+| `n_models` | 0.010 |
+| `bagging_fraction` | 0.004 |
+| `lambda_l1` | 0.003 |
+| `num_leaves` | 0.003 |
+| `bagging_freq` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 0.6737 | 0.0114 | 0.6624 |
+| True | 30 | 0.7097 | 0.0227 | 0.6842 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6823 | 0.6722 | 0.6739 | 0.6752 | **Q2** [0.0532, 0.0644] |
+| `num_leaves` | 0.6804 | 0.6748 | 0.6735 | 0.6750 | **Q3** [117.0, 123.0] |
+| `max_depth` | 0.6889 | — | 0.6738 | 0.6719 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | — | 0.6700 | 0.6721 | 0.6887 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 0.6811 | 0.6733 | 0.6727 | 0.6764 | **Q3** [0.0485, 0.1366] |
+| `lambda_l2` | 0.6784 | 0.6782 | 0.6734 | 0.6737 | **Q3** [0.008, 0.0742] |
+| `feature_fraction` | 0.6805 | 0.6722 | 0.6734 | 0.6775 | **Q2** [0.683, 0.7201] |
+| `bagging_fraction` | 0.6764 | 0.6724 | 0.6729 | 0.6819 | **Q2** [0.6716, 0.6964] |
+
+#### E. Slice plot
+
+![wine_quality@s42/naive-ensemble](slice_wine_quality@s42_naive-ensemble.png)
+
+
+---
+
+## wine_quality@s43  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.62376** (winner retrained in 1.42s, cv score of winner: 0.6569)
+- cv best RMSE: 0.6569, median: 0.6621, p10: 0.6594
+- train: median 0.867s/fold, mean 0.792s, p90 1.125s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.466 |
+| `learning_rate` | 0.245 |
+| `min_data_in_leaf` | 0.197 |
+| `max_depth` | 0.054 |
+| `bagging_fraction` | 0.016 |
+| `num_leaves` | 0.006 |
+| `n_models` | 0.006 |
+| `bagging_freq` | 0.006 |
+| `feature_fraction` | 0.004 |
+| `lambda_l1` | 0.001 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.6651 | 0.0093 | 0.6569 |
+| True | 32 | 0.6987 | 0.0202 | 0.6770 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6740 | 0.6632 | 0.6637 | 0.6682 | **Q2** [0.0858, 0.0975] |
+| `num_leaves` | 0.6745 | 0.6642 | 0.6656 | 0.6653 | **Q2** [112.0, 119.0] |
+| `max_depth` | 0.6754 | — | — | 0.6649 | **Q4** [11.0, ∞) |
+| `min_data_in_leaf` | — | 0.6626 | 0.6642 | 0.6774 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 0.6710 | 0.6656 | 0.6645 | 0.6681 | **Q3** [0.0008, 0.0027] |
+| `lambda_l2` | 0.6664 | 0.6649 | 0.6669 | 0.6710 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6664 | 0.6656 | 0.6641 | 0.6729 | **Q3** [0.6391, 0.6632] |
+| `bagging_fraction` | 0.6732 | 0.6649 | 0.6639 | 0.6671 | **Q3** [0.898, 0.9211] |
+
+#### E. Slice plot
+
+![wine_quality@s43/naive-ensemble](slice_wine_quality@s43_naive-ensemble.png)
+
+
+---
+
+## wine_quality@s44  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-ensemble
+
+- **holdout RMSE: 0.59391** (winner retrained in 1.18s, cv score of winner: 0.6701)
+- cv best RMSE: 0.6701, median: 0.6770, p10: 0.6730
+- train: median 0.643s/fold, mean 0.588s, p90 0.831s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.452 |
+| `learning_rate` | 0.309 |
+| `min_data_in_leaf` | 0.123 |
+| `max_depth` | 0.030 |
+| `feature_fraction` | 0.028 |
+| `lambda_l1` | 0.017 |
+| `bagging_freq` | 0.015 |
+| `n_models` | 0.014 |
+| `bagging_fraction` | 0.007 |
+| `num_leaves` | 0.004 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 0.6799 | 0.0095 | 0.6701 |
+| True | 31 | 0.7134 | 0.0234 | 0.6919 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6870 | 0.6784 | 0.6795 | 0.6830 | **Q2** [0.0556, 0.0661] |
+| `num_leaves` | 0.6875 | 0.6818 | 0.6798 | 0.6791 | **Q4** [124.0, ∞) |
+| `max_depth` | 0.6885 | — | 0.6792 | 0.6817 | **Q3** [10.0, 11.0] |
+| `min_data_in_leaf` | — | 0.6769 | 0.6783 | 0.6935 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 0.6846 | 0.6800 | 0.6794 | 0.6838 | **Q3** [0.0257, 0.1005] |
+| `lambda_l2` | 0.6871 | 0.6797 | 0.6803 | 0.6806 | **Q2** [0.0016, 0.006] |
+| `feature_fraction` | 0.6785 | 0.6794 | 0.6806 | 0.6894 | **Q1** [None, 0.5214] |
+| `bagging_fraction` | 0.6879 | 0.6803 | 0.6796 | 0.6800 | **Q3** [0.8354, 0.8616] |
+
+#### E. Slice plot
+
+![wine_quality@s44/naive-ensemble](slice_wine_quality@s44_naive-ensemble.png)
+
+
+---
+
+## Overall recommendations
+
+(no categorical settings were universally significant — see per-dataset breakdown)
+

--- a/bench_results/wide_v081/ds_wine_quality_ensemble_summary.json
+++ b/bench_results/wide_v081/ds_wine_quality_ensemble_summary.json
@@ -1,0 +1,1137 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "wine_quality"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "standard"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "4e208d83baceaa5a1ebd0eccaa975a01d7361bd2",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "wine_quality": {
+   "naive-ensemble": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6019243917131073,
+      "cv_best": 0.6623930151835229,
+      "crash_rate": 0.0,
+      "retrain_s": 1.7375
+     },
+     "43": {
+      "holdout_rmse": 0.6237599342564307,
+      "cv_best": 0.6569322374968483,
+      "crash_rate": 0.0,
+      "retrain_s": 1.4236
+     },
+     "44": {
+      "holdout_rmse": 0.5939066886200302,
+      "cv_best": 0.6700958043136409,
+      "crash_rate": 0.0,
+      "retrain_s": 1.1797
+     }
+    },
+    "holdout_mean": 0.60653,
+    "holdout_std": 0.012615,
+    "cv_best_mean": 0.66314
+   }
+  }
+ },
+ "runs": {
+  "wine_quality@s42": {
+   "dataset": "wine_quality",
+   "seed": 42,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.814159292035399,
+    "std": 0.8812175760471399
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6623930151835229,
+    "rmse_p10": 0.6661247005432719,
+    "rmse_median": 0.6696856131588103,
+    "train_s_median": 1.094092704541981,
+    "train_s_mean": 0.9965641587026417,
+    "train_s_p90": 1.4671036807075144,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.07263096259345696,
+     "num_leaves": 120,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.051023213383535854,
+     "lambda_l2": 0.09441683551720013,
+     "feature_fraction": 0.6875361393670734,
+     "bagging_fraction": 0.6922747624585986,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4027,
+     "learning_rate": 0.3696,
+     "min_data_in_leaf": 0.1413,
+     "feature_fraction": 0.036,
+     "max_depth": 0.0291,
+     "n_models": 0.01,
+     "bagging_fraction": 0.0042,
+     "lambda_l1": 0.0033,
+     "num_leaves": 0.0032,
+     "bagging_freq": 0.0005,
+     "lambda_l2": 0.0
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 0.6737,
+        "std": 0.0114,
+        "min": 0.6624
+       },
+       "True": {
+        "n": 30,
+        "mean": 0.7097,
+        "std": 0.0227,
+        "min": 0.6842
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.036,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0532
+       ],
+       "n": 125,
+       "mean_rmse": 0.6823
+      },
+      "Q2": {
+       "range": [
+        0.0532,
+        0.0644
+       ],
+       "n": 125,
+       "mean_rmse": 0.6722
+      },
+      "Q3": {
+       "range": [
+        0.0644,
+        0.0745
+       ],
+       "n": 125,
+       "mean_rmse": 0.6739
+      },
+      "Q4": {
+       "range": [
+        0.0745,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6752
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        107.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.6804
+      },
+      "Q2": {
+       "range": [
+        107.0,
+        117.0
+       ],
+       "n": 121,
+       "mean_rmse": 0.6748
+      },
+      "Q3": {
+       "range": [
+        117.0,
+        123.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.6735
+      },
+      "Q4": {
+       "range": [
+        123.0,
+        null
+       ],
+       "n": 142,
+       "mean_rmse": 0.675
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 95,
+       "mean_rmse": 0.6889
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 199,
+       "mean_rmse": 0.6738
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 206,
+       "mean_rmse": 0.6719
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 156,
+       "mean_rmse": 0.67
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 210,
+       "mean_rmse": 0.6721
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 0.6887
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.013
+       ],
+       "n": 125,
+       "mean_rmse": 0.6811
+      },
+      "Q2": {
+       "range": [
+        0.013,
+        0.0485
+       ],
+       "n": 125,
+       "mean_rmse": 0.6733
+      },
+      "Q3": {
+       "range": [
+        0.0485,
+        0.1366
+       ],
+       "n": 125,
+       "mean_rmse": 0.6727
+      },
+      "Q4": {
+       "range": [
+        0.1366,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6764
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.6784
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.008
+       ],
+       "n": 125,
+       "mean_rmse": 0.6782
+      },
+      "Q3": {
+       "range": [
+        0.008,
+        0.0742
+       ],
+       "n": 125,
+       "mean_rmse": 0.6734
+      },
+      "Q4": {
+       "range": [
+        0.0742,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6737
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.683
+       ],
+       "n": 125,
+       "mean_rmse": 0.6805
+      },
+      "Q2": {
+       "range": [
+        0.683,
+        0.7201
+       ],
+       "n": 125,
+       "mean_rmse": 0.6722
+      },
+      "Q3": {
+       "range": [
+        0.7201,
+        0.7687
+       ],
+       "n": 125,
+       "mean_rmse": 0.6734
+      },
+      "Q4": {
+       "range": [
+        0.7687,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6775
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6716
+       ],
+       "n": 125,
+       "mean_rmse": 0.6764
+      },
+      "Q2": {
+       "range": [
+        0.6716,
+        0.6964
+       ],
+       "n": 125,
+       "mean_rmse": 0.6724
+      },
+      "Q3": {
+       "range": [
+        0.6964,
+        0.7295
+       ],
+       "n": 125,
+       "mean_rmse": 0.6729
+      },
+      "Q4": {
+       "range": [
+        0.7295,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6819
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 2500.3,
+    "holdout": {
+     "holdout_rmse": 0.6019243917131073,
+     "retrain_s": 1.7375,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.6623930151835229
+    }
+   }
+  },
+  "wine_quality@s43": {
+   "dataset": "wine_quality",
+   "seed": 43,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.824163139669103,
+    "std": 0.8714271981133532
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6569322374968483,
+    "rmse_p10": 0.6593968972048557,
+    "rmse_median": 0.6621188458551353,
+    "train_s_median": 0.8671798724681139,
+    "train_s_mean": 0.7918897671818733,
+    "train_s_p90": 1.1246771014109256,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.09091364507979645,
+     "num_leaves": 128,
+     "max_depth": 11,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.01182923504331893,
+     "lambda_l2": 0.06468005932467129,
+     "feature_fraction": 0.6302047503554458,
+     "bagging_fraction": 0.894875066133473,
+     "bagging_freq": 4,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4657,
+     "learning_rate": 0.245,
+     "min_data_in_leaf": 0.197,
+     "max_depth": 0.054,
+     "bagging_fraction": 0.0159,
+     "num_leaves": 0.0065,
+     "n_models": 0.0056,
+     "bagging_freq": 0.0056,
+     "feature_fraction": 0.0039,
+     "lambda_l1": 0.0006,
+     "lambda_l2": 0.0003
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 0.6651,
+        "std": 0.0093,
+        "min": 0.6569
+       },
+       "True": {
+        "n": 32,
+        "mean": 0.6987,
+        "std": 0.0202,
+        "min": 0.677
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0336,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0858
+       ],
+       "n": 125,
+       "mean_rmse": 0.674
+      },
+      "Q2": {
+       "range": [
+        0.0858,
+        0.0975
+       ],
+       "n": 125,
+       "mean_rmse": 0.6632
+      },
+      "Q3": {
+       "range": [
+        0.0975,
+        0.1103
+       ],
+       "n": 125,
+       "mean_rmse": 0.6637
+      },
+      "Q4": {
+       "range": [
+        0.1103,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6682
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        112.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.6745
+      },
+      "Q2": {
+       "range": [
+        112.0,
+        119.0
+       ],
+       "n": 122,
+       "mean_rmse": 0.6642
+      },
+      "Q3": {
+       "range": [
+        119.0,
+        124.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.6656
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 146,
+       "mean_rmse": 0.6653
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.6754
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 385,
+       "mean_rmse": 0.6649
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 154,
+       "mean_rmse": 0.6626
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 211,
+       "mean_rmse": 0.6642
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 0.6774
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.671
+      },
+      "Q2": {
+       "range": [
+        0.0001,
+        0.0008
+       ],
+       "n": 125,
+       "mean_rmse": 0.6656
+      },
+      "Q3": {
+       "range": [
+        0.0008,
+        0.0027
+       ],
+       "n": 125,
+       "mean_rmse": 0.6645
+      },
+      "Q4": {
+       "range": [
+        0.0027,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6681
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6664
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6649
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6669
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.671
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6198
+       ],
+       "n": 125,
+       "mean_rmse": 0.6664
+      },
+      "Q2": {
+       "range": [
+        0.6198,
+        0.6391
+       ],
+       "n": 125,
+       "mean_rmse": 0.6656
+      },
+      "Q3": {
+       "range": [
+        0.6391,
+        0.6632
+       ],
+       "n": 125,
+       "mean_rmse": 0.6641
+      },
+      "Q4": {
+       "range": [
+        0.6632,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6729
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8797
+       ],
+       "n": 125,
+       "mean_rmse": 0.6732
+      },
+      "Q2": {
+       "range": [
+        0.8797,
+        0.898
+       ],
+       "n": 125,
+       "mean_rmse": 0.6649
+      },
+      "Q3": {
+       "range": [
+        0.898,
+        0.9211
+       ],
+       "n": 125,
+       "mean_rmse": 0.6639
+      },
+      "Q4": {
+       "range": [
+        0.9211,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6671
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1987.7,
+    "holdout": {
+     "holdout_rmse": 0.6237599342564307,
+     "retrain_s": 1.4236,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.6569322374968483
+    }
+   }
+  },
+  "wine_quality@s44": {
+   "dataset": "wine_quality",
+   "seed": 44,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.82185455944594,
+    "std": 0.880623502625106
+   },
+   "_variants": [
+    "naive-ensemble"
+   ],
+   "naive-ensemble": {
+    "variant": "naive-ensemble",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6700958043136409,
+    "rmse_p10": 0.6729943938696203,
+    "rmse_median": 0.6769752599520784,
+    "train_s_median": 0.6431091204285622,
+    "train_s_mean": 0.5878184696108103,
+    "train_s_p90": 0.831085979603231,
+    "best_params": {
+     "n_models": 4,
+     "learning_rate": 0.0657236973098598,
+     "num_leaves": 123,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 1.1104858324234023e-07,
+     "lambda_l2": 0.004513587360379444,
+     "feature_fraction": 0.5718944483732363,
+     "bagging_fraction": 0.8188822902247452,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.452,
+     "learning_rate": 0.3091,
+     "min_data_in_leaf": 0.1234,
+     "max_depth": 0.03,
+     "feature_fraction": 0.0281,
+     "lambda_l1": 0.0171,
+     "bagging_freq": 0.015,
+     "n_models": 0.0139,
+     "bagging_fraction": 0.0066,
+     "num_leaves": 0.0037,
+     "lambda_l2": 0.001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 0.7134,
+        "std": 0.0234,
+        "min": 0.6919
+       },
+       "False": {
+        "n": 469,
+        "mean": 0.6799,
+        "std": 0.0095,
+        "min": 0.6701
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0335,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0556
+       ],
+       "n": 125,
+       "mean_rmse": 0.687
+      },
+      "Q2": {
+       "range": [
+        0.0556,
+        0.0661
+       ],
+       "n": 125,
+       "mean_rmse": 0.6784
+      },
+      "Q3": {
+       "range": [
+        0.0661,
+        0.0829
+       ],
+       "n": 125,
+       "mean_rmse": 0.6795
+      },
+      "Q4": {
+       "range": [
+        0.0829,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.683
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        92.0
+       ],
+       "n": 122,
+       "mean_rmse": 0.6875
+      },
+      "Q2": {
+       "range": [
+        92.0,
+        119.0
+       ],
+       "n": 120,
+       "mean_rmse": 0.6818
+      },
+      "Q3": {
+       "range": [
+        119.0,
+        124.0
+       ],
+       "n": 108,
+       "mean_rmse": 0.6798
+      },
+      "Q4": {
+       "range": [
+        124.0,
+        null
+       ],
+       "n": 150,
+       "mean_rmse": 0.6791
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 102,
+       "mean_rmse": 0.6885
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 224,
+       "mean_rmse": 0.6792
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 174,
+       "mean_rmse": 0.6817
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 156,
+       "mean_rmse": 0.6769
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 209,
+       "mean_rmse": 0.6783
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 0.6935
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0021
+       ],
+       "n": 125,
+       "mean_rmse": 0.6846
+      },
+      "Q2": {
+       "range": [
+        0.0021,
+        0.0257
+       ],
+       "n": 125,
+       "mean_rmse": 0.68
+      },
+      "Q3": {
+       "range": [
+        0.0257,
+        0.1005
+       ],
+       "n": 125,
+       "mean_rmse": 0.6794
+      },
+      "Q4": {
+       "range": [
+        0.1005,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6838
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0016
+       ],
+       "n": 125,
+       "mean_rmse": 0.6871
+      },
+      "Q2": {
+       "range": [
+        0.0016,
+        0.006
+       ],
+       "n": 125,
+       "mean_rmse": 0.6797
+      },
+      "Q3": {
+       "range": [
+        0.006,
+        0.0253
+       ],
+       "n": 125,
+       "mean_rmse": 0.6803
+      },
+      "Q4": {
+       "range": [
+        0.0253,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6806
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5214
+       ],
+       "n": 125,
+       "mean_rmse": 0.6785
+      },
+      "Q2": {
+       "range": [
+        0.5214,
+        0.5462
+       ],
+       "n": 125,
+       "mean_rmse": 0.6794
+      },
+      "Q3": {
+       "range": [
+        0.5462,
+        0.5955
+       ],
+       "n": 125,
+       "mean_rmse": 0.6806
+      },
+      "Q4": {
+       "range": [
+        0.5955,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6894
+      },
+      "best_quartile": "Q1"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.7841
+       ],
+       "n": 125,
+       "mean_rmse": 0.6879
+      },
+      "Q2": {
+       "range": [
+        0.7841,
+        0.8354
+       ],
+       "n": 125,
+       "mean_rmse": 0.6803
+      },
+      "Q3": {
+       "range": [
+        0.8354,
+        0.8616
+       ],
+       "n": 125,
+       "mean_rmse": 0.6796
+      },
+      "Q4": {
+       "range": [
+        0.8616,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.68
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 1476.6,
+    "holdout": {
+     "holdout_rmse": 0.5939066886200302,
+     "retrain_s": 1.1797,
+     "predict_s": 0.0,
+     "cv_rmse_of_winner": 0.6700958043136409
+    }
+   }
+  }
+ }
+}

--- a/bench_results/wide_v081/ds_wine_quality_report.md
+++ b/bench_results/wide_v081/ds_wine_quality_report.md
@@ -1,0 +1,514 @@
+# Comparative Study Report — naive vs naive-ensemble vs MoE
+
+- **Trials per (variant × dataset × seed)**: 500
+
+- **Datasets**: ['wine_quality'], **seeds**: [42, 43, 44]
+
+- **n_splits**: 5 (gap=1), **rounds**: 100, **holdout**: final 20% (never seen by Optuna), **ES**: chronological tail 15% of each train window
+
+- **Build**: commit `747bb4a7b5e6`, lib sha256 `a3c30fcc7fd3…`, package `/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe`
+
+
+---
+
+## Headline: holdout RMSE (chronological tail, evaluated once per seed)
+
+Selection happened on CV inside the search region; this table is the unbiased comparison. `cv_best` is the (optimistic) selection metric, shown for reference.
+
+| Dataset | Variant | holdout RMSE (mean ± std) | cv_best (mean) | crash rate | retrain s |
+|---|---|---|---|---|---|
+| wine_quality | naive-lightgbm | **0.61457** ± 0.01410 | 0.66815 | 0.0% | 0.49 |
+| wine_quality | moe | **0.61195** ± 0.01642 | 0.66367 | 0.0% | 2.75 |
+
+
+## Selection metric per run (CV over the search region)
+
+| Run | Variant | cv best | cv median | median train s/fold | wall s |
+|---|---|---|---|---|---|
+| wine_quality@s42 | naive-lightgbm | 0.6678 | 0.6752 | 0.444 | 998 |
+| wine_quality@s42 | moe | 0.6642 | 0.6770 | 2.022 | 5340 |
+| wine_quality@s43 | naive-lightgbm | 0.6616 | 0.6684 | 0.364 | 839 |
+| wine_quality@s43 | moe | 0.6579 | 0.6694 | 1.700 | 6838 |
+| wine_quality@s44 | naive-lightgbm | 0.6750 | 0.6832 | 0.253 | 589 |
+| wine_quality@s44 | moe | 0.6689 | 0.6816 | 0.692 | 6366 |
+
+
+
+---
+
+## wine_quality@s42  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.60747** (winner retrained in 0.58s, cv score of winner: 0.6678)
+- cv best RMSE: 0.6678, median: 0.6752, p10: 0.6708
+- train: median 0.444s/fold, mean 0.393s, p90 0.576s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `learning_rate` | 0.431 |
+| `extra_trees` | 0.406 |
+| `min_data_in_leaf` | 0.106 |
+| `max_depth` | 0.026 |
+| `bagging_fraction` | 0.017 |
+| `feature_fraction` | 0.008 |
+| `num_leaves` | 0.003 |
+| `bagging_freq` | 0.002 |
+| `lambda_l2` | 0.001 |
+| `lambda_l1` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.6785 | 0.0102 | 0.6678 |
+| True | 32 | 0.7184 | 0.0293 | 0.6904 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6867 | 0.6761 | 0.6781 | 0.6835 | **Q2** [0.0428, 0.0486] |
+| `num_leaves` | 0.6892 | 0.6794 | 0.6772 | 0.6786 | **Q3** [117.0, 123.0] |
+| `max_depth` | 0.6960 | 0.6798 | — | 0.6779 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6756 | 0.6764 | 0.6774 | 0.6941 | **Q1** [None, 7.0] |
+| `lambda_l1` | 0.6792 | 0.6795 | 0.6780 | 0.6876 | **Q3** [0.0, 0.0] |
+| `lambda_l2` | 0.6783 | 0.6881 | 0.6777 | 0.6803 | **Q3** [0.0012, 0.0165] |
+| `feature_fraction` | 0.6831 | 0.6777 | 0.6779 | 0.6856 | **Q2** [0.6164, 0.6434] |
+| `bagging_fraction` | 0.6877 | 0.6786 | 0.6760 | 0.6821 | **Q3** [0.8882, 0.9047] |
+
+#### E. Slice plot
+
+![wine_quality@s42/naive-lightgbm](slice_wine_quality@s42_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.60354** (winner retrained in 3.89s, cv score of winner: 0.6642)
+- cv best RMSE: 0.6642, median: 0.6770, p10: 0.6690
+- train: median 2.022s/fold, mean 2.118s, p90 3.403s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.512 |
+| `mixture_r_smoothing` | 0.114 |
+| `learning_rate` | 0.064 |
+| `feature_fraction` | 0.047 |
+| `extra_trees` | 0.040 |
+| `lambda_l1` | 0.029 |
+| `min_data_in_leaf` | 0.029 |
+| `mixture_num_experts` | 0.024 |
+| `mixture_init` | 0.024 |
+| `mixture_e_step_mode` | 0.020 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 314 | 0.7158 | 0.2388 | 0.6642 |
+| gbdt | 127 | 0.8242 | 0.6551 | 0.6706 |
+| leaf_reuse | 59 | 1.1825 | 1.0711 | 0.6849 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| expert_choice | 269 | 0.7449 | 0.3284 | 0.6687 |
+| token_choice | 231 | 0.8608 | 0.7218 | 0.6642 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| loss_only | 352 | 0.7206 | 0.2408 | 0.6642 |
+| gate_only | 97 | 0.9746 | 0.9734 | 0.6661 |
+| em | 51 | 1.0001 | 0.7860 | 0.6750 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| kmeans_features | 145 | 0.7227 | 0.2405 | 0.6687 |
+| uniform | 109 | 0.7520 | 0.3656 | 0.6709 |
+| random | 188 | 0.7843 | 0.5624 | 0.6642 |
+| gmm_features | 17 | 1.0460 | 1.1231 | 0.6720 |
+| gmm | 28 | 1.1425 | 1.0025 | 0.6728 |
+| tree_hierarchical | 13 | 1.1704 | 0.9513 | 0.6726 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 318 | 0.7474 | 0.4348 | 0.6642 |
+| none | 125 | 0.8154 | 0.5179 | 0.6706 |
+| markov | 57 | 1.0460 | 0.9646 | 0.6874 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 450 | 0.7664 | 0.4504 | 0.6642 |
+| True | 50 | 1.0864 | 1.0500 | 0.6768 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.7753 | 0.5041 | 0.6642 |
+| True | 32 | 1.1360 | 0.9389 | 0.6800 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | — | 0.7246 | — | 0.8493 | **Q2** [2.0, 3.0] |
+| `mixture_diversity_lambda` | 0.7935 | 0.7483 | 0.7960 | 0.8559 | **Q2** [0.0303, 0.0764] |
+| `mixture_warmup_iters` | 0.8344 | 0.8656 | 0.7253 | 0.7672 | **Q3** [33.0, 40.0] |
+| `mixture_balance_factor` | 0.8672 | 0.7097 | 0.8310 | 0.7222 | **Q2** [6.0, 7.0] |
+| `learning_rate` | 0.8382 | 0.7447 | 0.7690 | 0.8417 | **Q2** [0.0746, 0.1015] |
+| `num_leaves` | 1.0571 | 0.7266 | 0.7259 | 0.6934 | **Q4** [113.0, ∞) |
+| `max_depth` | 1.0099 | — | 0.7640 | 0.7276 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.7058 | 0.7442 | 0.7004 | 1.0149 | **Q3** [10.0, 16.0] |
+
+#### E. Slice plot
+
+![wine_quality@s42/moe](slice_wine_quality@s42_moe.png)
+
+
+---
+
+## wine_quality@s43  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.63426** (winner retrained in 0.46s, cv score of winner: 0.6616)
+- cv best RMSE: 0.6616, median: 0.6684, p10: 0.6653
+- train: median 0.364s/fold, mean 0.330s, p90 0.484s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.633 |
+| `learning_rate` | 0.198 |
+| `min_data_in_leaf` | 0.121 |
+| `max_depth` | 0.018 |
+| `bagging_fraction` | 0.013 |
+| `feature_fraction` | 0.007 |
+| `bagging_freq` | 0.006 |
+| `num_leaves` | 0.003 |
+| `lambda_l1` | 0.001 |
+| `lambda_l2` | 0.000 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 0.6719 | 0.0100 | 0.6616 |
+| True | 31 | 0.7142 | 0.0202 | 0.6886 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6807 | 0.6707 | 0.6711 | 0.6756 | **Q2** [0.0519, 0.0594] |
+| `num_leaves` | 0.6827 | 0.6744 | 0.6711 | 0.6703 | **Q4** [124.25, ∞) |
+| `max_depth` | 0.6861 | 0.6733 | — | 0.6718 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6691 | 0.6714 | 0.6705 | 0.6843 | **Q1** [None, 6.0] |
+| `lambda_l1` | 0.6789 | 0.6731 | 0.6705 | 0.6755 | **Q3** [0.0707, 0.1534] |
+| `lambda_l2` | 0.6737 | 0.6702 | 0.6742 | 0.6800 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6736 | 0.6709 | 0.6721 | 0.6813 | **Q2** [0.5505, 0.5732] |
+| `bagging_fraction` | 0.6747 | 0.6730 | 0.6701 | 0.6802 | **Q3** [0.659, 0.6804] |
+
+#### E. Slice plot
+
+![wine_quality@s43/naive-lightgbm](slice_wine_quality@s43_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.63490** (winner retrained in 3.50s, cv score of winner: 0.6579)
+- cv best RMSE: 0.6579, median: 0.6694, p10: 0.6630
+- train: median 1.700s/fold, mean 2.719s, p90 6.880s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `lambda_l2` | 0.811 |
+| `lambda_l1` | 0.059 |
+| `learning_rate` | 0.020 |
+| `mixture_expert_dropout_rate` | 0.019 |
+| `mixture_init` | 0.014 |
+| `num_leaves` | 0.011 |
+| `mixture_load_balance_alpha` | 0.009 |
+| `mixture_hard_m_step` | 0.008 |
+| `min_data_in_leaf` | 0.007 |
+| `mixture_warmup_iters` | 0.007 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_routing_mode` | **token_choice** | 0.7241 (n=406) | expert_choice | Δ +0.3154 | p=1.60e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 278 | 0.7160 | 0.2509 | 0.6579 |
+| gbdt | 173 | 0.8270 | 0.6402 | 0.6635 |
+| leaf_reuse | 49 | 1.0118 | 0.8401 | 0.6605 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 406 | 0.7241 | 0.3103 | 0.6579 |
+| expert_choice | 94 | 1.0395 | 0.9252 | 0.6683 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 230 | 0.7384 | 0.3207 | 0.6579 |
+| loss_only | 194 | 0.7516 | 0.4347 | 0.6620 |
+| gate_only | 76 | 1.0006 | 0.9074 | 0.6683 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| uniform | 111 | 0.7075 | 0.1496 | 0.6600 |
+| gmm | 174 | 0.7309 | 0.3219 | 0.6579 |
+| random | 64 | 0.7663 | 0.4044 | 0.6683 |
+| gmm_features | 114 | 0.8219 | 0.7006 | 0.6635 |
+| kmeans_features | 22 | 1.1245 | 0.9604 | 0.6639 |
+| tree_hierarchical | 15 | 1.2339 | 0.9308 | 0.6674 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 352 | 0.7190 | 0.3272 | 0.6579 |
+| none | 71 | 0.8429 | 0.4949 | 0.6603 |
+| markov | 77 | 1.0228 | 0.9254 | 0.6656 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 468 | 0.7455 | 0.3718 | 0.6579 |
+| True | 32 | 1.3381 | 1.2738 | 0.6851 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 470 | 0.7768 | 0.4951 | 0.6579 |
+| True | 30 | 0.8872 | 0.6211 | 0.6789 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.8241 | — | — | 0.7819 | **Q4** [3.0, ∞) |
+| `mixture_diversity_lambda` | 0.7048 | 0.8208 | 0.7510 | 0.8570 | **Q1** [None, 0.0265] |
+| `mixture_warmup_iters` | 0.7388 | 0.7005 | 0.7460 | 0.9480 | **Q2** [10.0, 16.0] |
+| `mixture_balance_factor` | 0.9055 | 0.9678 | 0.6968 | 0.7379 | **Q3** [8.0, 10.0] |
+| `learning_rate` | 0.8304 | 0.7668 | 0.8348 | 0.7016 | **Q4** [0.162, ∞) |
+| `num_leaves` | 0.7780 | 0.7051 | 0.7524 | 0.8997 | **Q2** [70.0, 80.0] |
+| `max_depth` | 1.0306 | 0.7380 | 0.7879 | 0.7078 | **Q4** [12.0, ∞) |
+| `min_data_in_leaf` | 0.6939 | 0.7180 | 0.7326 | 0.9799 | **Q1** [None, 7.0] |
+
+#### E. Slice plot
+
+![wine_quality@s43/moe](slice_wine_quality@s43_moe.png)
+
+
+---
+
+## wine_quality@s44  (search X=[5198, 11], holdout n=1299)
+
+
+### naive-lightgbm
+
+- **holdout RMSE: 0.60197** (winner retrained in 0.42s, cv score of winner: 0.6750)
+- cv best RMSE: 0.6750, median: 0.6832, p10: 0.6787
+- train: median 0.253s/fold, mean 0.231s, p90 0.331s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `extra_trees` | 0.463 |
+| `learning_rate` | 0.193 |
+| `min_data_in_leaf` | 0.121 |
+| `max_depth` | 0.071 |
+| `bagging_fraction` | 0.055 |
+| `lambda_l2` | 0.037 |
+| `feature_fraction` | 0.024 |
+| `bagging_freq` | 0.014 |
+| `num_leaves` | 0.011 |
+| `lambda_l1` | 0.010 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 467 | 0.6860 | 0.0095 | 0.6750 |
+| True | 33 | 0.7144 | 0.0143 | 0.6983 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `learning_rate` | 0.6899 | 0.6850 | 0.6855 | 0.6911 | **Q2** [0.0429, 0.0497] |
+| `num_leaves` | 0.6954 | 0.6864 | 0.6855 | 0.6852 | **Q4** [121.0, ∞) |
+| `max_depth` | 0.6974 | — | 0.6848 | 0.6877 | **Q3** [9.0, 10.0] |
+| `min_data_in_leaf` | — | 0.6834 | 0.6849 | 0.6972 | **Q2** [5.0, 7.0] |
+| `lambda_l1` | 0.6902 | 0.6870 | 0.6857 | 0.6885 | **Q3** [0.0105, 0.0557] |
+| `lambda_l2` | 0.6878 | 0.6853 | 0.6860 | 0.6924 | **Q2** [0.0, 0.0] |
+| `feature_fraction` | 0.6864 | 0.6860 | 0.6851 | 0.6940 | **Q3** [0.5659, 0.5959] |
+| `bagging_fraction` | 0.6946 | 0.6863 | 0.6842 | 0.6863 | **Q3** [0.9006, 0.9204] |
+
+#### E. Slice plot
+
+![wine_quality@s44/naive-lightgbm](slice_wine_quality@s44_naive-lightgbm.png)
+
+
+### moe
+
+- **holdout RMSE: 0.59740** (winner retrained in 0.85s, cv score of winner: 0.6689)
+- cv best RMSE: 0.6689, median: 0.6816, p10: 0.6737
+- train: median 0.692s/fold, mean 2.536s, p90 6.826s
+- finite trials: 500 / 500
+
+#### A. fANOVA importance (top 10)
+
+| param | importance |
+|---|---|
+| `mixture_warmup_iters` | 0.234 |
+| `mixture_r_smoothing` | 0.145 |
+| `learning_rate` | 0.107 |
+| `mixture_balance_factor` | 0.081 |
+| `lambda_l1` | 0.077 |
+| `bagging_fraction` | 0.074 |
+| `mixture_hard_m_step` | 0.031 |
+| `mixture_init` | 0.028 |
+| `num_leaves` | 0.028 |
+| `lambda_l2` | 0.027 |
+
+#### B. Categorical: clearly best values (p<0.01)
+
+| param | best | mean RMSE | runner-up | Δ | p |
+|---|---|---|---|---|---|
+| `mixture_r_smoothing` | **ema** | 0.8104 (n=432) | none | Δ +0.6892 | p=1.56e-03 |
+
+<details><summary>All categorical breakdowns</summary>
+
+
+**`mixture_gate_type`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| none | 423 | 0.8988 | 0.7927 | 0.6689 |
+| leaf_reuse | 24 | 0.9515 | 0.6315 | 0.6800 |
+| gbdt | 53 | 1.1668 | 1.0338 | 0.6757 |
+
+**`mixture_routing_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| token_choice | 455 | 0.8978 | 0.7610 | 0.6689 |
+| expert_choice | 45 | 1.2524 | 1.2178 | 0.6806 |
+
+**`mixture_e_step_mode`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| em | 138 | 0.7634 | 0.3504 | 0.6736 |
+| loss_only | 100 | 0.9642 | 0.8916 | 0.6760 |
+| gate_only | 262 | 1.0042 | 0.9442 | 0.6689 |
+
+**`mixture_init`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| random | 84 | 0.7883 | 0.5910 | 0.6739 |
+| gmm | 34 | 0.8832 | 0.5735 | 0.6749 |
+| uniform | 40 | 0.9049 | 0.9399 | 0.6826 |
+| kmeans_features | 290 | 0.9611 | 0.8639 | 0.6689 |
+| tree_hierarchical | 16 | 1.0100 | 0.5253 | 0.6765 |
+| gmm_features | 36 | 1.0430 | 1.0009 | 0.6729 |
+
+**`mixture_r_smoothing`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| ema | 432 | 0.8104 | 0.6317 | 0.6689 |
+| none | 41 | 1.4996 | 1.2732 | 0.6962 |
+| markov | 27 | 1.9739 | 1.3279 | 0.6921 |
+
+**`mixture_hard_m_step`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 421 | 0.8702 | 0.6830 | 0.6689 |
+| True | 79 | 1.2468 | 1.2807 | 0.6906 |
+
+**`extra_trees`**
+| value | n | mean RMSE | std | min |
+|---|---|---|---|---|
+| False | 469 | 0.8862 | 0.7185 | 0.6689 |
+| True | 31 | 1.5877 | 1.5960 | 0.6864 |
+
+</details>
+
+
+#### D. Numeric: quartile mean RMSE (sweet spot)
+
+| param | Q1 | Q2 | Q3 | Q4 | best Q (range) |
+|---|---|---|---|---|---|
+| `mixture_num_experts` | 0.9595 | — | 1.0485 | 0.8193 | **Q4** [5.0, ∞) |
+| `mixture_diversity_lambda` | 0.7734 | 0.9252 | 0.9724 | 1.0479 | **Q1** [None, 0.0812] |
+| `mixture_warmup_iters` | 1.0311 | 0.9783 | 0.8875 | 0.8655 | **Q4** [34.0, ∞) |
+| `mixture_balance_factor` | 0.9830 | — | 0.8380 | 1.0811 | **Q3** [7.0, 8.0] |
+| `learning_rate` | 1.0319 | 0.7830 | 1.0300 | 0.8741 | **Q2** [0.1691, 0.2274] |
+| `num_leaves` | 0.9024 | 0.7842 | 0.9735 | 1.0511 | **Q2** [48.75, 73.0] |
+| `max_depth` | 1.1368 | 0.6967 | — | 0.9673 | **Q2** [10.0, 12.0] |
+| `min_data_in_leaf` | 0.8617 | 0.8523 | 0.9054 | 1.0863 | **Q2** [7.0, 10.0] |
+
+#### E. Slice plot
+
+![wine_quality@s44/moe](slice_wine_quality@s44_moe.png)
+
+
+---
+
+## Overall recommendations
+
+**Categorical settings that are statistically significant winners (p<0.01):**
+
+| dataset | param | best value | Δ vs runner-up | p |
+|---|---|---|---|---|
+| wine_quality@s43 | `mixture_routing_mode` | **token_choice** | +0.3154 | 1.60e-03 |
+| wine_quality@s44 | `mixture_r_smoothing` | **ema** | +0.6892 | 1.56e-03 |

--- a/bench_results/wide_v081/ds_wine_quality_summary.json
+++ b/bench_results/wide_v081/ds_wine_quality_summary.json
@@ -1,0 +1,2801 @@
+{
+ "config": {
+  "trials": 500,
+  "n_jobs": 1,
+  "rounds": 100,
+  "splits": 5,
+  "seeds": [
+   42,
+   43,
+   44
+  ],
+  "holdout_frac": 0.2,
+  "datasets": [
+   "wine_quality"
+  ],
+  "es_fraction": 0.15,
+  "cv_gap": 1,
+  "moe_refit_mode": "search",
+  "moe_space": "wide"
+ },
+ "provenance": {
+  "python": "3.10.15",
+  "numpy": "2.2.6",
+  "optuna": "4.5.0",
+  "platform": "Linux-6.11.0-26-generic-x86_64-with-glibc2.39",
+  "lightgbm_moe_package": "/home/mokumoku/Develop/LightGBM-MoE/python-package/lightgbm_moe",
+  "lib_sha256": "a3c30fcc7fd3fa463b720f101dd2ac03484ff0cba78df2742f449499223f3c1e",
+  "git_commit": "747bb4a7b5e61acefd52871ec1c7d8d7b10d8a33",
+  "git_dirty": false,
+  "data_cache": {
+   "fred_GDPC1.csv": {
+    "sha256": "c9e19b07676730ca7cdda7d71250578f05b0ee14b2842ce96ce9885a9e2ddc72",
+    "bytes": 6485
+   },
+   "openml_cpu_act.csv": {
+    "sha256": "aa75ac84469d4dd850a82753ec6afbcb829870dd0b7bb5727532ba5caa87ef4c",
+    "bytes": 805128
+   },
+   "openml_elevators.csv": {
+    "sha256": "8468221a537d2c0e9532f110631b02705cdd75d608aaa99262fa854961d0af69",
+    "bytes": 1709475
+   },
+   "openml_houses.csv": {
+    "sha256": "d4479bae1851fb1d765cc07e67496b798615e544a6d5b81d07835a5b0f322536",
+    "bytes": 1239602
+   },
+   "openml_wine_quality.csv": {
+    "sha256": "5a130cc9d47976fd6bdb5003f561355e129d0fd4996dc20b73f93841e3482ce3",
+    "bytes": 379244
+   },
+   "sp500_GSPC.csv": {
+    "sha256": "cc45e062bade6034c5b8914f60c9af9076aad3e9e3b990738abccd2b5d2190de",
+    "bytes": 105451
+   },
+   "vix_VIX.csv": {
+    "sha256": "cb841de3663120bc1b3ce404e6cd7ffe2746b34fd10d6f4d81a59180cf30d29e",
+    "bytes": 110052
+   }
+  }
+ },
+ "summary": {
+  "wine_quality": {
+   "naive-lightgbm": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6074681092037725,
+      "cv_best": 0.6678315805287544,
+      "crash_rate": 0.0,
+      "retrain_s": 0.5848
+     },
+     "43": {
+      "holdout_rmse": 0.6342589836527157,
+      "cv_best": 0.6616039534327645,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4568
+     },
+     "44": {
+      "holdout_rmse": 0.601969596654756,
+      "cv_best": 0.6750059411681695,
+      "crash_rate": 0.0,
+      "retrain_s": 0.4187
+     }
+    },
+    "holdout_mean": 0.614566,
+    "holdout_std": 0.014105,
+    "cv_best_mean": 0.668147
+   },
+   "moe": {
+    "per_seed": {
+     "42": {
+      "holdout_rmse": 0.6035409183504291,
+      "cv_best": 0.6642314305744101,
+      "crash_rate": 0.0,
+      "retrain_s": 3.8929
+     },
+     "43": {
+      "holdout_rmse": 0.6349048964452817,
+      "cv_best": 0.6579053398236865,
+      "crash_rate": 0.0,
+      "retrain_s": 3.4975
+     },
+     "44": {
+      "holdout_rmse": 0.5974012445017838,
+      "cv_best": 0.668882979281968,
+      "crash_rate": 0.0,
+      "retrain_s": 0.8456
+     }
+    },
+    "holdout_mean": 0.611949,
+    "holdout_std": 0.016425,
+    "cv_best_mean": 0.663673
+   }
+  }
+ },
+ "runs": {
+  "wine_quality@s42": {
+   "dataset": "wine_quality",
+   "seed": 42,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.814159292035399,
+    "std": 0.8812175760471399
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6678315805287544,
+    "rmse_p10": 0.6707616881741089,
+    "rmse_median": 0.6752456702324852,
+    "train_s_median": 0.44440003801137207,
+    "train_s_mean": 0.39313212369233375,
+    "train_s_p90": 0.5764076562225818,
+    "best_params": {
+     "learning_rate": 0.04561171136354861,
+     "num_leaves": 112,
+     "max_depth": 12,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 1.1006876169427215e-06,
+     "lambda_l2": 0.01627506790725957,
+     "feature_fraction": 0.6077025846821319,
+     "bagging_fraction": 0.8927049696094213,
+     "bagging_freq": 2,
+     "extra_trees": false
+    },
+    "importance": {
+     "learning_rate": 0.4309,
+     "extra_trees": 0.4065,
+     "min_data_in_leaf": 0.1061,
+     "max_depth": 0.0263,
+     "bagging_fraction": 0.017,
+     "feature_fraction": 0.0076,
+     "num_leaves": 0.0028,
+     "bagging_freq": 0.002,
+     "lambda_l2": 0.0008,
+     "lambda_l1": 0.0001
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 0.7184,
+        "std": 0.0293,
+        "min": 0.6904
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.6785,
+        "std": 0.0102,
+        "min": 0.6678
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0399,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0428
+       ],
+       "n": 125,
+       "mean_rmse": 0.6867
+      },
+      "Q2": {
+       "range": [
+        0.0428,
+        0.0486
+       ],
+       "n": 125,
+       "mean_rmse": 0.6761
+      },
+      "Q3": {
+       "range": [
+        0.0486,
+        0.0568
+       ],
+       "n": 125,
+       "mean_rmse": 0.6781
+      },
+      "Q4": {
+       "range": [
+        0.0568,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6835
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        95.75
+       ],
+       "n": 125,
+       "mean_rmse": 0.6892
+      },
+      "Q2": {
+       "range": [
+        95.75,
+        117.0
+       ],
+       "n": 111,
+       "mean_rmse": 0.6794
+      },
+      "Q3": {
+       "range": [
+        117.0,
+        123.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.6772
+      },
+      "Q4": {
+       "range": [
+        123.0,
+        null
+       ],
+       "n": 146,
+       "mean_rmse": 0.6786
+      },
+      "best_quartile": "Q3"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 81,
+       "mean_rmse": 0.696
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 75,
+       "mean_rmse": 0.6798
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 344,
+       "mean_rmse": 0.6779
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 110,
+       "mean_rmse": 0.6756
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        9.0
+       ],
+       "n": 138,
+       "mean_rmse": 0.6764
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        12.0
+       ],
+       "n": 122,
+       "mean_rmse": 0.6774
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 0.6941
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6792
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6795
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.678
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6876
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6783
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0012
+       ],
+       "n": 125,
+       "mean_rmse": 0.6881
+      },
+      "Q3": {
+       "range": [
+        0.0012,
+        0.0165
+       ],
+       "n": 125,
+       "mean_rmse": 0.6777
+      },
+      "Q4": {
+       "range": [
+        0.0165,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6803
+      },
+      "best_quartile": "Q3"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6164
+       ],
+       "n": 125,
+       "mean_rmse": 0.6831
+      },
+      "Q2": {
+       "range": [
+        0.6164,
+        0.6434
+       ],
+       "n": 125,
+       "mean_rmse": 0.6777
+      },
+      "Q3": {
+       "range": [
+        0.6434,
+        0.6866
+       ],
+       "n": 125,
+       "mean_rmse": 0.6779
+      },
+      "Q4": {
+       "range": [
+        0.6866,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6856
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8669
+       ],
+       "n": 125,
+       "mean_rmse": 0.6877
+      },
+      "Q2": {
+       "range": [
+        0.8669,
+        0.8882
+       ],
+       "n": 125,
+       "mean_rmse": 0.6786
+      },
+      "Q3": {
+       "range": [
+        0.8882,
+        0.9047
+       ],
+       "n": 125,
+       "mean_rmse": 0.676
+      },
+      "Q4": {
+       "range": [
+        0.9047,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6821
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 998.0,
+    "holdout": {
+     "holdout_rmse": 0.6074681092037725,
+     "retrain_s": 0.5848,
+     "predict_s": 0.0047,
+     "cv_rmse_of_winner": 0.6678315805287544
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6642314305744101,
+    "rmse_p10": 0.6690205592110693,
+    "rmse_median": 0.6769520427706504,
+    "train_s_median": 2.021704987995326,
+    "train_s_mean": 2.1184314399309456,
+    "train_s_p90": 3.4030468361079698,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.12275178105109033,
+     "num_leaves": 111,
+     "max_depth": 11,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 9.603661659717413e-05,
+     "lambda_l2": 5.933308307649239e-07,
+     "feature_fraction": 0.7110546547053804,
+     "bagging_fraction": 0.6736676345218678,
+     "bagging_freq": 3,
+     "extra_trees": false,
+     "mixture_init": "random",
+     "mixture_e_step_mode": "loss_only",
+     "mixture_warmup_iters": 25,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.8109375220408812,
+     "mixture_diversity_lambda": 0.05737390279969626,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.21218180414979493,
+     "mixture_load_balance_alpha": 0.23727291411597787,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.49153555768252344,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "lambda_l2": 0.5116,
+     "mixture_r_smoothing": 0.1142,
+     "learning_rate": 0.0637,
+     "feature_fraction": 0.0472,
+     "extra_trees": 0.0403,
+     "lambda_l1": 0.0288,
+     "min_data_in_leaf": 0.0286,
+     "mixture_num_experts": 0.0239,
+     "mixture_init": 0.0237,
+     "mixture_e_step_mode": 0.0204,
+     "mixture_gate_type": 0.0202,
+     "mixture_expert_dropout_rate": 0.0127,
+     "mixture_balance_factor": 0.012,
+     "mixture_routing_mode": 0.0105,
+     "mixture_warmup_iters": 0.0088,
+     "bagging_freq": 0.0088,
+     "mixture_load_balance_alpha": 0.0084,
+     "num_leaves": 0.0078,
+     "mixture_diversity_lambda": 0.0057,
+     "mixture_refit_leaves": 0.0012,
+     "mixture_hard_m_step": 0.0009,
+     "max_depth": 0.0003,
+     "bagging_fraction": 0.0003
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "leaf_reuse": {
+        "n": 59,
+        "mean": 1.1825,
+        "std": 1.0711,
+        "min": 0.6849
+       },
+       "none": {
+        "n": 314,
+        "mean": 0.7158,
+        "std": 0.2388,
+        "min": 0.6642
+       },
+       "gbdt": {
+        "n": 127,
+        "mean": 0.8242,
+        "std": 0.6551,
+        "min": 0.6706
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 0.1084,
+       "p_value": 0.072656,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 231,
+        "mean": 0.8608,
+        "std": 0.7218,
+        "min": 0.6642
+       },
+       "expert_choice": {
+        "n": 269,
+        "mean": 0.7449,
+        "std": 0.3284,
+        "min": 0.6687
+       }
+      },
+      "best": {
+       "value": "expert_choice",
+       "runner_up": "token_choice",
+       "delta_mean": 0.1159,
+       "p_value": 0.02551,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "gate_only": {
+        "n": 97,
+        "mean": 0.9746,
+        "std": 0.9734,
+        "min": 0.6661
+       },
+       "loss_only": {
+        "n": 352,
+        "mean": 0.7206,
+        "std": 0.2408,
+        "min": 0.6642
+       },
+       "em": {
+        "n": 51,
+        "mean": 1.0001,
+        "std": 0.786,
+        "min": 0.675
+       }
+      },
+      "best": {
+       "value": "loss_only",
+       "runner_up": "gate_only",
+       "delta_mean": 0.254,
+       "p_value": 0.012788,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "uniform": {
+        "n": 109,
+        "mean": 0.752,
+        "std": 0.3656,
+        "min": 0.6709
+       },
+       "gmm": {
+        "n": 28,
+        "mean": 1.1425,
+        "std": 1.0025,
+        "min": 0.6728
+       },
+       "random": {
+        "n": 188,
+        "mean": 0.7843,
+        "std": 0.5624,
+        "min": 0.6642
+       },
+       "gmm_features": {
+        "n": 17,
+        "mean": 1.046,
+        "std": 1.1231,
+        "min": 0.672
+       },
+       "kmeans_features": {
+        "n": 145,
+        "mean": 0.7227,
+        "std": 0.2405,
+        "min": 0.6687
+       },
+       "tree_hierarchical": {
+        "n": 13,
+        "mean": 1.1704,
+        "std": 0.9513,
+        "min": 0.6726
+       }
+      },
+      "best": {
+       "value": "kmeans_features",
+       "runner_up": "uniform",
+       "delta_mean": 0.0293,
+       "p_value": 0.470757,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 318,
+        "mean": 0.7474,
+        "std": 0.4348,
+        "min": 0.6642
+       },
+       "markov": {
+        "n": 57,
+        "mean": 1.046,
+        "std": 0.9646,
+        "min": 0.6874
+       },
+       "none": {
+        "n": 125,
+        "mean": 0.8154,
+        "std": 0.5179,
+        "min": 0.6706
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.068,
+       "p_value": 0.196561,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 450,
+        "mean": 0.7664,
+        "std": 0.4504,
+        "min": 0.6642
+       },
+       "True": {
+        "n": 50,
+        "mean": 1.0864,
+        "std": 1.05,
+        "min": 0.6768
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.32,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 32,
+        "mean": 1.136,
+        "std": 0.9389,
+        "min": 0.68
+       },
+       "False": {
+        "n": 468,
+        "mean": 0.7753,
+        "std": 0.5041,
+        "min": 0.6642
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3607,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q2": {
+       "range": [
+        2.0,
+        3.0
+       ],
+       "n": 204,
+       "mean_rmse": 0.7246
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 296,
+       "mean_rmse": 0.8493
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0303
+       ],
+       "n": 125,
+       "mean_rmse": 0.7935
+      },
+      "Q2": {
+       "range": [
+        0.0303,
+        0.0764
+       ],
+       "n": 125,
+       "mean_rmse": 0.7483
+      },
+      "Q3": {
+       "range": [
+        0.0764,
+        0.1318
+       ],
+       "n": 125,
+       "mean_rmse": 0.796
+      },
+      "Q4": {
+       "range": [
+        0.1318,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8559
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        18.0
+       ],
+       "n": 117,
+       "mean_rmse": 0.8344
+      },
+      "Q2": {
+       "range": [
+        18.0,
+        33.0
+       ],
+       "n": 126,
+       "mean_rmse": 0.8656
+      },
+      "Q3": {
+       "range": [
+        33.0,
+        40.0
+       ],
+       "n": 111,
+       "mean_rmse": 0.7253
+      },
+      "Q4": {
+       "range": [
+        40.0,
+        null
+       ],
+       "n": 146,
+       "mean_rmse": 0.7672
+      },
+      "best_quartile": "Q3"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 103,
+       "mean_rmse": 0.8672
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        7.0
+       ],
+       "n": 42,
+       "mean_rmse": 0.7097
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 218,
+       "mean_rmse": 0.831
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 0.7222
+      },
+      "best_quartile": "Q2"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0746
+       ],
+       "n": 125,
+       "mean_rmse": 0.8382
+      },
+      "Q2": {
+       "range": [
+        0.0746,
+        0.1015
+       ],
+       "n": 125,
+       "mean_rmse": 0.7447
+      },
+      "Q3": {
+       "range": [
+        0.1015,
+        0.137
+       ],
+       "n": 125,
+       "mean_rmse": 0.769
+      },
+      "Q4": {
+       "range": [
+        0.137,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8417
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        95.0
+       ],
+       "n": 122,
+       "mean_rmse": 1.0571
+      },
+      "Q2": {
+       "range": [
+        95.0,
+        104.0
+       ],
+       "n": 113,
+       "mean_rmse": 0.7266
+      },
+      "Q3": {
+       "range": [
+        104.0,
+        113.0
+       ],
+       "n": 135,
+       "mean_rmse": 0.7259
+      },
+      "Q4": {
+       "range": [
+        113.0,
+        null
+       ],
+       "n": 130,
+       "mean_rmse": 0.6934
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 105,
+       "mean_rmse": 1.0099
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 159,
+       "mean_rmse": 0.764
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 236,
+       "mean_rmse": 0.7276
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 104,
+       "mean_rmse": 0.7058
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 144,
+       "mean_rmse": 0.7442
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        16.0
+       ],
+       "n": 118,
+       "mean_rmse": 0.7004
+      },
+      "Q4": {
+       "range": [
+        16.0,
+        null
+       ],
+       "n": 134,
+       "mean_rmse": 1.0149
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 5340.0,
+    "holdout": {
+     "holdout_rmse": 0.6035409183504291,
+     "retrain_s": 3.8929,
+     "predict_s": 0.0064,
+     "cv_rmse_of_winner": 0.6642314305744101
+    }
+   }
+  },
+  "wine_quality@s43": {
+   "dataset": "wine_quality",
+   "seed": 43,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.824163139669103,
+    "std": 0.8714271981133532
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6616039534327645,
+    "rmse_p10": 0.6652944243932436,
+    "rmse_median": 0.6684038308014946,
+    "train_s_median": 0.36378450635820625,
+    "train_s_mean": 0.3296983803108334,
+    "train_s_p90": 0.4835702716559172,
+    "best_params": {
+     "learning_rate": 0.06040448838984146,
+     "num_leaves": 128,
+     "max_depth": 12,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.02893676523283207,
+     "lambda_l2": 1.6219088598086246e-05,
+     "feature_fraction": 0.5640541661353708,
+     "bagging_fraction": 0.6592922439138048,
+     "bagging_freq": 0,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.633,
+     "learning_rate": 0.1981,
+     "min_data_in_leaf": 0.1214,
+     "max_depth": 0.0175,
+     "bagging_fraction": 0.0126,
+     "feature_fraction": 0.0074,
+     "bagging_freq": 0.0061,
+     "num_leaves": 0.0029,
+     "lambda_l1": 0.0009,
+     "lambda_l2": 0.0002
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 0.7142,
+        "std": 0.0202,
+        "min": 0.6886
+       },
+       "False": {
+        "n": 469,
+        "mean": 0.6719,
+        "std": 0.01,
+        "min": 0.6616
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0423,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0519
+       ],
+       "n": 125,
+       "mean_rmse": 0.6807
+      },
+      "Q2": {
+       "range": [
+        0.0519,
+        0.0594
+       ],
+       "n": 125,
+       "mean_rmse": 0.6707
+      },
+      "Q3": {
+       "range": [
+        0.0594,
+        0.0669
+       ],
+       "n": 125,
+       "mean_rmse": 0.6711
+      },
+      "Q4": {
+       "range": [
+        0.0669,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6756
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        106.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.6827
+      },
+      "Q2": {
+       "range": [
+        106.0,
+        120.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.6744
+      },
+      "Q3": {
+       "range": [
+        120.0,
+        124.25
+       ],
+       "n": 138,
+       "mean_rmse": 0.6711
+      },
+      "Q4": {
+       "range": [
+        124.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6703
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        11.0
+       ],
+       "n": 82,
+       "mean_rmse": 0.6861
+      },
+      "Q2": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 108,
+       "mean_rmse": 0.6733
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 310,
+       "mean_rmse": 0.6718
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 123,
+       "mean_rmse": 0.6691
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 108,
+       "mean_rmse": 0.6714
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        11.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.6705
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 150,
+       "mean_rmse": 0.6843
+      },
+      "best_quartile": "Q1"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0251
+       ],
+       "n": 125,
+       "mean_rmse": 0.6789
+      },
+      "Q2": {
+       "range": [
+        0.0251,
+        0.0707
+       ],
+       "n": 125,
+       "mean_rmse": 0.6731
+      },
+      "Q3": {
+       "range": [
+        0.0707,
+        0.1534
+       ],
+       "n": 125,
+       "mean_rmse": 0.6705
+      },
+      "Q4": {
+       "range": [
+        0.1534,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6755
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6737
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6702
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0001
+       ],
+       "n": 125,
+       "mean_rmse": 0.6742
+      },
+      "Q4": {
+       "range": [
+        0.0001,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.68
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5505
+       ],
+       "n": 125,
+       "mean_rmse": 0.6736
+      },
+      "Q2": {
+       "range": [
+        0.5505,
+        0.5732
+       ],
+       "n": 125,
+       "mean_rmse": 0.6709
+      },
+      "Q3": {
+       "range": [
+        0.5732,
+        0.5944
+       ],
+       "n": 125,
+       "mean_rmse": 0.6721
+      },
+      "Q4": {
+       "range": [
+        0.5944,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6813
+      },
+      "best_quartile": "Q2"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.6365
+       ],
+       "n": 125,
+       "mean_rmse": 0.6747
+      },
+      "Q2": {
+       "range": [
+        0.6365,
+        0.659
+       ],
+       "n": 125,
+       "mean_rmse": 0.673
+      },
+      "Q3": {
+       "range": [
+        0.659,
+        0.6804
+       ],
+       "n": 125,
+       "mean_rmse": 0.6701
+      },
+      "Q4": {
+       "range": [
+        0.6804,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6802
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 839.2,
+    "holdout": {
+     "holdout_rmse": 0.6342589836527157,
+     "retrain_s": 0.4568,
+     "predict_s": 0.0027,
+     "cv_rmse_of_winner": 0.6616039534327645
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6579053398236865,
+    "rmse_p10": 0.6629985166779194,
+    "rmse_median": 0.6694134654924517,
+    "train_s_median": 1.6996230626478792,
+    "train_s_mean": 2.7191684716917575,
+    "train_s_p90": 6.88023131106049,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 3,
+     "learning_rate": 0.10070905204692204,
+     "num_leaves": 75,
+     "max_depth": 12,
+     "min_data_in_leaf": 7,
+     "lambda_l1": 0.0001421257358706162,
+     "lambda_l2": 4.063668681354946e-08,
+     "feature_fraction": 0.7002329496195168,
+     "bagging_fraction": 0.865557503748515,
+     "bagging_freq": 5,
+     "extra_trees": false,
+     "mixture_init": "gmm",
+     "mixture_e_step_mode": "em",
+     "mixture_warmup_iters": 9,
+     "mixture_balance_factor": 9,
+     "mixture_smoothing_lambda": 0.17740272845465566,
+     "mixture_diversity_lambda": 0.027379324396539832,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.03658792531512999,
+     "mixture_load_balance_alpha": 0.15612328099067874,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "always",
+     "mixture_refit_decay_rate": 0.33674932802473007,
+     "mixture_regrow_oldest_trees": false
+    },
+    "importance": {
+     "lambda_l2": 0.8115,
+     "lambda_l1": 0.0593,
+     "learning_rate": 0.0202,
+     "mixture_expert_dropout_rate": 0.0192,
+     "mixture_init": 0.0142,
+     "num_leaves": 0.011,
+     "mixture_load_balance_alpha": 0.0089,
+     "mixture_hard_m_step": 0.0076,
+     "min_data_in_leaf": 0.0072,
+     "mixture_warmup_iters": 0.007,
+     "mixture_diversity_lambda": 0.0054,
+     "bagging_fraction": 0.0043,
+     "mixture_num_experts": 0.0041,
+     "feature_fraction": 0.0035,
+     "mixture_r_smoothing": 0.0032,
+     "max_depth": 0.0032,
+     "mixture_balance_factor": 0.0027,
+     "mixture_routing_mode": 0.0024,
+     "mixture_e_step_mode": 0.002,
+     "mixture_gate_type": 0.0014,
+     "bagging_freq": 0.0014,
+     "mixture_refit_leaves": 0.0,
+     "extra_trees": 0.0
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 173,
+        "mean": 0.827,
+        "std": 0.6402,
+        "min": 0.6635
+       },
+       "leaf_reuse": {
+        "n": 49,
+        "mean": 1.0118,
+        "std": 0.8401,
+        "min": 0.6605
+       },
+       "none": {
+        "n": 278,
+        "mean": 0.716,
+        "std": 0.2509,
+        "min": 0.6579
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "gbdt",
+       "delta_mean": 0.111,
+       "p_value": 0.030878,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "expert_choice": {
+        "n": 94,
+        "mean": 1.0395,
+        "std": 0.9252,
+        "min": 0.6683
+       },
+       "token_choice": {
+        "n": 406,
+        "mean": 0.7241,
+        "std": 0.3103,
+        "min": 0.6579
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.3154,
+       "p_value": 0.001604,
+       "significant": "True"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "loss_only": {
+        "n": 194,
+        "mean": 0.7516,
+        "std": 0.4347,
+        "min": 0.662
+       },
+       "gate_only": {
+        "n": 76,
+        "mean": 1.0006,
+        "std": 0.9074,
+        "min": 0.6683
+       },
+       "em": {
+        "n": 230,
+        "mean": 0.7384,
+        "std": 0.3207,
+        "min": 0.6579
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.0132,
+       "p_value": 0.727576,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "gmm": {
+        "n": 174,
+        "mean": 0.7309,
+        "std": 0.3219,
+        "min": 0.6579
+       },
+       "tree_hierarchical": {
+        "n": 15,
+        "mean": 1.2339,
+        "std": 0.9308,
+        "min": 0.6674
+       },
+       "uniform": {
+        "n": 111,
+        "mean": 0.7075,
+        "std": 0.1496,
+        "min": 0.66
+       },
+       "kmeans_features": {
+        "n": 22,
+        "mean": 1.1245,
+        "std": 0.9604,
+        "min": 0.6639
+       },
+       "gmm_features": {
+        "n": 114,
+        "mean": 0.8219,
+        "std": 0.7006,
+        "min": 0.6635
+       },
+       "random": {
+        "n": 64,
+        "mean": 0.7663,
+        "std": 0.4044,
+        "min": 0.6683
+       }
+      },
+      "best": {
+       "value": "uniform",
+       "runner_up": "gmm",
+       "delta_mean": 0.0234,
+       "p_value": 0.410084,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "ema": {
+        "n": 352,
+        "mean": 0.719,
+        "std": 0.3272,
+        "min": 0.6579
+       },
+       "none": {
+        "n": 71,
+        "mean": 0.8429,
+        "std": 0.4949,
+        "min": 0.6603
+       },
+       "markov": {
+        "n": 77,
+        "mean": 1.0228,
+        "std": 0.9254,
+        "min": 0.6656
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.1239,
+       "p_value": 0.047894,
+       "significant": "False"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 468,
+        "mean": 0.7455,
+        "std": 0.3718,
+        "min": 0.6579
+       },
+       "True": {
+        "n": 32,
+        "mean": 1.3381,
+        "std": 1.2738,
+        "min": 0.6851
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.5926,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 470,
+        "mean": 0.7768,
+        "std": 0.4951,
+        "min": 0.6579
+       },
+       "True": {
+        "n": 30,
+        "mean": 0.8872,
+        "std": 0.6211,
+        "min": 0.6789
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.1104,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        3.0
+       ],
+       "n": 18,
+       "mean_rmse": 0.8241
+      },
+      "Q4": {
+       "range": [
+        3.0,
+        null
+       ],
+       "n": 482,
+       "mean_rmse": 0.7819
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0265
+       ],
+       "n": 125,
+       "mean_rmse": 0.7048
+      },
+      "Q2": {
+       "range": [
+        0.0265,
+        0.076
+       ],
+       "n": 125,
+       "mean_rmse": 0.8208
+      },
+      "Q3": {
+       "range": [
+        0.076,
+        0.205
+       ],
+       "n": 125,
+       "mean_rmse": 0.751
+      },
+      "Q4": {
+       "range": [
+        0.205,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.857
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.7388
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        16.0
+       ],
+       "n": 126,
+       "mean_rmse": 0.7005
+      },
+      "Q3": {
+       "range": [
+        16.0,
+        29.25
+       ],
+       "n": 134,
+       "mean_rmse": 0.746
+      },
+      "Q4": {
+       "range": [
+        29.25,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.948
+      },
+      "best_quartile": "Q2"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        6.0
+       ],
+       "n": 119,
+       "mean_rmse": 0.9055
+      },
+      "Q2": {
+       "range": [
+        6.0,
+        8.0
+       ],
+       "n": 48,
+       "mean_rmse": 0.9678
+      },
+      "Q3": {
+       "range": [
+        8.0,
+        10.0
+       ],
+       "n": 200,
+       "mean_rmse": 0.6968
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 133,
+       "mean_rmse": 0.7379
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0874
+       ],
+       "n": 125,
+       "mean_rmse": 0.8304
+      },
+      "Q2": {
+       "range": [
+        0.0874,
+        0.1063
+       ],
+       "n": 125,
+       "mean_rmse": 0.7668
+      },
+      "Q3": {
+       "range": [
+        0.1063,
+        0.162
+       ],
+       "n": 125,
+       "mean_rmse": 0.8348
+      },
+      "Q4": {
+       "range": [
+        0.162,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.7016
+      },
+      "best_quartile": "Q4"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        70.0
+       ],
+       "n": 115,
+       "mean_rmse": 0.778
+      },
+      "Q2": {
+       "range": [
+        70.0,
+        80.0
+       ],
+       "n": 133,
+       "mean_rmse": 0.7051
+      },
+      "Q3": {
+       "range": [
+        80.0,
+        92.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.7524
+      },
+      "Q4": {
+       "range": [
+        92.0,
+        null
+       ],
+       "n": 128,
+       "mean_rmse": 0.8997
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 82,
+       "mean_rmse": 1.0306
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        11.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.738
+      },
+      "Q3": {
+       "range": [
+        11.0,
+        12.0
+       ],
+       "n": 117,
+       "mean_rmse": 0.7879
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 236,
+       "mean_rmse": 0.7078
+      },
+      "best_quartile": "Q4"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 98,
+       "mean_rmse": 0.6939
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 151,
+       "mean_rmse": 0.718
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        17.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.7326
+      },
+      "Q4": {
+       "range": [
+        17.0,
+        null
+       ],
+       "n": 127,
+       "mean_rmse": 0.9799
+      },
+      "best_quartile": "Q1"
+     }
+    },
+    "wall_s": 6838.5,
+    "holdout": {
+     "holdout_rmse": 0.6349048964452817,
+     "retrain_s": 3.4975,
+     "predict_s": 0.006,
+     "cv_rmse_of_winner": 0.6579053398236865
+    }
+   }
+  },
+  "wine_quality@s44": {
+   "dataset": "wine_quality",
+   "seed": 44,
+   "X_search_shape": [
+    5198,
+    11
+   ],
+   "n_holdout": 1299,
+   "y_stats": {
+    "mean": 5.82185455944594,
+    "std": 0.880623502625106
+   },
+   "_variants": [
+    "naive-lightgbm",
+    "moe"
+   ],
+   "naive-lightgbm": {
+    "variant": "naive-lightgbm",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.6750059411681695,
+    "rmse_p10": 0.6787441051119998,
+    "rmse_median": 0.6831889167168698,
+    "train_s_median": 0.2532746622338891,
+    "train_s_mean": 0.23125280601531267,
+    "train_s_p90": 0.33145536363124845,
+    "best_params": {
+     "learning_rate": 0.04461125130710717,
+     "num_leaves": 121,
+     "max_depth": 10,
+     "min_data_in_leaf": 5,
+     "lambda_l1": 0.005261648621024161,
+     "lambda_l2": 8.760779701697903e-06,
+     "feature_fraction": 0.5244154587898375,
+     "bagging_fraction": 0.9173849804212569,
+     "bagging_freq": 1,
+     "extra_trees": false
+    },
+    "importance": {
+     "extra_trees": 0.4629,
+     "learning_rate": 0.1929,
+     "min_data_in_leaf": 0.1215,
+     "max_depth": 0.0709,
+     "bagging_fraction": 0.055,
+     "lambda_l2": 0.0375,
+     "feature_fraction": 0.0238,
+     "bagging_freq": 0.0141,
+     "num_leaves": 0.011,
+     "lambda_l1": 0.0104
+    },
+    "categorical_stats": {
+     "extra_trees": {
+      "per_value": {
+       "False": {
+        "n": 467,
+        "mean": 0.686,
+        "std": 0.0095,
+        "min": 0.675
+       },
+       "True": {
+        "n": 33,
+        "mean": 0.7144,
+        "std": 0.0143,
+        "min": 0.6983
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.0284,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.0429
+       ],
+       "n": 125,
+       "mean_rmse": 0.6899
+      },
+      "Q2": {
+       "range": [
+        0.0429,
+        0.0497
+       ],
+       "n": 125,
+       "mean_rmse": 0.685
+      },
+      "Q3": {
+       "range": [
+        0.0497,
+        0.0599
+       ],
+       "n": 125,
+       "mean_rmse": 0.6855
+      },
+      "Q4": {
+       "range": [
+        0.0599,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6911
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        111.0
+       ],
+       "n": 113,
+       "mean_rmse": 0.6954
+      },
+      "Q2": {
+       "range": [
+        111.0,
+        117.0
+       ],
+       "n": 130,
+       "mean_rmse": 0.6864
+      },
+      "Q3": {
+       "range": [
+        117.0,
+        121.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6855
+      },
+      "Q4": {
+       "range": [
+        121.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 0.6852
+      },
+      "best_quartile": "Q4"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        9.0
+       ],
+       "n": 65,
+       "mean_rmse": 0.6974
+      },
+      "Q3": {
+       "range": [
+        9.0,
+        10.0
+       ],
+       "n": 189,
+       "mean_rmse": 0.6848
+      },
+      "Q4": {
+       "range": [
+        10.0,
+        null
+       ],
+       "n": 246,
+       "mean_rmse": 0.6877
+      },
+      "best_quartile": "Q3"
+     },
+     "min_data_in_leaf": {
+      "Q2": {
+       "range": [
+        5.0,
+        7.0
+       ],
+       "n": 145,
+       "mean_rmse": 0.6834
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        11.0
+       ],
+       "n": 218,
+       "mean_rmse": 0.6849
+      },
+      "Q4": {
+       "range": [
+        11.0,
+        null
+       ],
+       "n": 137,
+       "mean_rmse": 0.6972
+      },
+      "best_quartile": "Q2"
+     },
+     "lambda_l1": {
+      "Q1": {
+       "range": [
+        null,
+        0.0016
+       ],
+       "n": 125,
+       "mean_rmse": 0.6902
+      },
+      "Q2": {
+       "range": [
+        0.0016,
+        0.0105
+       ],
+       "n": 125,
+       "mean_rmse": 0.687
+      },
+      "Q3": {
+       "range": [
+        0.0105,
+        0.0557
+       ],
+       "n": 125,
+       "mean_rmse": 0.6857
+      },
+      "Q4": {
+       "range": [
+        0.0557,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6885
+      },
+      "best_quartile": "Q3"
+     },
+     "lambda_l2": {
+      "Q1": {
+       "range": [
+        null,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6878
+      },
+      "Q2": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.6853
+      },
+      "Q3": {
+       "range": [
+        0.0,
+        0.0
+       ],
+       "n": 125,
+       "mean_rmse": 0.686
+      },
+      "Q4": {
+       "range": [
+        0.0,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6924
+      },
+      "best_quartile": "Q2"
+     },
+     "feature_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.5426
+       ],
+       "n": 125,
+       "mean_rmse": 0.6864
+      },
+      "Q2": {
+       "range": [
+        0.5426,
+        0.5659
+       ],
+       "n": 125,
+       "mean_rmse": 0.686
+      },
+      "Q3": {
+       "range": [
+        0.5659,
+        0.5959
+       ],
+       "n": 125,
+       "mean_rmse": 0.6851
+      },
+      "Q4": {
+       "range": [
+        0.5959,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.694
+      },
+      "best_quartile": "Q3"
+     },
+     "bagging_fraction": {
+      "Q1": {
+       "range": [
+        null,
+        0.8702
+       ],
+       "n": 125,
+       "mean_rmse": 0.6946
+      },
+      "Q2": {
+       "range": [
+        0.8702,
+        0.9006
+       ],
+       "n": 125,
+       "mean_rmse": 0.6863
+      },
+      "Q3": {
+       "range": [
+        0.9006,
+        0.9204
+       ],
+       "n": 125,
+       "mean_rmse": 0.6842
+      },
+      "Q4": {
+       "range": [
+        0.9204,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.6863
+      },
+      "best_quartile": "Q3"
+     }
+    },
+    "wall_s": 589.3,
+    "holdout": {
+     "holdout_rmse": 0.601969596654756,
+     "retrain_s": 0.4187,
+     "predict_s": 0.0023,
+     "cv_rmse_of_winner": 0.6750059411681695
+    }
+   },
+   "moe": {
+    "variant": "moe",
+    "n_trials": 500,
+    "n_finite": 500,
+    "rmse_best": 0.668882979281968,
+    "rmse_p10": 0.6737233834579471,
+    "rmse_median": 0.6816325212585055,
+    "train_s_median": 0.6917454969137907,
+    "train_s_mean": 2.535645652293414,
+    "train_s_p90": 6.826330545209349,
+    "best_params": {
+     "mixture_r_smoothing": "ema",
+     "mixture_routing_mode": "token_choice",
+     "mixture_gate_type": "none",
+     "mixture_num_experts": 4,
+     "learning_rate": 0.26497794538420644,
+     "num_leaves": 92,
+     "max_depth": 12,
+     "min_data_in_leaf": 9,
+     "lambda_l1": 3.160185059294906e-05,
+     "lambda_l2": 0.5400265664262608,
+     "feature_fraction": 0.8522310119461001,
+     "bagging_fraction": 0.8444032998348514,
+     "bagging_freq": 4,
+     "extra_trees": false,
+     "mixture_init": "kmeans_features",
+     "mixture_e_step_mode": "gate_only",
+     "mixture_warmup_iters": 28,
+     "mixture_balance_factor": 7,
+     "mixture_smoothing_lambda": 0.28263916164890357,
+     "mixture_diversity_lambda": 0.10328485062972023,
+     "mixture_hard_m_step": false,
+     "mixture_expert_dropout_rate": 0.2780775537708466,
+     "mixture_load_balance_alpha": 0.24414906289851712,
+     "mixture_refit_leaves": true,
+     "mixture_refit_trigger": "elbo",
+     "mixture_refit_decay_rate": 0.24407926536996227,
+     "mixture_elbo_drop_threshold": 0.0027490228152206985,
+     "mixture_elbo_plateau_threshold": 0.0033908190606146524,
+     "mixture_elbo_window": 7,
+     "mixture_regrow_oldest_trees": true,
+     "mixture_regrow_per_fire": 4,
+     "mixture_regrow_mode": "replace"
+    },
+    "importance": {
+     "mixture_warmup_iters": 0.2338,
+     "mixture_r_smoothing": 0.1451,
+     "learning_rate": 0.1073,
+     "mixture_balance_factor": 0.0806,
+     "lambda_l1": 0.0774,
+     "bagging_fraction": 0.0745,
+     "mixture_hard_m_step": 0.0314,
+     "mixture_init": 0.0282,
+     "num_leaves": 0.0277,
+     "lambda_l2": 0.0266,
+     "mixture_refit_leaves": 0.0263,
+     "mixture_diversity_lambda": 0.0238,
+     "mixture_load_balance_alpha": 0.02,
+     "extra_trees": 0.0193,
+     "min_data_in_leaf": 0.0179,
+     "feature_fraction": 0.0158,
+     "mixture_e_step_mode": 0.0158,
+     "mixture_expert_dropout_rate": 0.0081,
+     "max_depth": 0.0062,
+     "mixture_gate_type": 0.0045,
+     "mixture_num_experts": 0.004,
+     "bagging_freq": 0.003,
+     "mixture_routing_mode": 0.0027
+    },
+    "categorical_stats": {
+     "mixture_gate_type": {
+      "per_value": {
+       "gbdt": {
+        "n": 53,
+        "mean": 1.1668,
+        "std": 1.0338,
+        "min": 0.6757
+       },
+       "none": {
+        "n": 423,
+        "mean": 0.8988,
+        "std": 0.7927,
+        "min": 0.6689
+       },
+       "leaf_reuse": {
+        "n": 24,
+        "mean": 0.9515,
+        "std": 0.6315,
+        "min": 0.68
+       }
+      },
+      "best": {
+       "value": "none",
+       "runner_up": "leaf_reuse",
+       "delta_mean": 0.0527,
+       "p_value": 0.704011,
+       "significant": "False"
+      }
+     },
+     "mixture_routing_mode": {
+      "per_value": {
+       "token_choice": {
+        "n": 455,
+        "mean": 0.8978,
+        "std": 0.761,
+        "min": 0.6689
+       },
+       "expert_choice": {
+        "n": 45,
+        "mean": 1.2524,
+        "std": 1.2178,
+        "min": 0.6806
+       }
+      },
+      "best": {
+       "value": "token_choice",
+       "runner_up": "expert_choice",
+       "delta_mean": 0.3546,
+       "p_value": 0.064061,
+       "significant": "False"
+      }
+     },
+     "mixture_e_step_mode": {
+      "per_value": {
+       "em": {
+        "n": 138,
+        "mean": 0.7634,
+        "std": 0.3504,
+        "min": 0.6736
+       },
+       "gate_only": {
+        "n": 262,
+        "mean": 1.0042,
+        "std": 0.9442,
+        "min": 0.6689
+       },
+       "loss_only": {
+        "n": 100,
+        "mean": 0.9642,
+        "std": 0.8916,
+        "min": 0.676
+       }
+      },
+      "best": {
+       "value": "em",
+       "runner_up": "loss_only",
+       "delta_mean": 0.2008,
+       "p_value": 0.035628,
+       "significant": "False"
+      }
+     },
+     "mixture_init": {
+      "per_value": {
+       "kmeans_features": {
+        "n": 290,
+        "mean": 0.9611,
+        "std": 0.8639,
+        "min": 0.6689
+       },
+       "tree_hierarchical": {
+        "n": 16,
+        "mean": 1.01,
+        "std": 0.5253,
+        "min": 0.6765
+       },
+       "random": {
+        "n": 84,
+        "mean": 0.7883,
+        "std": 0.591,
+        "min": 0.6739
+       },
+       "gmm": {
+        "n": 34,
+        "mean": 0.8832,
+        "std": 0.5735,
+        "min": 0.6749
+       },
+       "gmm_features": {
+        "n": 36,
+        "mean": 1.043,
+        "std": 1.0009,
+        "min": 0.6729
+       },
+       "uniform": {
+        "n": 40,
+        "mean": 0.9049,
+        "std": 0.9399,
+        "min": 0.6826
+       }
+      },
+      "best": {
+       "value": "random",
+       "runner_up": "gmm",
+       "delta_mean": 0.0949,
+       "p_value": 0.428474,
+       "significant": "False"
+      }
+     },
+     "mixture_r_smoothing": {
+      "per_value": {
+       "none": {
+        "n": 41,
+        "mean": 1.4996,
+        "std": 1.2732,
+        "min": 0.6962
+       },
+       "ema": {
+        "n": 432,
+        "mean": 0.8104,
+        "std": 0.6317,
+        "min": 0.6689
+       },
+       "markov": {
+        "n": 27,
+        "mean": 1.9739,
+        "std": 1.3279,
+        "min": 0.6921
+       }
+      },
+      "best": {
+       "value": "ema",
+       "runner_up": "none",
+       "delta_mean": 0.6892,
+       "p_value": 0.001556,
+       "significant": "True"
+      }
+     },
+     "mixture_hard_m_step": {
+      "per_value": {
+       "False": {
+        "n": 421,
+        "mean": 0.8702,
+        "std": 0.683,
+        "min": 0.6689
+       },
+       "True": {
+        "n": 79,
+        "mean": 1.2468,
+        "std": 1.2807,
+        "min": 0.6906
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.3766,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     },
+     "extra_trees": {
+      "per_value": {
+       "True": {
+        "n": 31,
+        "mean": 1.5877,
+        "std": 1.596,
+        "min": 0.6864
+       },
+       "False": {
+        "n": 469,
+        "mean": 0.8862,
+        "std": 0.7185,
+        "min": 0.6689
+       }
+      },
+      "best": {
+       "value": "False",
+       "runner_up": "True",
+       "delta_mean": 0.7015,
+       "p_value": 1.0,
+       "significant": "False"
+      }
+     }
+    },
+    "numeric_quartiles": {
+     "mixture_num_experts": {
+      "Q1": {
+       "range": [
+        null,
+        4.0
+       ],
+       "n": 80,
+       "mean_rmse": 0.9595
+      },
+      "Q3": {
+       "range": [
+        4.0,
+        5.0
+       ],
+       "n": 192,
+       "mean_rmse": 1.0485
+      },
+      "Q4": {
+       "range": [
+        5.0,
+        null
+       ],
+       "n": 228,
+       "mean_rmse": 0.8193
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_diversity_lambda": {
+      "Q1": {
+       "range": [
+        null,
+        0.0812
+       ],
+       "n": 125,
+       "mean_rmse": 0.7734
+      },
+      "Q2": {
+       "range": [
+        0.0812,
+        0.1164
+       ],
+       "n": 125,
+       "mean_rmse": 0.9252
+      },
+      "Q3": {
+       "range": [
+        0.1164,
+        0.145
+       ],
+       "n": 125,
+       "mean_rmse": 0.9724
+      },
+      "Q4": {
+       "range": [
+        0.145,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 1.0479
+      },
+      "best_quartile": "Q1"
+     },
+     "mixture_warmup_iters": {
+      "Q1": {
+       "range": [
+        null,
+        28.0
+       ],
+       "n": 95,
+       "mean_rmse": 1.0311
+      },
+      "Q2": {
+       "range": [
+        28.0,
+        30.0
+       ],
+       "n": 114,
+       "mean_rmse": 0.9783
+      },
+      "Q3": {
+       "range": [
+        30.0,
+        34.0
+       ],
+       "n": 160,
+       "mean_rmse": 0.8875
+      },
+      "Q4": {
+       "range": [
+        34.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 0.8655
+      },
+      "best_quartile": "Q4"
+     },
+     "mixture_balance_factor": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 95,
+       "mean_rmse": 0.983
+      },
+      "Q3": {
+       "range": [
+        7.0,
+        8.0
+       ],
+       "n": 273,
+       "mean_rmse": 0.838
+      },
+      "Q4": {
+       "range": [
+        8.0,
+        null
+       ],
+       "n": 132,
+       "mean_rmse": 1.0811
+      },
+      "best_quartile": "Q3"
+     },
+     "learning_rate": {
+      "Q1": {
+       "range": [
+        null,
+        0.1691
+       ],
+       "n": 125,
+       "mean_rmse": 1.0319
+      },
+      "Q2": {
+       "range": [
+        0.1691,
+        0.2274
+       ],
+       "n": 125,
+       "mean_rmse": 0.783
+      },
+      "Q3": {
+       "range": [
+        0.2274,
+        0.2604
+       ],
+       "n": 125,
+       "mean_rmse": 1.03
+      },
+      "Q4": {
+       "range": [
+        0.2604,
+        null
+       ],
+       "n": 125,
+       "mean_rmse": 0.8741
+      },
+      "best_quartile": "Q2"
+     },
+     "num_leaves": {
+      "Q1": {
+       "range": [
+        null,
+        48.75
+       ],
+       "n": 125,
+       "mean_rmse": 0.9024
+      },
+      "Q2": {
+       "range": [
+        48.75,
+        73.0
+       ],
+       "n": 124,
+       "mean_rmse": 0.7842
+      },
+      "Q3": {
+       "range": [
+        73.0,
+        82.0
+       ],
+       "n": 116,
+       "mean_rmse": 0.9735
+      },
+      "Q4": {
+       "range": [
+        82.0,
+        null
+       ],
+       "n": 135,
+       "mean_rmse": 1.0511
+      },
+      "best_quartile": "Q2"
+     },
+     "max_depth": {
+      "Q1": {
+       "range": [
+        null,
+        10.0
+       ],
+       "n": 92,
+       "mean_rmse": 1.1368
+      },
+      "Q2": {
+       "range": [
+        10.0,
+        12.0
+       ],
+       "n": 127,
+       "mean_rmse": 0.6967
+      },
+      "Q4": {
+       "range": [
+        12.0,
+        null
+       ],
+       "n": 281,
+       "mean_rmse": 0.9673
+      },
+      "best_quartile": "Q2"
+     },
+     "min_data_in_leaf": {
+      "Q1": {
+       "range": [
+        null,
+        7.0
+       ],
+       "n": 78,
+       "mean_rmse": 0.8617
+      },
+      "Q2": {
+       "range": [
+        7.0,
+        10.0
+       ],
+       "n": 153,
+       "mean_rmse": 0.8523
+      },
+      "Q3": {
+       "range": [
+        10.0,
+        15.0
+       ],
+       "n": 138,
+       "mean_rmse": 0.9054
+      },
+      "Q4": {
+       "range": [
+        15.0,
+        null
+       ],
+       "n": 131,
+       "mean_rmse": 1.0863
+      },
+      "best_quartile": "Q2"
+     }
+    },
+    "wall_s": 6366.5,
+    "holdout": {
+     "holdout_rmse": 0.5974012445017838,
+     "retrain_s": 0.8456,
+     "predict_s": 0.0063,
+     "cv_rmse_of_winner": 0.668882979281968
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
Post-release housekeeping for v0.8.1:

- **Bench artifacts committed** so the README's `bench_results/wide_v081/` / `meth2_v081/` links resolve: per-dataset `*_summary.json` (full study output minus per-trial logs — config, provenance sha256s, per-run aggregates, winning params, holdout results; ~50KB each) and the rendered `*_report.md`. Raw JSONs with complete trial logs (240MB) stay untracked; provenance hashes tie them to these summaries.
- **README.ja.md synced** — its benchmark section was two generations old (still showing the retracted vix −15.1%). Now a full translation of the unified wide-space study, including the methodology note and retraction history.
- **Quick Start comments refreshed in both languages** — "gbdt best on 4/6" / "token tied 3/3" came from the retracted study; now cite the current winner frequencies (gbdt 11/24, token_choice 14/24) with explicit "search the alternatives" notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)