### PR TITLE
fix(build): restore license metadata form that works without a local LICENSE file

### DIFF
--- a/python-package/pyproject.toml
+++ b/python-package/pyproject.toml
@@ -23,10 +23,7 @@ dependencies = [
     "scipy"
 ]
 description = "LightGBM-MoE: A regime-switching / mixture-of-experts extension of LightGBM"
-license = "MIT"
-license-files = [
-    "LICENSE"
-]
+license = {text = "MIT"}
 maintainers = [
   {name = "Yu Shi", email = "yushi@microsoft.com"}
 ]


### PR DESCRIPTION
## Problem

The v0.8.2 Release run failed in every sdist/wheel job:

```
ConfigurationError: Every pattern in "project.license-files" must match at least one file: 'LICENSE' did not match any
```

In the upstream merge (#52) I adopted upstream's `license = "MIT"` + `license-files = ["LICENSE"]` form. Upstream's build flow copies `LICENSE` next to `pyproject.toml` before building; our release workflow runs `python -m build python-package` directly, where no `LICENSE` file exists — so metadata parsing fails before anything compiles.

## Fix

Revert to the fork's original `license = {text = "MIT"}`, which needs no file on disk.

Verified locally with the exact release command: `python -m build --sdist python-package` → builds successfully.

After merging, I'll re-point the `v0.8.2` tag at the fixed commit (no release was published from the failed run, so re-tagging is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)