### PR TITLE
perf(moe): ホットパスの不要コピー・毎iterアロケーション・計測歪みの解消

### DIFF
--- a/examples/perf_bench.py
+++ b/examples/perf_bench.py
@@ -142,8 +142,12 @@ def generate_data(cfg: BenchConfig):
 # =============================================================================
 # Run a single config
 # =============================================================================
-def run_one(label: str, model: str, params: dict, X_tr, y_tr, X_va, y_va, cfg: BenchConfig) -> RunResult:
-    """指定パラメータで訓練+予測、メトリクスを返す"""
+def run_one(label: str, model: str, params: dict, ds, X_tr, y_tr, X_va, y_va, cfg: BenchConfig) -> RunResult:
+    """指定パラメータで訓練+予測、メトリクスを返す。
+
+    ds は構築済み lgb.Dataset。全 config / repeat で共有することで、
+    ビニング(遅延構築)が train_time_s に混入して speedup 比を
+    1x 方向に希釈するのを防ぐ。"""
     base_rss = get_peak_rss_mb()
 
     train_times = []
@@ -154,7 +158,6 @@ def run_one(label: str, model: str, params: dict, X_tr, y_tr, X_va, y_va, cfg: B
 
     for rep in range(cfg.n_repeats):
         gc.collect()
-        ds = lgb.Dataset(X_tr, label=y_tr, free_raw_data=False)
 
         t0 = time.perf_counter()
         bst = lgb.train(params, ds, num_boost_round=cfg.n_boost_round)
@@ -175,7 +178,7 @@ def run_one(label: str, model: str, params: dict, X_tr, y_tr, X_va, y_va, cfg: B
             except Exception:
                 n_trees = 0
 
-        del bst, ds
+        del bst
         gc.collect()
 
     peak_rss = get_peak_rss_mb()
@@ -264,28 +267,39 @@ def cmd_run(args):
 
     print(f"=== perf_bench.py ===")
     print(f"  rows={cfg.n_rows:,}  cols={cfg.n_cols}  rounds={cfg.n_boost_round}  threads={cfg.threads}")
-    print(f"  CPU: {get_cpu_info()}")
-    print(f"  Build: {get_build_info()}")
+    cpu_info = get_cpu_info()
+    build_info = get_build_info()
+    print(f"  CPU: {cpu_info}")
+    print(f"  Build: {build_info}")
 
     print(f"\nGenerating data...")
     X_tr, y_tr, X_va, y_va = generate_data(cfg)
     print(f"  X_tr={X_tr.shape} {X_tr.dtype}  X_va={X_va.shape}")
+
+    # Dataset は一度だけ構築して全 config / repeat で共有する
+    # (ビニングを計測区間の外へ出す — run_one の docstring 参照)
+    t0 = time.perf_counter()
+    ds = lgb.Dataset(X_tr, label=y_tr, free_raw_data=False)
+    ds.construct()
+    construct_s = time.perf_counter() - t0
+    print(f"  Dataset constructed in {construct_s:.2f}s (shared across runs)")
 
     matrix = build_matrix(cfg)
     print(f"\nRunning {len(matrix)} configs...\n")
 
     report = BenchReport(
         config=asdict(cfg),
-        cpu_info=get_cpu_info(),
-        build_info=get_build_info(),
+        cpu_info=cpu_info,
+        build_info=build_info,
     )
+    report.config["dataset_construct_s"] = round(construct_s, 3)
 
     print(f"  {'label':<22s}  {'train':>8s}  {'predict':>8s}  {'peak_MB':>8s}  {'rmse_va':>8s}  {'trees':>6s}")
     print(f"  {'-' * 22}  {'-' * 8}  {'-' * 8}  {'-' * 8}  {'-' * 8}  {'-' * 6}")
 
     for label, model, params in matrix:
         try:
-            r = run_one(label, model, params, X_tr, y_tr, X_va, y_va, cfg)
+            r = run_one(label, model, params, ds, X_tr, y_tr, X_va, y_va, cfg)
             report.runs.append(asdict(r))
             print(f"  {r.label:<22s}  {r.train_time_s:>7.2f}s  {r.predict_time_s:>7.3f}s  "
                   f"{r.peak_rss_mb:>7.0f}M  {r.rmse_holdout:>8.4f}  {r.n_trees:>6d}")

--- a/python-package/lightgbm_moe/basic.py
+++ b/python-package/lightgbm_moe/basic.py
@@ -4792,13 +4792,14 @@ class Booster:
     def _moe_data_to_array(self, data: _LGBM_PredictDataType) -> np.ndarray:
         """Convert MoE prediction input to a contiguous 2-D numpy array.
 
-        int8 arrays are preserved; pandas DataFrames are processed with the
-        booster's stored pandas_categorical mapping — the same path
-        ``predict()`` uses — so pandas-categorical columns are encoded
-        consistently with training.
+        int8, float32 and float64 arrays are preserved as-is — the C API
+        consumes all three natively, so upcasting float32 would only add an
+        N×F copy. pandas DataFrames are processed with the booster's stored
+        pandas_categorical mapping — the same path ``predict()`` uses — so
+        pandas-categorical columns are encoded consistently with training.
         """
         if isinstance(data, np.ndarray):
-            if data.dtype == np.int8:
+            if data.dtype in (np.int8, np.float32, np.float64):
                 return np.ascontiguousarray(data)
             return np.ascontiguousarray(data, dtype=np.float64)
         elif PANDAS_INSTALLED and isinstance(data, pd_DataFrame):
@@ -4808,6 +4809,8 @@ class Booster:
                 categorical_feature="auto",
                 pandas_categorical=self.pandas_categorical,
             )[0]
+            if df_array.dtype in (np.float32, np.float64):
+                return np.ascontiguousarray(df_array)
             return np.ascontiguousarray(df_array, dtype=np.float64)
         else:
             raise TypeError(f"Unsupported data type: {type(data)}")
@@ -4880,6 +4883,9 @@ class Booster:
         if data_array.dtype == np.int8:
             ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_int8))
             dtype_code = _C_API_DTYPE_INT8
