### PR TITLE
perf(moe): バッチ推論の行ごとコピー排除・predict_markovの入力二重変換解消 (audit PR-3)

### DIFF
--- a/python-package/lightgbm_moe/basic.py
+++ b/python-package/lightgbm_moe/basic.py
@@ -5353,9 +5353,13 @@ class Booster:
             out_result = np.empty((nrow, num_experts), dtype=np.float64)
             # First sample: use base probabilities
             out_result[0] = base_proba[0]
-            # Subsequent samples: blend with previous
+            # Subsequent samples: blend with previous. The recurrence is
+            # inherently sequential; reuse one scratch row instead of
+            # allocating several temporaries per row.
+            blended = np.empty(num_experts, dtype=np.float64)
             for i in range(1, nrow):
-                blended = (1.0 - lambda_val) * base_proba[i] + lambda_val * out_result[i - 1]
+                np.multiply(base_proba[i], 1.0 - lambda_val, out=blended)
+                blended += lambda_val * out_result[i - 1]
                 blended /= blended.sum()  # Renormalize
                 out_result[i] = blended
             return out_result
@@ -5403,18 +5407,26 @@ class Booster:
         if not self.is_mixture():
             raise LightGBMError("predict_markov can only be used with MoE models")
 
+        # Convert the input ONCE and pass the resulting ndarray to both
+        # sub-calls: their own _moe_data_to_array becomes a no-op on an
+        # already-contiguous array. Passing the raw input instead would
+        # materialize the N x F matrix twice (DataFrame conversion in
+        # particular is a full copy each time).
+        data_array = self._moe_data_to_array(data)
+
         # Get expert predictions
         expert_preds = self.predict_expert_pred(
-            data, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
+            data_array, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
         )  # (nrow, n_experts)
 
         # Get Markov-smoothed regime probabilities
         regime_proba = self.predict_regime_proba_markov(
-            data, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
+            data_array, start_iteration=start_iteration, num_iteration=num_iteration, **kwargs
         )  # (nrow, n_experts)
 
