### PR TITLE
fix(build): remove machine-local lib symlink that broke all wheel builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -294,6 +294,8 @@ eggs/
 .eggs/
 lib/
 lib64/
+# dev-environment symlink (dir-only 'lib/' above does not match symlinks)
+python-package/lightgbm_moe/lib
 parts/
 sdist/
 var/

--- a/python-package/lightgbm_moe/lib
+++ b/python-package/lightgbm_moe/lib
@@ -1,1 +1,0 @@
-/home/mokumoku/Develop/LightGBM-MoE/python-package/.venv/lib/python3.11/site-packages/lightgbm_moe/lib


### PR DESCRIPTION
\`python-package/lightgbm_moe/lib\` was a symlink to an absolute path inside a local .venv, accidentally committed in ac648a84 (PR #45) via a directory-level \`git add\`. In clean checkouts the symlink dangles and **every wheel build has failed since** (Release workflow, Python-package bdist jobs) with \`FileNotFoundError: 'lightgbm_moe/lib'\` — i.e. **pip install from the v0.8.1 tag was broken**.

The existing \`.gitignore\` \`lib/\` pattern did not protect against this: trailing-slash patterns match directories only, and a symlink is not a directory. This PR removes the tracked symlink and adds an explicit non-slash ignore entry.

**Verified**: wheel builds successfully from a clean worktree checkout of this branch (\`pip wheel ./python-package\`), with \`lib_lightgbm.so\` present in the wheel.

Note: Static Analysis has been red since May (pre-existing fork-wide lint debt, unrelated); Python-package/Release failures date exactly to #45 and are this symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)