+        elif data_array.dtype == np.float32:
+            ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+            dtype_code = _C_API_DTYPE_FLOAT32
         else:
             ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
             dtype_code = _C_API_DTYPE_FLOAT64
@@ -4950,6 +4956,9 @@ class Booster:
         if data_array.dtype == np.int8:
             ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_int8))
             dtype_code = _C_API_DTYPE_INT8
+        elif data_array.dtype == np.float32:
+            ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+            dtype_code = _C_API_DTYPE_FLOAT32
         else:
             ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
             dtype_code = _C_API_DTYPE_FLOAT64
@@ -5020,6 +5029,9 @@ class Booster:
         if data_array.dtype == np.int8:
             ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_int8))
             dtype_code = _C_API_DTYPE_INT8
+        elif data_array.dtype == np.float32:
+            ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_float))
+            dtype_code = _C_API_DTYPE_FLOAT32
         else:
             ptr_data = data_array.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
             dtype_code = _C_API_DTYPE_FLOAT64

--- a/python-package/lightgbm_moe/diagnostics.py
+++ b/python-package/lightgbm_moe/diagnostics.py
@@ -30,7 +30,10 @@ def diagnose_moe(model, X, y, print_report=True):
 
     regime_proba = model.predict_regime_proba(X)
     expert_preds = model.predict_expert_pred(X)
-    moe_preds = model.predict(X)
+    # The MoE combined prediction is exactly sum_k gate_prob_k * expert_pred_k
+    # (MixtureGBDT::Predict); deriving it from the two arrays above avoids a
+    # third full inference pass over the gate + all expert forests.
+    moe_preds = (regime_proba * expert_preds).sum(axis=1)
     # argmax of gate probabilities — identical to predict_regime(X),
     # without a redundant prediction pass.
     regime_pred = np.argmax(regime_proba, axis=1)