-        # Weighted sum: prediction = sum_k(proba[k] * expert[k])
-        return (regime_proba * expert_preds).sum(axis=1)
+        # Weighted sum: prediction = sum_k(proba[k] * expert[k]) without
+        # materializing the intermediate N x K product array.
+        return np.einsum("ij,ij->i", regime_proba, expert_preds)
 
     def _extract_gate_model_string(self) -> str:
         """Extract gate model section from MoE model string.

--- a/src/boosting/mixture_gbdt.cpp
+++ b/src/boosting/mixture_gbdt.cpp
@@ -3892,16 +3892,31 @@ void MixtureGBDT::PredictByMap(const std::unordered_map<int, double>& features, 
   const PredictionEarlyStopInstance* early_stop_ptr =
       early_stop ? early_stop : &NoEarlyStopInstance();
 
-  std::vector<double> expert_preds(num_experts_);
+  // Stack buffers for K ≤ 64 — same per-row rationale as Predict() above;
+  // this is the per-row path for map-based (sparse single-row) prediction.
+  double stack_buf[3 * 64];
+  std::vector<double> heap_buf;
+  double* expert_preds;
+  double* gate_raw;
+  double* gate_prob;
+  if (num_experts_ <= 64) {
+    expert_preds = stack_buf;
+    gate_raw = stack_buf + num_experts_;
+    gate_prob = stack_buf + 2 * num_experts_;
+  } else {
+    heap_buf.resize(3 * static_cast<size_t>(num_experts_));
+    expert_preds = heap_buf.data();
+    gate_raw = heap_buf.data() + num_experts_;
+    gate_prob = heap_buf.data() + 2 * num_experts_;
+  }
+
   for (int k = 0; k < num_experts_; ++k) {
     experts_[k]->PredictByMap(features, &expert_preds[k], early_stop_ptr);
   }
 
-  std::vector<double> gate_raw(num_experts_);
-  gate_->PredictRawByMap(features, gate_raw.data(), early_stop_ptr);
+  gate_->PredictRawByMap(features, gate_raw, early_stop_ptr);
 
-  std::vector<double> gate_prob(num_experts_);
-  ComputeGateProbForInference(gate_raw.data(), gate_prob.data());
+  ComputeGateProbForInference(gate_raw, gate_prob);
 
   double sum = 0.0;
   for (int k = 0; k < num_experts_; ++k) {

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -506,11 +506,21 @@ class Booster {
     UNIQUE_LOCK(mutex_)
     mixture->InitPredict(config.start_iteration_predict,
                          config.num_iteration_predict, false);
+    // Per-thread row-conversion scratch. The per-row callback receives a
+    // slice sized ncol; accessors that can read the caller's matrix in
+    // place (float64 row-major) simply ignore it. This replaces the old
+    // RowFunctionFromDenseMatrix pattern of one heap-allocated
+    // std::vector<double>(ncol) per row.
+    const size_t scratch_stride = static_cast<size_t>(std::max(ncol, 1));
+    std::vector<double> row_scratch(
+        static_cast<size_t>(OMP_NUM_THREADS()) * scratch_stride);
     OMP_INIT_EX();
     #pragma omp parallel for num_threads(OMP_NUM_THREADS()) schedule(static)
     for (int32_t i = 0; i < nrow; ++i) {
       OMP_LOOP_EX_BEGIN();
-      per_row_fn(mixture, i);
+      double* scratch = row_scratch.data() +
+          static_cast<size_t>(omp_get_thread_num()) * scratch_stride;
+      per_row_fn(mixture, i, scratch);
       OMP_LOOP_EX_END();
     }
     OMP_THROW_EX();
@@ -2971,6 +2981,60 @@ int LGBM_BoosterIsMixture(BoosterHandle handle, int* out_is_mixture) {
   API_END();
 }
 
+namespace {
+
+// Per-row accessor for the MoE batch predict entry points. The generic
+// RowFunctionFromDenseMatrix heap-allocates and element-copies an ncol-sized
+// std::vector<double> per row — N mallocs plus a full-matrix copy per batch
+// call. Float64 row-major input (the standard lightgbm_moe Python path,
+// which always passes is_row_major=1 and converts DataFrames to float64) is
+// read directly from the caller's matrix with zero copies; float32 / int8 /
+// col-major inputs convert into the per-thread scratch provided by
+// PredictMoERows.
+template <typename T>
+std::function<const double*(int row_idx, double* scratch)>
+MoERowAccessor_helper(const void* data, int num_row, int num_col,
+                      int is_row_major) {
+  const T* data_ptr = reinterpret_cast<const T*>(data);
+  if (is_row_major) {
+    return [data_ptr, num_col](int row_idx, double* scratch) {
+      const T* row = data_ptr + static_cast<size_t>(num_col) * row_idx;
+      for (int j = 0; j < num_col; ++j) {
+        scratch[j] = static_cast<double>(row[j]);
+      }
+      return static_cast<const double*>(scratch);
+    };
+  }
+  return [data_ptr, num_row, num_col](int row_idx, double* scratch) {
+    for (int j = 0; j < num_col; ++j) {
+      scratch[j] = static_cast<double>(
+          data_ptr[static_cast<size_t>(num_row) * j + row_idx]);
+    }
+    return static_cast<const double*>(scratch);
+  };
+}
+
+std::function<const double*(int row_idx, double* scratch)>
+MoERowAccessor(const void* data, int num_row, int num_col, int data_type,
+               int is_row_major) {
+  if (data_type == C_API_DTYPE_FLOAT64 && is_row_major) {
+    const double* data_ptr = reinterpret_cast<const double*>(data);
+    return [data_ptr, num_col](int row_idx, double* /*scratch*/) {
+      return data_ptr + static_cast<size_t>(num_col) * row_idx;
+    };
+  } else if (data_type == C_API_DTYPE_FLOAT64) {
+    return MoERowAccessor_helper<double>(data, num_row, num_col, is_row_major);
+  } else if (data_type == C_API_DTYPE_FLOAT32) {
+    return MoERowAccessor_helper<float>(data, num_row, num_col, is_row_major);
+  } else if (data_type == C_API_DTYPE_INT8) {
+    return MoERowAccessor_helper<int8_t>(data, num_row, num_col, is_row_major);
+  }
+  Log::Fatal("Unknown data type in MoERowAccessor");
+  return nullptr;
+}
+
+}  // anonymous namespace
+
 int LGBM_BoosterPredictRegime(BoosterHandle handle,
                                const void* data,
                                int data_type,
@@ -2982,13 +3046,14 @@ int LGBM_BoosterPredictRegime(BoosterHandle handle,
                                int32_t* out_result) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  auto get_row = RowFunctionFromDenseMatrix(data, nrow, ncol, data_type, is_row_major);
+  auto get_row = MoERowAccessor(data, nrow, ncol, data_type, is_row_major);
   ref_booster->PredictMoERows(
       nrow, ncol, parameter, "LGBM_BoosterPredictRegime",
-      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i) {
-        auto row = get_row(i);
+      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i,
+                             double* scratch) {
+        const double* row = get_row(i, scratch);
         int regime;
-        mixture->PredictRegime(row.data(), &regime);
+        mixture->PredictRegime(row, &regime);
         out_result[i] = regime;
       });
   *out_len = nrow;
@@ -3006,14 +3071,15 @@ int LGBM_BoosterPredictRegimeProba(BoosterHandle handle,
                                     double* out_result) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  auto get_row = RowFunctionFromDenseMatrix(data, nrow, ncol, data_type, is_row_major);
+  auto get_row = MoERowAccessor(data, nrow, ncol, data_type, is_row_major);
   int64_t total = 0;
   ref_booster->PredictMoERows(
       nrow, ncol, parameter, "LGBM_BoosterPredictRegimeProba",
-      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i) {
-        auto row = get_row(i);
+      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i,
+                             double* scratch) {
+        const double* row = get_row(i, scratch);
         mixture->PredictRegimeProba(
-            row.data(),
+            row,
             out_result + static_cast<size_t>(i) * mixture->NumExperts());
       });
   {
@@ -3035,14 +3101,15 @@ int LGBM_BoosterPredictExpertPred(BoosterHandle handle,
                                    double* out_result) {
   API_BEGIN();
   Booster* ref_booster = reinterpret_cast<Booster*>(handle);
-  auto get_row = RowFunctionFromDenseMatrix(data, nrow, ncol, data_type, is_row_major);
+  auto get_row = MoERowAccessor(data, nrow, ncol, data_type, is_row_major);
   int64_t total = 0;
   ref_booster->PredictMoERows(
       nrow, ncol, parameter, "LGBM_BoosterPredictExpertPred",
-      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i) {
-        auto row = get_row(i);
+      [&get_row, out_result](const LightGBM::MixtureGBDT* mixture, int32_t i,
+                             double* scratch) {
+        const double* row = get_row(i, scratch);
         mixture->PredictExpertPred(
-            row.data(),
+            row,
             out_result + static_cast<size_t>(i) * mixture->NumExperts());
       });
   {


### PR DESCRIPTION
## 概要

メモリ監査(Tier A #1 + Tier C)の対応。推論経路の行ごとヒープ確保と入力の二重実体化を除去します。

## 変更内容

- **c_api MoEバッチ推論**(`PredictRegime`/`RegimeProba`/`ExpertPred`): `RowFunctionFromDenseMatrix`は**1行ごとに`std::vector<double>(ncol)`をheap確保+全要素コピー**していました(=バッチ1回でN回のmalloc+実質全行列コピー)。新しい`MoERowAccessor`は、float64行メジャー入力(Python経路の標準形)なら**呼び出し元の行列をゼロコピーで直接参照**、float32/int8/列メジャーは`PredictMoERows`がバッチごとに1回確保するスレッドごとスクラッチへ変換
- **`PredictByMap`**: K≤64のスタックバッファ化(`Predict()`と同じパターン、行ごとの3 malloc除去)
- **`basic.py predict_markov`**: 入力を1回だけ変換して`predict_expert_pred`と`predict_regime_proba_markov`に共有(従来はN×F行列を2回実体化 — 報告のデータ規模なら**約5.3GB×2→×1**)。加重和はeinsumでN×K中間配列なし、markovブレンドループはスクラッチ1行を再利用

## 検証(同一モデル・同一データを新旧バイナリで推論)

- `predict_regime` / `predict_regime_proba` / `predict_expert_pred`、float32入力、DataFrame入力: **全てビット一致**
- `predict_markov`のみ**最大1ulp(8.9e-16)**の差 — einsum化による加算順序の違いで、N×K中間配列の排除とのトレードオフ(モデル挙動上は無意味な差)
- test_mixture / test_basic / test_engine 302 passed、cpplint / ruff パス

## 残課題(フォローアップ)

- markovブレンドのC APIバッチ化(C++に`PredictWithPrevProba`は実装済みだが未公開。Pythonの行ループが残る)

🤖 Generated with [Claude Code](https://claude.com/claude-code)