--- a/src/boosting/mixture_gbdt.cpp
+++ b/src/boosting/mixture_gbdt.cpp
@@ -1605,16 +1605,28 @@ void MixtureGBDT::Forward() {
     // gate_proba_ / gate_proba_no_bias_ are in sample-major order
     #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
     for (data_size_t i = 0; i < num_data_; ++i) {
-      std::vector<double> scores_no_bias(num_experts_);
-      std::vector<double> scores_with_bias(num_experts_);
+      // Stack buffers for K ≤ 64 — avoids two heap allocs per sample per
+      // iteration (same pattern as EStep / MStepGate).
+      double stack_buf[2 * 64];
+      std::vector<double> heap_buf;
+      double* scores_no_bias;
+      double* scores_with_bias;
+      if (num_experts_ <= 64) {
+        scores_no_bias = stack_buf;
+        scores_with_bias = stack_buf + num_experts_;
+      } else {
+        heap_buf.resize(2 * static_cast<size_t>(num_experts_));
+        scores_no_bias = heap_buf.data();
+        scores_with_bias = heap_buf.data() + num_experts_;
+      }
       for (int k = 0; k < num_experts_; ++k) {
         const double z_over_T = gate_raw[k * num_data_ + i] * inv_T;
         scores_no_bias[k]   = z_over_T;
         scores_with_bias[k] = z_over_T + expert_bias_[k] * inv_T;
       }
-      Softmax(scores_no_bias.data(), num_experts_,
+      Softmax(scores_no_bias, num_experts_,
               gate_proba_no_bias_.data() + i * num_experts_);
-      Softmax(scores_with_bias.data(), num_experts_,
+      Softmax(scores_with_bias, num_experts_,
               gate_proba_.data() + i * num_experts_);
     }
   }
@@ -1641,13 +1653,15 @@ void MixtureGBDT::Forward() {
     if (lambda > 0.0 && num_data_ > 1) {
       auto markov_sweep = [&](double* buf) {
         std::vector<double> prev_row(num_experts_);
+        // Reused across rows (fully overwritten each iteration) — allocating
+        // it inside the loop cost one heap alloc per row per sweep.
+        std::vector<double> cur_row(num_experts_);
         // Row 0 is never blended (no prior available).
         for (int k = 0; k < num_experts_; ++k) {
           prev_row[k] = buf[k];
         }
         for (data_size_t i = 1; i < num_data_; ++i) {
           // Snapshot row i's unsmoothed value before the blend.
-          std::vector<double> cur_row(num_experts_);
           for (int k = 0; k < num_experts_; ++k) {
             cur_row[k] = buf[i * num_experts_ + k];
           }
@@ -1723,11 +1737,21 @@ void MixtureGBDT::ForwardValid(int valid_idx) {
   // gate_proba is in sample-major order: gate_proba[i * num_experts_ + k]
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
   for (data_size_t i = 0; i < num_valid; ++i) {
-    std::vector<double> scores(num_experts_);
+    // Stack buffer for K ≤ 64 — avoids a heap alloc per sample per iteration
+    // (same pattern as EStep / MStepGate).
+    double scores_buf[64];
+    std::vector<double> scores_heap;
+    double* scores;
+    if (num_experts_ <= 64) {
+      scores = scores_buf;
+    } else {
+      scores_heap.resize(num_experts_);
+      scores = scores_heap.data();
+    }
     for (int k = 0; k < num_experts_; ++k) {
       scores[k] = (gate_raw[k * num_valid + i] + expert_bias_[k]) / gate_temperature_;
     }
-    Softmax(scores.data(), num_experts_, gate_proba.data() + i * num_experts_);
+    Softmax(scores, num_experts_, gate_proba.data() + i * num_experts_);
   }
 
   // Markov mode: same single-pass forward sweep as Forward(); see audit
@@ -1738,11 +1762,12 @@ void MixtureGBDT::ForwardValid(int valid_idx) {
     const double lambda = config_->mixture_smoothing_lambda;
     if (lambda > 0.0 && num_valid > 1) {
       std::vector<double> prev_row(num_experts_);
+      // Reused across rows — see the markov_sweep note in Forward().
+      std::vector<double> cur_row(num_experts_);
       for (int k = 0; k < num_experts_; ++k) {
         prev_row[k] = gate_proba[k];
       }
       for (data_size_t i = 1; i < num_valid; ++i) {
-        std::vector<double> cur_row(num_experts_);
         for (int k = 0; k < num_experts_; ++k) {
           cur_row[k] = gate_proba[i * num_experts_ + k];
         }
@@ -1995,7 +2020,17 @@ double MixtureGBDT::ComputeMarginalLogLikelihood() const {
   #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static) reduction(+:total)
   for (data_size_t i = 0; i < num_data_; ++i) {
     double max_term = -std::numeric_limits<double>::infinity();
-    std::vector<double> terms(num_experts_);
+    // Stack buffer for K ≤ 64 — this loop runs over all N rows on every
+    // post-warmup iteration (same pattern as EStep).
+    double terms_buf[64];
+    std::vector<double> terms_heap;
+    double* terms;
+    if (num_experts_ <= 64) {
+      terms = terms_buf;
+    } else {
+      terms_heap.resize(num_experts_);
+      terms = terms_heap.data();
+    }
     for (int k = 0; k < num_experts_; ++k) {
       // Prior π_k(x) is bias-free, matching the E-step. ELBO is the model
       // log-likelihood; the routing-side bias is not part of the model.
@@ -2465,118 +2500,11 @@ void MixtureGBDT::MStepExperts() {
     }
   }
 
-  // Phase 1: Pre-compute gradients for all experts (using full OMP parallelism)
-  std::vector<std::vector<score_t>> all_grads(num_experts_);
-  std::vector<std::vector<score_t>> all_hess(num_experts_);
-
-  for (int k = 0; k < num_experts_; ++k) {
-    if (!expert_active[k]) {
-      // Dropped experts get zero gradients (trivial no-split tree)
-      all_grads[k].assign(num_data_, 0.0);
-      all_hess[k].assign(num_data_, kMixtureEpsilon);
-      continue;
-    }
-
-    all_grads[k].resize(num_data_);
-    all_hess[k].resize(num_data_);
-
-    const double* expert_k_pred = expert_pred_.data() + k * num_data_;
-
-    if (objective_function_ != nullptr) {
-      std::vector<double> expert_k_pred_vec(expert_k_pred, expert_k_pred + num_data_);
-      std::vector<score_t> temp_grad(num_data_);
-      std::vector<score_t> temp_hess(num_data_);
-      objective_function_->GetGradients(expert_k_pred_vec.data(), temp_grad.data(), temp_hess.data());
-
-      // Gradient weighting is always soft (r_ik). The hard_m_step flag now
-      // only restricts which samples each expert sees via SetBaggingData
-      // (sparse subset of argmax winners) — see the bagging branch above.
-      // Earlier behavior zeroed gradients for non-winners outright, which
-      // produced expert collapse whenever bagging fell back to the full
-      // dataset (assigned < min_safe): losers got no gradient signal at all
-      // for those samples, so the gate could not learn to route to them.
-      #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-      for (data_size_t i = 0; i < num_data_; ++i) {
-        double r_ik = responsibilities_[i * num_experts_ + k];
-        all_grads[k][i] = static_cast<score_t>(r_ik * temp_grad[i]);
-        const double hess_val = r_ik * static_cast<double>(temp_hess[i]);
-        all_hess[k][i] = static_cast<score_t>(std::max(hess_val, kMixtureEpsilon));
-
-        if (diversity_lambda > 0.0) {
-          // Diversity regularizer — encourages f_k to differ from f_j on
-          // samples j owns (high r_ij). Earlier code added
-          //     +λ Σ_{j≠k} r_ij (f_k − f_j)
-          // to the gradient — that is the gradient of *aligning* f_k with
-          // the other experts, not diversifying them. Verified empirically:
-          // at λ=0.05 with K=3 the old sign drove pairwise expert distance
-          // down to 22% of the λ=0 baseline.
-          //
-          // Sign-flipping alone is unstable (the natural diversity reward
-          // R_k = -½ λ Σ r_ij (f_k − f_j)² is unbounded below; predictions
-          // run off to ±∞ at any non-trivial λ — λ=0.001 was empirically
-          // shown to inflate peak |pred| 25× in 30 iters). Huber-style
-          // saturation: clip (f_k − f_j) to ±δ before summing so the per-
-          // pair contribution is bounded by ±λ·δ·r_ij. Inside the clip
-          // region the reward is quadratic; outside it is linear. Hessian
-          // damping +λ·Σ r_ij keeps the leaf-value Newton step
-          // well-conditioned (the un-saturated true Hessian of a diversity
-          // reward is negative, which destabilizes Newton).
-          constexpr double kDiversityClip = 1.0;
-          double div_grad = 0.0;
-          double div_hess = 0.0;
-          for (int j = 0; j < num_experts_; ++j) {
-            if (j == k) continue;
-            const double r_ij = responsibilities_[i * num_experts_ + j];
-            const double f_k = expert_k_pred[i];
-            const double f_j = expert_pred_sm_[i * num_experts_ + j];
-            const double diff = f_k - f_j;
-            const double clipped = std::max(-kDiversityClip,
-                                            std::min(kDiversityClip, diff));
-            div_grad += r_ij * clipped;
-            div_hess += r_ij;
-          }
-          const double inv_pairs = 1.0 / (num_experts_ - 1);
-          all_grads[k][i] -= static_cast<score_t>(diversity_lambda * div_grad * inv_pairs);
-          all_hess[k][i] += static_cast<score_t>(diversity_lambda * div_hess * inv_pairs);
-        }
-      }
-    } else {
-      // L2 fallback path: same soft-gradient policy as above.
-      #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-      for (data_size_t i = 0; i < num_data_; ++i) {
-        double diff = expert_k_pred[i] - labels[i];
-        double r_ik = responsibilities_[i * num_experts_ + k];
-        all_grads[k][i] = static_cast<score_t>(r_ik * 2.0 * diff);
-        all_hess[k][i] = static_cast<score_t>(
-            std::max(r_ik * 2.0, kMixtureEpsilon));
-
-        if (diversity_lambda > 0.0) {
-          // Same Huber-saturated diversity regularizer as the
-          // objective_function_ branch above. See that branch for the
-          // sign / clip / Hessian damping rationale.
-          constexpr double kDiversityClip = 1.0;
-          double div_grad = 0.0;
-          double div_hess = 0.0;
-          for (int j = 0; j < num_experts_; ++j) {
-            if (j == k) continue;
-            const double r_ij = responsibilities_[i * num_experts_ + j];
-            const double f_k = expert_k_pred[i];
-            const double f_j = expert_pred_sm_[i * num_experts_ + j];
-            const double dd = f_k - f_j;
-            const double clipped = std::max(-kDiversityClip,
-                                            std::min(kDiversityClip, dd));
-            div_grad += r_ij * clipped;
-            div_hess += r_ij;
-          }
-          const double inv_pairs = 1.0 / (num_experts_ - 1);
-          all_grads[k][i] -= static_cast<score_t>(diversity_lambda * div_grad * inv_pairs);
-          all_hess[k][i] += static_cast<score_t>(diversity_lambda * div_hess * inv_pairs);
-        }
-      }
-    }
-  }
-
-  // Adaptive per-expert learning rate: scale gradients based on loss trend
+  // Adaptive per-expert learning rate: update the loss history and derive
+  // per-expert scales BEFORE the training loop. This reads only expert_pred_
+  // and responsibilities_, both frozen until the next Forward()/EStep, so
+  // hoisting it above the per-expert gradient computation is exact. The
+  // scale itself is applied right after each expert's gradients are built.
   if (config_->mixture_adaptive_lr) {
     const label_t* lr_labels = train_data_->metadata().label();
     const int window = config_->mixture_adaptive_lr_window;
@@ -2631,19 +2559,6 @@ void MixtureGBDT::MStepExperts() {
       }
     }
 
-    // Apply LR scale to gradients
-    for (int k = 0; k < num_experts_; ++k) {
-      if (!expert_active[k]) continue;
-      double scale = expert_lr_scale_[k];
-      if (std::abs(scale - 1.0) > 1e-6) {
-        score_t s = static_cast<score_t>(scale);
-        #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
-        for (data_size_t i = 0; i < num_data_; ++i) {
-          all_grads[k][i] *= s;
-        }
-      }
-    }
-
     // Log occasionally
     if (iter_ % 20 == 0) {
       std::string lr_str;
@@ -2653,6 +2568,136 @@ void MixtureGBDT::MStepExperts() {
       Log::Debug("MixtureGBDT: Adaptive LR scales = [%s]", lr_str.c_str());
     }
   }
+
+  // Gradients are computed lazily, immediately before each expert's
+  // TrainOneIter call, into the member scratch buffers gradients_ /
+  // hessians_ (N each; otherwise idle outside the progressive-seed phase).
+  // Everything the gradients depend on — expert_pred_, expert_pred_sm_,
+  // responsibilities_, labels — is frozen while experts train, so lazy
+  // per-expert computation matches the former precompute-all-experts
+  // "Phase 1" exactly, without reallocating K×N×2 gradient buffers every
+  // boosting iteration. The former defensive copy of the expert's
+  // predictions is also gone: GetGradients takes its input as const.
+  if (static_cast<data_size_t>(gradients_.size()) < num_data_) {
+    gradients_.resize(num_data_);
+    hessians_.resize(num_data_);
+  }
+  score_t* grads = gradients_.data();
+  score_t* hesss = hessians_.data();
+
+  auto compute_expert_gradients = [&](int k) {
+    if (!expert_active[k]) {
+      // Dropped experts get zero gradients (trivial no-split tree)
+      std::fill_n(grads, num_data_, static_cast<score_t>(0.0));
+      std::fill_n(hesss, num_data_, static_cast<score_t>(kMixtureEpsilon));
+      return;
+    }
+
+    const double* expert_k_pred = expert_pred_.data() + k * num_data_;
+
+    if (objective_function_ != nullptr) {
+      objective_function_->GetGradients(expert_k_pred, grads, hesss);
+
+      // Gradient weighting is always soft (r_ik). The hard_m_step flag now
+      // only restricts which samples each expert sees via SetBaggingData
+      // (sparse subset of argmax winners) — see the bagging branch below.
+      // Earlier behavior zeroed gradients for non-winners outright, which
+      // produced expert collapse whenever bagging fell back to the full
+      // dataset (assigned < min_safe): losers got no gradient signal at all
+      // for those samples, so the gate could not learn to route to them.
+      #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
+      for (data_size_t i = 0; i < num_data_; ++i) {
+        double r_ik = responsibilities_[i * num_experts_ + k];
+        grads[i] = static_cast<score_t>(r_ik * grads[i]);
+        const double hess_val = r_ik * static_cast<double>(hesss[i]);
+        hesss[i] = static_cast<score_t>(std::max(hess_val, kMixtureEpsilon));
+
+        if (diversity_lambda > 0.0) {
+          // Diversity regularizer — encourages f_k to differ from f_j on
+          // samples j owns (high r_ij). Earlier code added
+          //     +λ Σ_{j≠k} r_ij (f_k − f_j)
+          // to the gradient — that is the gradient of *aligning* f_k with
+          // the other experts, not diversifying them. Verified empirically:
+          // at λ=0.05 with K=3 the old sign drove pairwise expert distance
+          // down to 22% of the λ=0 baseline.
+          //
+          // Sign-flipping alone is unstable (the natural diversity reward
+          // R_k = -½ λ Σ r_ij (f_k − f_j)² is unbounded below; predictions
+          // run off to ±∞ at any non-trivial λ — λ=0.001 was empirically
+          // shown to inflate peak |pred| 25× in 30 iters). Huber-style
+          // saturation: clip (f_k − f_j) to ±δ before summing so the per-
+          // pair contribution is bounded by ±λ·δ·r_ij. Inside the clip
+          // region the reward is quadratic; outside it is linear. Hessian
+          // damping +λ·Σ r_ij keeps the leaf-value Newton step
+          // well-conditioned (the un-saturated true Hessian of a diversity
+          // reward is negative, which destabilizes Newton).
+          constexpr double kDiversityClip = 1.0;
+          double div_grad = 0.0;
+          double div_hess = 0.0;
+          for (int j = 0; j < num_experts_; ++j) {
+            if (j == k) continue;
+            const double r_ij = responsibilities_[i * num_experts_ + j];
+            const double f_k = expert_k_pred[i];
+            const double f_j = expert_pred_sm_[i * num_experts_ + j];
+            const double diff = f_k - f_j;
+            const double clipped = std::max(-kDiversityClip,
+                                            std::min(kDiversityClip, diff));
+            div_grad += r_ij * clipped;
+            div_hess += r_ij;
+          }
+          const double inv_pairs = 1.0 / (num_experts_ - 1);
+          grads[i] -= static_cast<score_t>(diversity_lambda * div_grad * inv_pairs);
+          hesss[i] += static_cast<score_t>(diversity_lambda * div_hess * inv_pairs);
+        }
+      }
+    } else {
+      // L2 fallback path: same soft-gradient policy as above.
+      #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
+      for (data_size_t i = 0; i < num_data_; ++i) {
+        double diff = expert_k_pred[i] - labels[i];
+        double r_ik = responsibilities_[i * num_experts_ + k];
+        grads[i] = static_cast<score_t>(r_ik * 2.0 * diff);
+        hesss[i] = static_cast<score_t>(
+            std::max(r_ik * 2.0, kMixtureEpsilon));
+
+        if (diversity_lambda > 0.0) {
+          // Same Huber-saturated diversity regularizer as the
+          // objective_function_ branch above. See that branch for the
+          // sign / clip / Hessian damping rationale.
+          constexpr double kDiversityClip = 1.0;
+          double div_grad = 0.0;
+          double div_hess = 0.0;
+          for (int j = 0; j < num_experts_; ++j) {
+            if (j == k) continue;
+            const double r_ij = responsibilities_[i * num_experts_ + j];
+            const double f_k = expert_k_pred[i];
+            const double f_j = expert_pred_sm_[i * num_experts_ + j];
+            const double dd = f_k - f_j;
+            const double clipped = std::max(-kDiversityClip,
+                                            std::min(kDiversityClip, dd));
+            div_grad += r_ij * clipped;
+            div_hess += r_ij;
+          }
+          const double inv_pairs = 1.0 / (num_experts_ - 1);
+          grads[i] -= static_cast<score_t>(diversity_lambda * div_grad * inv_pairs);
+          hesss[i] += static_cast<score_t>(diversity_lambda * div_hess * inv_pairs);
+        }
+      }
+    }
+
+    // Apply the adaptive LR scale to gradients (matching the former
+    // post-pass over the precomputed per-expert buffers).
+    if (config_->mixture_adaptive_lr) {
+      const double scale = expert_lr_scale_[k];
+      if (std::abs(scale - 1.0) > 1e-6) {
+        const score_t s = static_cast<score_t>(scale);
+        #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
+        for (data_size_t i = 0; i < num_data_; ++i) {
+          grads[i] *= s;
+        }
+      }
+    }
+  };
 
   // Lazily build the [0..num_data_-1] identity index buffer used as the
   // "no sparse restriction" fallback for SetBaggingData. Holding it on the
@@ -2664,7 +2709,8 @@ void MixtureGBDT::MStepExperts() {
               static_cast<data_size_t>(0));
   }
 
-  // Phase 2: Train experts sequentially.
+  // Train experts sequentially, computing each expert's gradients into the
+  // shared scratch buffers just before its TrainOneIter call.
   //
   // Earlier versions trained experts concurrently via std::thread (#9), but
   // running OpenMP parallel regions from multiple non-OMP host threads
@@ -2676,6 +2722,8 @@ void MixtureGBDT::MStepExperts() {
   // so sequential training keeps the inner parallelism while avoiding the
   // unsafe nested host-thread + OMP interaction.
   for (int k = 0; k < num_experts_; ++k) {
+    compute_expert_gradients(k);
+
     // Always call SetBaggingData with a member-owned buffer. data_partition_
     // stores the raw pointer and re-reads it on every BeforeTrain(). Passing
     // a stack pointer (the original #10 implementation) left a dangling
@@ -2697,7 +2745,7 @@ void MixtureGBDT::MStepExperts() {
       experts_[k]->SetBaggingData(all_data_indices_.data(), num_data_);
     }
     try {
-      experts_[k]->TrainOneIter(all_grads[k].data(), all_hess[k].data());
+      experts_[k]->TrainOneIter(grads, hesss);
     } catch (const std::exception& e) {
       Log::Warning("MixtureGBDT: expert %d skipped iter %d (%s)",
                    k, iter_, e.what());


### PR DESCRIPTION
## 概要

コードベース監査(無駄なデータコピー / I/O の徹底調査)で見つかった High 優先の6件を修正する。**修正はすべて数値的に厳密等価**(下記の検証参照)。

## 変更内容

### C++ 学習ホットパス (`src/boosting/mixture_gbdt.cpp`)

1. **MStepExperts: expert 予測値の不要なフルコピーを削除** — `GetGradients` は `const double*` を取るだけなのに、`expert_pred_` 内の連続領域を毎 iter × K expert 分 `std::vector` にコピーしていた(N=100万・K=4 で 32MB/iter)。ポインタ直渡しに変更。
2. **MStepExperts: 勾配バッファの毎 iter 再確保を解消** — K×N×2 本のローカルバッファ + expert ごとの temp バッファ(計 ~64MB/iter のヒープ churn)を廃止。勾配計算を各 expert の `TrainOneIter` 直前に移し、seed フェーズ以外は遊休のメンバ `gradients_`/`hessians_` を再利用する。入力(`expert_pred_` / `expert_pred_sm_` / `responsibilities_`)は学習ループ中フリーズしているため値は完全に同一。adaptive-LR の履歴・スケール計算はループ前に巻き上げ、スケール適用は expert ごとに実施。
3. **Forward / ForwardValid: 行ごとのヒープ確保を解消** — OMP ループ内の per-row `std::vector`(毎 iter 2N 回の malloc/free)を、`EStep`/`MStepGate` で採用済みの「K≤64 はスタックバッファ」パターンに統一。Markov sweep の行スナップショットもループ外に巻き上げ。
4. **ComputeMarginalLogLikelihood: per-row の logsumexp バッファをスタック化**(post-warmup 毎 iter × N 行で発生)。

### Python (`python-package/lightgbm_moe/`)

5. **`_moe_data_to_array`: float32 の float64 アップキャストを廃止** — C API は FLOAT32 をネイティブ対応しているのに全 MoE 推論 API で N×F×8B のフルコピーが発生していた。`predict_regime` / `predict_regime_proba` / `predict_expert_pred` に FLOAT32 パススルーを追加。
6. **`diagnose_moe`: 3本目の推論パスを削除** — `MixtureGBDT::Predict` は厳密に `Σ_k gate_prob_k × expert_pred_k` なので、手元の2配列から導出に変更(gate 森 + 全 expert 森の再走 ≈ 推論コスト +50% を削減)。

### ベンチ (`examples/perf_bench.py`)

7. **Dataset のビニングを計測区間の外へ** — `lgb.Dataset` は遅延構築のため、ビン構築が `lgb.train` 内 = 計測区間内で走り、しかも同一データで config × repeat 回(デフォルト 20 回)繰り返されていた。定数のビニング時間が分子分母双方に乗るため **quantized_grad の speedup 比が 1x 方向に希釈される**計測バグ。Dataset を1回構築して全 run で共有(`use_quantized_grad` 等は `CheckDatasetResetConfig` の対象外のため再構築は発生しないことを確認済み)。

## 検証

- **ビット一致検証**: master ビルドとパッチ版ビルドで同一条件学習(25 rounds, valid set あり)し、予測を比較 →
  - soft M-step + adaptive_lr + diversity_lambda: **bit-identical**
  - hard M-step + markov + estimate_variance: **bit-identical**
  - objective=regression_l1(L2 fallback 経路): **bit-identical**
- **float32 パス**: float32 表現可能な値で `predict_regime` / `predict_regime_proba` / `predict_expert_pred` の float32 入力 == float64 入力を確認。
- **`diagnose_moe` 導出**: `(proba × preds).sum(axis=1)` vs `predict()` の最大差 8.9e-16(浮動小数の加算順の差のみ)。
- **テスト**: `test_mixture.py` → 20 passed / 6 failed。**失敗6件は master でも同一に失敗する既存問題**(refit 系2件、auto_k BIC、pruning 2件、iteration_range 1件)で、本 PR とは無関係。
- **perf_bench smoke**: 7 config 完走、Dataset 共有で警告・再構築なし。

## スコープ外(監査で検出済みの残項目)

Medium 以下(refit コールバックの `GetTrainingScore()` 化、MStepGate の N×K バッファのメンバ化、`LoadModelFromString` の substr 3重コピー、`get_all_boosters` の K+1 回シリアライズ、auto_k の Dataset 再構築等)は別 PR で対応可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)